### PR TITLE
Improve kernel-thrown exceptions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AMDGPU"
 uuid = "21141c5a-9bdb-4563-92ae-f87d6854732e"
 authors = ["Julian P Samaroo <jpsamaroo@jpsamaroo.me>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,6 +6,11 @@ makedocs(
         "Home" => "index.md",
         "Quick Start" => "quickstart.md",
         "Global Variables" => "globals.md",
+        "Exceptions" => "exceptions.md",
+        "Memory" => "memory.md",
+        "Intrinsics" => [
+            "Execution Control" => "execution_control.md",
+        ],
         "API Reference" => "api.md"
     ]
 )

--- a/docs/src/exceptions.md
+++ b/docs/src/exceptions.md
@@ -1,0 +1,32 @@
+# Kernel-thrown Exceptions
+
+Just like regular CPU-executed Julia functions, GPU kernels can throw
+exceptions! For example, the following kernel will throw a `KernelException`:
+
+```julia
+function throwkernel(A)
+    A[0] = 1
+end
+HA = HSAArray(zeros(Int,1))
+wait(@roc throwkernel(HA))
+```
+
+Kernels that hit an exception will write some exception information into a
+pre-allocated list for the CPU to inspect. Once complete, the wavefront
+throwing the exception will stop itself, but other wavefronts will continue
+executing (possibly throwing their own exceptions, or not).
+
+Kernel-thrown exceptions are thrown on the CPU in the call to `wait(event)`,
+where `event` is the returned value of `@roc` calls. When the kernel signals
+that it's completed, the `wait` function will check if an exception flag has
+been set, and if it has, will collect all of the relevant exception information
+that the kernels set up. Unlike CPU execution, GPU kernel exceptions aren't
+very user-customizable and pretty (for now!). They don't call `Base.show`, but
+instead pass the LLVM function name of their exception handler (details in
+`GPUCompiler`, `src/irgen.jl`). Therefore, the exact error that occured might
+be a bit hard to figure out.
+
+If exception checking turns out to be too expensive for your needs, you can
+disable those checks by passing the kwarg `check_exceptions=false` to the
+`wait` call, which will skip any error checking (although it will still wait
+for the kernel to signal completion).

--- a/docs/src/execution_control.md
+++ b/docs/src/execution_control.md
@@ -1,0 +1,27 @@
+# Execution Control and Intrinsics
+
+GPU execution is similar to CPU execution in some ways, although there are many
+differences. AMD GPUs have Compute Units (CUs), which can be thought of like
+CPU cores. Those CUs have (on pre-Navi architectures) 64 "shader processors",
+which are essentially the same as CPU SIMD lanes. The lanes in a CU operate in
+lockstep just like CPU SIMD lanes, and have execution masks and various kinds
+of SIMD instructions available. CUs execute wavefronts, which are pieces of
+work split off from a single kernel launch. A single CU can run one out of many
+wavefronts (one is chosen by the CU scheduler each cycle), which allows for
+very efficient parallel and concurrent execution on the device. Each wavefront
+runs independently of the other wavefronts, only stopping to synchronize with
+other wavefronts or terminate when specified by the program.
+
+We can control wavefront execution through a variety of intrinsics provided by
+ROCm. For example, the `endpgm()` intrinsic stops the current wavefront's
+execution, and is also automatically inserted by the compiler at the end of
+each kernel (except in certain unique cases).
+
+`signal_completion(x)` signals the "kernel doorbell" with the value `x`, which
+is the signal checked by the CPU `wait` call to determine when the kernel has
+completed. This doorbell is set to `0` automatically by GPU hardware once the
+kernel is complete.
+
+`sendmsg(x,y=0)` and `sendmsghalt(x,y=0)` can be used to signal special
+conditions to the scheduler/hardware, such as making requests to stop wavefront
+generation, or halt all running wavefronts. Check the ISA manual for details!

--- a/docs/src/memory.md
+++ b/docs/src/memory.md
@@ -1,0 +1,54 @@
+# Memory Allocation and Intrinsics
+
+## Memory Varieties
+
+GPUs contain various kinds of memory, just like CPUs:
+
+- Global: Globally accessible by all CUs on a GPU, and possibly accessible from outside of the GPU (by the CPU host, by other GPUs, by PCIe devices, etc.). Slowest form of memory.
+- Constant: Same as global memory, but signals to the hardware that it can use special instructions to access and cache this memory. Can be changed between kernel invocations.
+- Region: Also known as Global Data Store (GDS), all wavefronts on a CU can access the same memory region from the same address. Faster than Global/Constant. Automatically allocated by the compiler/runtime, not user accessible.
+- Local: Also known as Local Data Store (LDS), all wavefronts in the same workgroup can access the same memory region from the same address. Faster than GDS.
+- Private: Uses the hardware scratch space, and is private to each SIMD lane in a wavefront. Fastest form of traditional memory.
+
+## Memory Allocation/Deallocation
+
+Currently, we can explicitly allocate Global and Local memory from within
+kernels, and Global from outside of kernels. Global memory allocations are done
+with `AMDGPU.Mem.alloc`, like so:
+
+```julia
+buf = Mem.alloc(agent, bytes)
+```
+
+`buf` in this example is a `Mem.Buffer`, which contains a pointer that points
+to the allocated memory. The buffer can be converted to a pointer by doing
+`Base.unsafe_convert(Ptr{Nothing}, buf)`, and may then be converted to the
+appropriate pointer type, and loaded from/stored to. By default, memory is
+allocated specifically on and for `agent`, and is only accessible to that agent
+unless transferred using the various functions in the `Mem` module. If memory
+should be globally accessible by the CPU and by all GPUs, the kwarg
+`coherent=true` may be passed, which utilizes Unified Memory instead. Memory
+should be freed once no longer necessary with `Mem.free(buf)`.
+
+Global memory allocated by a kernel is automatically freed when the kernel
+completes, which is done in the `wait` call on the host. This behavior can be
+disabled by passing `cleanup=false` to `wait`.
+
+Global memory may also be allocated and freed dynamically from kernels by
+calling `AMDGPU.malloc(::Csize_t)::DevicePtr` and `AMDGPU.free(::DevicePtr)`.
+This memory allocation/deallocation uses hostcalls to operate, and so is
+relatively slow, but is also very useful. Currently, memory allocated with
+`AMDGPU.malloc` is coherent.
+
+Local memory may be allocated within a kernel by calling
+`alloc_local(id, T, len)`, where `id` is some sort of bitstype ID for the local
+allocation, `T` is the Julia element type, and `len` is the number of elements
+of type `T` to allocate. Local memory does not need to be freed, as it is
+automatically allocated/freed by the hardware.
+
+## Memory Modification Intrinsics
+
+Like C, AMDGPU.jl provides the `memset!` and `memcpy!` intrinsics, which are
+useful for setting a memory region to a value, or copying one region to
+another, respectively. Check `test/device/memory.jl` for examples of their
+usage.

--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -66,6 +66,7 @@ include(joinpath("device", "globals.jl"))
 include("compiler.jl")
 include("execution_utils.jl")
 include("execution.jl")
+include("exceptions.jl")
 include("reflection.jl")
 
 ### ROCArray ###

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -15,7 +15,14 @@ function GPUCompiler.process_module!(job::ROCCompilerJob, mod::LLVM.Module)
     invoke(GPUCompiler.process_module!,
            Tuple{CompilerJob{GCNCompilerTarget}, typeof(mod)},
            job, mod)
-    #emit_exception_flag!(mod)
+    # Run this early (before optimization) to ensure we link OCKL
+    emit_exception_user!(mod)
+end
+function GPUCompiler.finish_module!(job::ROCCompilerJob, mod::LLVM.Module)
+    invoke(GPUCompiler.finish_module!,
+           Tuple{CompilerJob{GCNCompilerTarget}, typeof(mod)},
+           job, mod)
+    delete_exception_user!(mod)
 end
 
 function GPUCompiler.link_libraries!(job::ROCCompilerJob, mod::LLVM.Module,

--- a/src/device/gcn.jl
+++ b/src/device/gcn.jl
@@ -1,10 +1,14 @@
-if Base.libllvm_version >= v"7.0"
-    include(joinpath("gcn", "math.jl"))
-end
+# HSA dispatch packet offsets
+_packet_names = fieldnames(HSA.KernelDispatchPacket)
+_packet_offsets = fieldoffset.(HSA.KernelDispatchPacket, 1:length(_packet_names))
+
+include(joinpath("gcn", "math.jl"))
 include(joinpath("gcn", "indexing.jl"))
 include(joinpath("gcn", "assertion.jl"))
 include(joinpath("gcn", "synchronization.jl"))
 include(joinpath("gcn", "memory_static.jl"))
-include(joinpath("gcn", "memory_dynamic.jl"))
 include(joinpath("gcn", "hostcall.jl"))
 include(joinpath("gcn", "output.jl"))
+include(joinpath("gcn", "memory_dynamic.jl"))
+include(joinpath("gcn", "execution_control.jl"))
+include(joinpath("gcn", "atomics.jl"))

--- a/src/device/gcn/atomics.jl
+++ b/src/device/gcn/atomics.jl
@@ -1,0 +1,484 @@
+# Atomic Functions (B.12)
+
+#
+# Low-level intrinsics
+#
+
+# TODO:
+# - scoped atomics: _system and _block versions (see CUDA programming guide, sm_60+)
+#   https://github.com/Microsoft/clang/blob/86d4513d3e0daa4d5a29b0b1de7c854ca15f9fe5/test/CodeGen/builtins-nvptx.c#L293
+
+## LLVM
+
+# common arithmetic operations on integers using LLVM instructions
+#
+# > 8.6.6. atomicrmw Instruction
+# >
+# > nand is not supported. The other keywords are supported for i32 and i64 types, with the
+# > following restrictions.
+# >
+# > - The pointer must be either a global pointer, a shared pointer, or a generic pointer
+# >   that points to either the global address space or the shared address space.
+
+@generated function llvm_atomic_op(::Val{binop}, ptr::DevicePtr{T,A}, val::T) where {binop, T, A}
+    T_val = convert(LLVMType, T)
+    T_ptr = convert(LLVMType, DevicePtr{T,A})
+    T_actual_ptr = LLVM.PointerType(T_val)
+
+    llvm_f, _ = create_function(T_val, [T_ptr, T_val])
+
+    Builder(JuliaContext()) do builder
+        entry = BasicBlock(llvm_f, "entry", JuliaContext())
+        position!(builder, entry)
+
+        actual_ptr = inttoptr!(builder, parameters(llvm_f)[1], T_actual_ptr)
+
+        rv = atomic_rmw!(builder, binop,
+                         actual_ptr, parameters(llvm_f)[2],
+                         atomic_acquire_release, #=single_threaded=# false)
+
+        ret!(builder, rv)
+    end
+
+    call_function(llvm_f, T, Tuple{DevicePtr{T,A}, T}, :((ptr,val)))
+end
+
+const binops = Dict(
+    :xchg  => LLVM.API.LLVMAtomicRMWBinOpXchg,
+    :add   => LLVM.API.LLVMAtomicRMWBinOpAdd,
+    :sub   => LLVM.API.LLVMAtomicRMWBinOpSub,
+    :and   => LLVM.API.LLVMAtomicRMWBinOpAnd,
+    :or    => LLVM.API.LLVMAtomicRMWBinOpOr,
+    :xor   => LLVM.API.LLVMAtomicRMWBinOpXor,
+    :max   => LLVM.API.LLVMAtomicRMWBinOpMax,
+    :min   => LLVM.API.LLVMAtomicRMWBinOpMin,
+    :umax  => LLVM.API.LLVMAtomicRMWBinOpUMax,
+    :umin  => LLVM.API.LLVMAtomicRMWBinOpUMin
+)
+
+# all atomic operations have acquire and/or release semantics,
+# depending on whether they load or store values (mimics Base)
+const atomic_acquire = LLVM.API.LLVMAtomicOrderingAcquire
+const atomic_release = LLVM.API.LLVMAtomicOrderingRelease
+const atomic_acquire_release = LLVM.API.LLVMAtomicOrderingAcquireRelease
+
+for T in (Int32, Int64, UInt32, UInt64)
+    ops = [:xchg, :add, :sub, :and, :or, :xor, :max, :min]
+
+    ASs = Union{AS.Generic, AS.Global, AS.Local}
+
+    for op in ops
+        # LLVM distinguishes signedness in the operation, not the integer type.
+        rmw =  if T <: Unsigned && (op == :max || op == :min)
+            Symbol("u$op")
+        else
+            Symbol("$op")
+        end
+
+        fn = Symbol("atomic_$(op)!")
+        @eval @inline $fn(ptr::DevicePtr{$T,<:$ASs}, val::$T) =
+            llvm_atomic_op($(Val(binops[rmw])), ptr, val)
+    end
+end
+
+@generated function llvm_atomic_cas(ptr::DevicePtr{T,A}, cmp::T, val::T) where {T, A}
+    T_val = convert(LLVMType, T)
+    T_ptr = convert(LLVMType, DevicePtr{T,A})
+    T_actual_ptr = LLVM.PointerType(T_val)
+
+    llvm_f, _ = create_function(T_val, [T_ptr, T_val, T_val])
+
+    Builder(JuliaContext()) do builder
+        entry = BasicBlock(llvm_f, "entry", JuliaContext())
+        position!(builder, entry)
+
+        actual_ptr = inttoptr!(builder, parameters(llvm_f)[1], T_actual_ptr)
+
+        res = atomic_cmpxchg!(builder, actual_ptr, parameters(llvm_f)[2],
+                              parameters(llvm_f)[3], atomic_acquire_release, atomic_acquire,
+                              #=single threaded=# false)
+
+        rv = extract_value!(builder, res, 0)
+
+        ret!(builder, rv)
+    end
+
+    call_function(llvm_f, T, Tuple{DevicePtr{T,A}, T, T}, :((ptr,cmp,val)))
+end
+
+for T in (Int32, Int64, UInt32, UInt64)
+    @eval @inline atomic_cas!(ptr::DevicePtr{$T}, cmp::$T, val::$T) =
+        llvm_atomic_cas(ptr, cmp, val)
+end
+
+
+## NVVM
+
+#=
+# floating-point operations using NVVM intrinsics
+
+# TODO: Base.Ref{T,AS} would make these operations possible with plain `ccall`
+
+for A in (AS.Generic, AS.Global, AS.Shared)
+    # declare float @llvm.nvvm.atomic.load.add.f32.p0f32(float* address, float val)
+    # declare float @llvm.nvvm.atomic.load.add.f32.p1f32(float addrspace(1)* address, float val)
+    # declare float @llvm.nvvm.atomic.load.add.f32.p3f32(float addrspace(3)* address, float val)
+    #
+    # FIXME: these only works on sm_60+, but we can't verify that for now
+    # declare double @llvm.nvvm.atomic.load.add.f64.p0f64(double* address, double val)
+    # declare double @llvm.nvvm.atomic.load.add.f64.p1f64(double addrspace(1)* address, double val)
+    # declare double @llvm.nvvm.atomic.load.add.f64.p3f64(double addrspace(3)* address, double val)
+    for T in (Float32, Float64)
+        nb = sizeof(T)*8
+
+        if A == AS.Generic
+            # FIXME: Ref doesn't encode the AS --> wrong mangling for nonzero address spaces
+            intr = "llvm.nvvm.atomic.load.add.f$nb.p$(convert(Int, A))i8"
+            @eval @inline atomic_add!(ptr::DevicePtr{$T,$A}, val::$T) =
+                ccall($intr, llvmcall, $T, (Ref{$T}, $T), ptr, val)
+        else
+            import Base.Sys: WORD_SIZE
+            if T == Float32
+                T_val = "float"
+            else
+                T_val = "double"
+            end
+            if A == AS.Generic
+                T_ptr = "$(T_val)*"
+            else
+                T_ptr = "$(T_val) addrspace($(convert(Int, A)))*"
+            end
+            intr = "llvm.nvvm.atomic.load.add.f$nb.p$(convert(Int, A))f$nb"
+            @eval @inline atomic_add!(ptr::DevicePtr{$T,$A}, val::$T) = Base.llvmcall(
+                $("declare $T_val @$intr($T_ptr, $T_val)",
+                  "%ptr = inttoptr i$WORD_SIZE %0 to $T_ptr
+                   %rv = call $T_val @$intr($T_ptr %ptr, $T_val %1)
+                   ret $T_val %rv"), $T,
+                Tuple{DevicePtr{$T,$A}, $T}, ptr, val)
+        end
+    end
+
+    # declare i32 @llvm.nvvm.atomic.load.inc.32.p0i32(i32* address, i32 val)
+    # declare i32 @llvm.nvvm.atomic.load.inc.32.p1i32(i32 addrspace(1)* address, i32 val)
+    # declare i32 @llvm.nvvm.atomic.load.inc.32.p3i32(i32 addrspace(3)* address, i32 val)
+    #
+    # declare i32 @llvm.nvvm.atomic.load.dec.32.p0i32(i32* address, i32 val)
+    # declare i32 @llvm.nvvm.atomic.load.dec.32.p1i32(i32 addrspace(1)* address, i32 val)
+    # declare i32 @llvm.nvvm.atomic.load.dec.32.p3i32(i32 addrspace(3)* address, i32 val)
+    for T in (Int32,), op in (:inc, :dec)
+        nb = sizeof(T)*8
+        fn = Symbol("atomic_$(op)!")
+
+        if A == AS.Generic
+            # FIXME: Ref doesn't encode the AS --> wrong mangling for nonzero address spaces
+            intr = "llvm.nvvm.atomic.load.$op.$nb.p$(convert(Int, A))i8"
+            @eval @inline $fn(ptr::DevicePtr{$T,$A}, val::$T) =
+                ccall($intr, llvmcall, $T, (Ref{$T}, $T), ptr, val)
+        else
+            import Base.Sys: WORD_SIZE
+            T_val = "i32"
+            if A == AS.Generic
+                T_ptr = "$(T_val)*"
+            else
+                T_ptr = "$(T_val) addrspace($(convert(Int, A)))*"
+            end
+            intr = "llvm.nvvm.atomic.load.$op.$nb.p$(convert(Int, A))i$nb"
+            @eval @inline $fn(ptr::DevicePtr{$T,$A}, val::$T) = Base.llvmcall(
+                $("declare $T_val @$intr($T_ptr, $T_val)",
+                  "%ptr = inttoptr i$WORD_SIZE %0 to $T_ptr
+                   %rv = call $T_val @$intr($T_ptr %ptr, $T_val %1)
+                   ret $T_val %rv"), $T,
+                Tuple{DevicePtr{$T,$A}, $T}, ptr, val)
+        end
+    end
+end
+=#
+
+
+## Julia
+
+# floating-point CAS via bitcasting
+
+inttype(::Type{T}) where {T<:Integer} = T
+inttype(::Type{Float16}) = Int16
+inttype(::Type{Float32}) = Int32
+inttype(::Type{Float64}) = Int64
+
+for T in [Float32, Float64]
+    @eval @inline function atomic_cas!(ptr::DevicePtr{$T}, cmp::$T, new::$T)
+        IT = inttype($T)
+        cmp_i = reinterpret(IT, cmp)
+        new_i = reinterpret(IT, new)
+        old_i = atomic_cas!(convert(DevicePtr{IT}, ptr), cmp_i, new_i)
+        return reinterpret($T, old_i)
+    end
+end
+
+# floating-point operations via atomic_cas!
+
+const opnames = Dict{Symbol, Symbol}(:- => :sub, :* => :mul, :/ => :div)
+
+for T in [Float32, Float64]
+    for op in [:-, :*, :/, :max, :min]
+        opname = get(opnames, op, op)
+        fn = Symbol("atomic_$(opname)!")
+        @eval @inline function $fn(ptr::DevicePtr{$T}, val::$T)
+            old = Base.unsafe_load(ptr, 1)
+            while true
+                cmp = old
+                new = $op(old, val)
+                old = atomic_cas!(ptr, cmp, new)
+                (old == cmp) && return new
+            end
+        end
+    end
+end
+
+
+## documentation
+
+"""
+    atomic_cas!(ptr::DevicePtr{T}, cmp::T, val::T)
+
+Reads the value `old` located at address `ptr` and compare with `cmp`. If `old` equals to
+`cmp`, stores `val` at the same address. Otherwise, doesn't change the value `old`. These
+operations are performed in one atomic transaction. The function returns `old`.
+
+This operation is supported for values of type Int32, Int64, UInt32 and UInt64.
+"""
+atomic_cas!
+
+"""
+    atomic_xchg!(ptr::DevicePtr{T}, val::T)
+
+Reads the value `old` located at address `ptr` and stores `val` at the same address. These
+operations are performed in one atomic transaction. The function returns `old`.
+
+This operation is supported for values of type Int32, Int64, UInt32 and UInt64.
+"""
+atomic_xchg!
+
+"""
+    atomic_add!(ptr::DevicePtr{T}, val::T)
+
+Reads the value `old` located at address `ptr`, computes `old + val`, and stores the result
+back to memory at the same address. These operations are performed in one atomic
+transaction. The function returns `old`.
+
+This operation is supported for values of type Int32, Int64, UInt32, UInt64, and Float32.
+Additionally, on GPU hardware with compute capability 6.0+, values of type Float64 are
+supported.
+"""
+atomic_add!
+
+"""
+    atomic_sub!(ptr::DevicePtr{T}, val::T)
+
+Reads the value `old` located at address `ptr`, computes `old - val`, and stores the result
+back to memory at the same address. These operations are performed in one atomic
+transaction. The function returns `old`.
+
+This operation is supported for values of type Int32, Int64, UInt32 and UInt64.
+Additionally, on GPU hardware with compute capability 6.0+, values of type Float32 and
+Float64 are supported.
+"""
+atomic_sub!
+
+"""
+    atomic_mul!(ptr::DevicePtr{T}, val::T)
+
+Reads the value `old` located at address `ptr`, computes `*(old, val)`, and stores the
+result back to memory at the same address. These operations are performed in one atomic
+transaction. The function returns `old`.
+
+This operation is supported on GPU hardware with compute capability 6.0+ for values of type
+Float32 and Float64.
+"""
+atomic_mul!
+
+"""
+    atomic_div!(ptr::DevicePtr{T}, val::T)
+
+Reads the value `old` located at address `ptr`, computes `/(old, val)`, and stores the
+result back to memory at the same address. These operations are performed in one atomic
+transaction. The function returns `old`.
+
+This operation is supported on GPU hardware with compute capability 6.0+ for values of type
+Float32 and Float64.
+"""
+atomic_div!
+
+"""
+    atomic_and!(ptr::DevicePtr{T}, val::T)
+
+Reads the value `old` located at address `ptr`, computes `old & val`, and stores the result
+back to memory at the same address. These operations are performed in one atomic
+transaction. The function returns `old`.
+
+This operation is supported for values of type Int32, Int64, UInt32 and UInt64.
+"""
+atomic_and!
+
+"""
+    atomic_or!(ptr::DevicePtr{T}, val::T)
+
+Reads the value `old` located at address `ptr`, computes `old | val`, and stores the result
+back to memory at the same address. These operations are performed in one atomic
+transaction. The function returns `old`.
+
+This operation is supported for values of type Int32, Int64, UInt32 and UInt64.
+"""
+atomic_or!
+
+"""
+    atomic_xor!(ptr::DevicePtr{T}, val::T)
+
+Reads the value `old` located at address `ptr`, computes `old ⊻ val`, and stores the result
+back to memory at the same address. These operations are performed in one atomic
+transaction. The function returns `old`.
+
+This operation is supported for values of type Int32, Int64, UInt32 and UInt64.
+"""
+atomic_xor!
+
+"""
+    atomic_min!(ptr::DevicePtr{T}, val::T)
+
+Reads the value `old` located at address `ptr`, computes `min(old, val)`, and stores the
+result back to memory at the same address. These operations are performed in one atomic
+transaction. The function returns `old`.
+
+This operation is supported for values of type Int32, Int64, UInt32 and UInt64.
+Additionally, on GPU hardware with compute capability 6.0+, values of type Float32 and
+Float64 are supported.
+"""
+atomic_min!
+
+"""
+    atomic_max!(ptr::DevicePtr{T}, val::T)
+
+Reads the value `old` located at address `ptr`, computes `max(old, val)`, and stores the
+result back to memory at the same address. These operations are performed in one atomic
+transaction. The function returns `old`.
+
+This operation is supported for values of type Int32, Int64, UInt32 and UInt64.
+Additionally, on GPU hardware with compute capability 6.0+, values of type Float32 and
+Float64 are supported.
+"""
+atomic_max!
+
+"""
+    atomic_inc!(ptr::DevicePtr{T}, val::T)
+
+Reads the value `old` located at address `ptr`, computes `((old >= val) ? 0 : (old+1))`, and
+stores the result back to memory at the same address. These three operations are performed
+in one atomic transaction. The function returns `old`.
+
+This operation is only supported for values of type Int32.
+"""
+atomic_inc!
+
+"""
+    atomic_dec!(ptr::DevicePtr{T}, val::T)
+
+Reads the value `old` located at address `ptr`, computes `(((old == 0) | (old > val)) ? val
+: (old-1) )`, and stores the result back to memory at the same address. These three
+operations are performed in one atomic transaction. The function returns `old`.
+
+This operation is only supported for values of type Int32.
+"""
+atomic_dec!
+
+
+
+#
+# High-level interface
+#
+
+# prototype of a high-level interface for performing atomic operations on arrays
+#
+# this design could be generalized by having atomic {field,array}{set,ref} accessors, as
+# well as acquire/release operations to implement the fallback functionality where any
+# operation can be applied atomically.
+
+export @atomic
+
+const inplace_ops = Dict(
+    :(+=) => :(+),
+    :(-=) => :(-),
+    :(&=) => :(&),
+    :(|=) => :(|),
+    :(⊻=) => :(⊻)
+)
+
+struct AtomicError <: Exception
+    msg::AbstractString
+end
+
+Base.showerror(io::IO, err::AtomicError) =
+    print(io, "AtomicError: ", err.msg)
+
+"""
+    @atomic a[I] = op(a[I], val)
+    @atomic a[I] ...= val
+
+Atomically perform a sequence of operations that loads an array element `a[I]`, performs the
+operation `op` on that value and a second value `val`, and writes the result back to the
+array. This sequence can be written out as a regular assignment, in which case the same
+array element should be used in the left and right hand side of the assignment, or as an
+in-place application of a known operator. In both cases, the array reference should be pure
+and not induce any side-effects.
+
+!!! warn
+    This interface is experimental, and might change without warning.  Use the lower-level
+    `atomic_...!` functions for a stable API.
+"""
+macro atomic(ex)
+    # decode assignment and call
+    if ex.head == :(=)
+        ref = ex.args[1]
+        rhs = ex.args[2]
+        Meta.isexpr(rhs, :call) || throw(AtomicError("right-hand side of an @atomic assignment should be a call"))
+        op = rhs.args[1]
+        if rhs.args[2] != ref
+            throw(AtomicError("right-hand side of a non-inplace @atomic assignment should reference the left-hand side"))
+        end
+        val = rhs.args[3]
+    elseif haskey(inplace_ops, ex.head)
+        op = inplace_ops[ex.head]
+        ref = ex.args[1]
+        val = ex.args[2]
+    else
+        throw(AtomicError("unknown @atomic expression"))
+    end
+
+    # decode array expression
+    Meta.isexpr(ref, :ref) || throw(AtomicError("@atomic should be applied to an array reference expression"))
+    array = ref.args[1]
+    indices = Expr(:tuple, ref.args[2:end]...)
+
+    esc(quote
+        $atomic_arrayset($array, $indices, $op, $val)
+    end)
+end
+
+# FIXME: make this respect the indexing style
+@inline atomic_arrayset(A::AbstractArray, Is::Tuple, op::Function, val) =
+    atomic_arrayset(A, Base._to_linear_index(A, Is...), op, val)
+
+function atomic_arrayset(A::AbstractArray, I::Integer, op::Function, val)
+    error("Don't know how to atomically perform $op on $(typeof(A))")
+    # TODO: while { acquire, op, cmpxchg }
+end
+
+# AMDGPU.jl atomics
+for (op,impl) in [(+)      => atomic_add!,
+                  (-)      => atomic_sub!,
+                  (&)      => atomic_and!,
+                  (|)      => atomic_or!,
+                  (⊻)      => atomic_xor!,
+                  Base.max => atomic_max!,
+                  Base.min => atomic_min!]
+    @eval @inline atomic_arrayset(A::ROCDeviceArray, I::Integer, ::typeof($op), val) =
+        $impl(pointer(A, I), val)
+end

--- a/src/device/gcn/execution_control.jl
+++ b/src/device/gcn/execution_control.jl
@@ -1,0 +1,41 @@
+## completion signal
+
+const completion_signal_base = _packet_offsets[findfirst(x->x==:completion_signal,_packet_names)]
+
+@generated function _completion_signal()
+    T_int8 = LLVM.Int8Type(JuliaContext())
+    T_int64 = LLVM.Int64Type(JuliaContext())
+    _as = convert(Int, AS.Constant)
+    T_ptr_i8 = LLVM.PointerType(T_int8, _as)
+    T_ptr_i64 = LLVM.PointerType(T_int64, _as)
+
+    # create function
+    llvm_f, _ = create_function(T_int64)
+    mod = LLVM.parent(llvm_f)
+
+    # generate IR
+    Builder(JuliaContext()) do builder
+        entry = BasicBlock(llvm_f, "entry", JuliaContext())
+        position!(builder, entry)
+
+        # get the kernel dispatch pointer
+        intr_typ = LLVM.FunctionType(T_ptr_i8)
+        intr = LLVM.Function(mod, "llvm.amdgcn.dispatch.ptr", intr_typ)
+        ptr = call!(builder, intr)
+
+        # load the index
+        signal_ptr_i8 = inbounds_gep!(builder, ptr, [ConstantInt(completion_signal_base, JuliaContext())])
+        signal_ptr = bitcast!(builder, signal_ptr_i8, T_ptr_i64)
+        signal = load!(builder, signal_ptr)
+        ret!(builder, signal)
+    end
+
+    call_function(llvm_f, UInt64)
+end
+
+signal_completion(value::Int64) = device_signal_store!(_completion_signal(), value)
+
+## misc. intrinsics
+@inline sendmsg(x1, x2=Int32(0)) = ccall("llvm.amdgcn.s.sendmsg", llvmcall, Cvoid, (Int32, Int32), x1, x2)
+@inline sendmsghalt(x1, x2=Int32(0)) = ccall("llvm.amdgcn.s.sendmsghalt", llvmcall, Cvoid, (Int32, Int32), x1, x2)
+@inline endpgm() = @asmcall("s_endpgm", "", true)

--- a/src/device/gcn/hostcall.jl
+++ b/src/device/gcn/hostcall.jl
@@ -133,7 +133,7 @@ end
         push!(ex.args, :($device_signal_wait(hc.signal, hc.host_sentinel)))
         # Get return buffer and load first value
         ptr = :(Base.unsafe_convert(DevicePtr{DevicePtr{$RT,AS.Global},AS.Global}, hc.buf_ptr))
-        push!(ex.args, :(Base.unsafe_load(Base.unsafe_load($ptr))))
+        push!(ex.args, :(unsafe_load(unsafe_load($ptr))))
     end
 
     return ex

--- a/src/device/gcn/indexing.jl
+++ b/src/device/gcn/indexing.jl
@@ -33,7 +33,7 @@ end
 @generated function _dim(::Val{base}, ::Val{off}, ::Val{range}, ::Type{T}) where {base, off, range, T}
     T_int8 = LLVM.Int8Type(JuliaContext())
     T_int32 = LLVM.Int32Type(JuliaContext())
-    _as = Base.libllvm_version < v"7.0" ? 2 : 4
+    _as = convert(Int, AS.Constant)
     T_ptr_i8 = LLVM.PointerType(T_int8, _as)
     T_ptr_i32 = LLVM.PointerType(T_int32, _as)
     T_ptr_T = LLVM.PointerType(convert(LLVMType, T), _as)
@@ -91,8 +91,6 @@ for dim in (:x, :y, :z)
     cufn = Symbol("blockIdx_$dim")
     @eval @inline $cufn() = $fn()
 end
-_packet_names = fieldnames(HSA.KernelDispatchPacket)
-_packet_offsets = fieldoffset.(HSA.KernelDispatchPacket, 1:length(_packet_names))
 for (dim,off) in ((:x,1), (:y,2), (:z,3))
     # Workitem dimension
     fn = Symbol("workgroupDim_$dim")

--- a/src/device/gcn/memory_dynamic.jl
+++ b/src/device/gcn/memory_dynamic.jl
@@ -1,4 +1,18 @@
-export malloc
+export malloc, free
 
-# Stub implementation
-malloc(::Csize_t) = C_NULL
+function malloc(sz::Csize_t)
+    malloc_gbl = get_global_pointer(Val(:__global_malloc_hostcall),
+                                    HostCall{UInt64,DevicePtr{UInt8,AS.Global},Tuple{UInt64,Csize_t}})
+    malloc_hc = Base.unsafe_load(malloc_gbl)
+    kern = _completion_signal()
+    ptr = hostcall!(malloc_hc, kern, sz)
+    return ptr
+end
+
+function free(ptr::DevicePtr{T,AS.Global}) where T
+    free_gbl = get_global_pointer(Val(:__global_free_hostcall),
+                                  HostCall{UInt64,Nothing,Tuple{UInt64,DevicePtr{UInt8,AS.Global}}})
+    free_hc = Base.unsafe_load(free_gbl)
+    kern = _completion_signal()
+    hostcall!(free_hc, kern, Base.unsafe_convert(DevicePtr{UInt8,AS.Global}, ptr))
+end

--- a/src/device/gcn/memory_static.jl
+++ b/src/device/gcn/memory_static.jl
@@ -1,7 +1,7 @@
-export alloc_special
+export alloc_special, alloc_local
 
 "Allocates on-device memory statically from the specified address space."
-@generated function alloc_special(::Val{id}, ::Type{T}, ::Val{as}, ::Val{len}=Val(0)) where {id,T,as,len}
+@generated function alloc_special(::Val{id}, ::Type{T}, ::Val{as}, ::Val{len}) where {id,T,as,len}
     eltyp = convert(LLVMType, T)
 
     # old versions of GPUArrays invoke _shmem with an integer id; make sure those are unique
@@ -41,3 +41,80 @@ export alloc_special
 
     call_function(llvm_f, DevicePtr{T,as})
 end
+
+@inline alloc_local(id, T, len) = alloc_special(Val(id), Val(T), Val(AS.Local), Val(len))
+
+@inline @generated function alloc_string(::Val{str}) where str
+    T_pint8_generic = LLVM.PointerType(LLVM.Int8Type(JuliaContext()), convert(Int, AS.Generic))
+    llvm_f, _ = create_function(LLVM.Int64Type(JuliaContext()))
+    Builder(JuliaContext()) do builder
+        entry = BasicBlock(llvm_f, "entry", JuliaContext())
+        position!(builder, entry)
+        str_ptr = globalstring_ptr!(builder, String(str))
+        str_ptr_i64 = ptrtoint!(builder, str_ptr, LLVM.Int64Type(JuliaContext()))
+        ret!(builder, str_ptr_i64)
+    end
+    call_function(llvm_f, DevicePtr{UInt8,AS.Generic})
+end
+
+# TODO: Support various types of len
+@inline @generated function memcpy!(dest_ptr::DevicePtr{UInt8,DestAS}, src_ptr::DevicePtr{UInt8,SrcAS}, len::LT) where {DestAS,SrcAS,LT<:Union{Int64,UInt64}}
+    T_nothing = LLVM.VoidType(JuliaContext())
+    dest_as = convert(Int, DestAS)
+    src_as = convert(Int, SrcAS)
+    T_int8 = LLVM.Int8Type(JuliaContext())
+    T_int64 = LLVM.Int64Type(JuliaContext())
+    T_pint8_dest = LLVM.PointerType(T_int8, dest_as)
+    T_pint64_dest = LLVM.PointerType(T_int64, dest_as)
+    T_pint8_src = LLVM.PointerType(T_int8, src_as)
+    T_pint64_src = LLVM.PointerType(T_int64, src_as)
+    T_int1 = LLVM.Int1Type(JuliaContext())
+
+    llvm_f, _ = create_function(T_nothing, [T_int64, T_int64, T_int64])
+    mod = LLVM.parent(llvm_f)
+    T_intr = LLVM.FunctionType(T_nothing, [T_pint8_dest, T_pint8_src, T_int64, T_int1])
+    intr = LLVM.Function(mod, "llvm.memcpy.p$(dest_as)i8.p$(src_as)i8.i64", T_intr)
+    Builder(JuliaContext()) do builder
+        entry = BasicBlock(llvm_f, "entry", JuliaContext())
+        position!(builder, entry)
+
+        dest_ptr_i64 = inttoptr!(builder, parameters(llvm_f)[1], T_pint64_dest)
+        dest_ptr_i8 = bitcast!(builder, dest_ptr_i64, T_pint8_dest)
+
+        src_ptr_i64 = inttoptr!(builder, parameters(llvm_f)[2], T_pint64_src)
+        src_ptr_i8 = bitcast!(builder, src_ptr_i64, T_pint8_src)
+
+        call!(builder, intr, [dest_ptr_i8, src_ptr_i8, parameters(llvm_f)[3], ConstantInt(T_int1, 0)])
+        ret!(builder)
+    end
+    call_function(llvm_f, Nothing, Tuple{DevicePtr{UInt8,DestAS},DevicePtr{UInt8,SrcAS},LT}, :((dest_ptr, src_ptr, len)))
+end
+memcpy!(dest_ptr::DevicePtr{T,DestAS}, src_ptr::DevicePtr{T,SrcAS}, len::Integer) where {T,DestAS,SrcAS} =
+    memcpy!(convert(DevicePtr{UInt8,DestAS}, dest_ptr), convert(DevicePtr{UInt8,SrcAS}, src_ptr), UInt64(len))
+@inline @generated function memset!(dest_ptr::DevicePtr{UInt8,DestAS}, value::UInt8, len::LT) where {DestAS,LT<:Union{Int64,UInt64}}
+    T_nothing = LLVM.VoidType(JuliaContext())
+    dest_as = convert(Int, DestAS)
+    T_int8 = LLVM.Int8Type(JuliaContext())
+    T_int64 = LLVM.Int64Type(JuliaContext())
+    T_pint8_dest = LLVM.PointerType(T_int8, dest_as)
+    T_pint64_dest = LLVM.PointerType(T_int64, dest_as)
+    T_int1 = LLVM.Int1Type(JuliaContext())
+
+    llvm_f, _ = create_function(T_nothing, [T_int64, T_int8, T_int64])
+    mod = LLVM.parent(llvm_f)
+    T_intr = LLVM.FunctionType(T_nothing, [T_pint8_dest, T_int8, T_int64, T_int1])
+    intr = LLVM.Function(mod, "llvm.memset.p$(dest_as)i8.i64", T_intr)
+    Builder(JuliaContext()) do builder
+        entry = BasicBlock(llvm_f, "entry", JuliaContext())
+        position!(builder, entry)
+
+        dest_ptr_i64 = inttoptr!(builder, parameters(llvm_f)[1], T_pint64_dest)
+        dest_ptr_i8 = bitcast!(builder, dest_ptr_i64, T_pint8_dest)
+
+        call!(builder, intr, [dest_ptr_i8, parameters(llvm_f)[2], parameters(llvm_f)[3], ConstantInt(T_int1, 0)])
+        ret!(builder)
+    end
+    call_function(llvm_f, Nothing, Tuple{DevicePtr{UInt8,DestAS},UInt8,LT}, :((dest_ptr, value, len)))
+end
+memset!(dest_ptr::DevicePtr{T,DestAS}, value::UInt8, len::Integer) where {T,DestAS} =
+    memset!(convert(DevicePtr{UInt8,DestAS}, dest_ptr), value, UInt64(len))

--- a/src/device/gcn/output.jl
+++ b/src/device/gcn/output.jl
@@ -24,6 +24,8 @@ function OutputContext(io::IO=stdout; agent=get_default_agent(), buf_len=2^16, k
     OutputContext(hc)
 end
 
+const GLOBAL_OUTPUT_CONTEXT_TYPE = OutputContext{HostCall{UInt64,Int64,Tuple{DeviceStaticString{2^16}}}}
+
 ### macros
 
 macro rocprint(oc, str)
@@ -33,9 +35,30 @@ macro rocprintln(oc, str)
     rocprint(oc, str, true)
 end
 
+macro rocprint(str)
+    @gensym oc_ptr oc
+    ex = quote
+        $(esc(oc_ptr)) = AMDGPU.get_global_pointer(Val(:__global_output_context),
+                                                         $GLOBAL_OUTPUT_CONTEXT_TYPE)
+        $(esc(oc)) = Base.unsafe_load($(esc(oc_ptr)))
+    end
+    push!(ex.args, rocprint(oc, str))
+    ex
+end
+macro rocprintln(str)
+    @gensym oc_ptr oc
+    ex = quote
+        $(esc(oc_ptr)) = AMDGPU.get_global_pointer(Val(:__global_output_context),
+                                                         $GLOBAL_OUTPUT_CONTEXT_TYPE)
+        $(esc(oc)) = Base.unsafe_load($(esc(oc_ptr)))
+    end
+    push!(ex.args, rocprint(oc, str, true))
+    ex
+end
+
 ### parse-time helpers
 
-function rocprint(oc, str, nl=false)
+function rocprint(oc, str, nl::Bool=false)
     ex = Expr(:block)
     if !(str isa Expr)
         str = Expr(:string, str)
@@ -50,18 +73,14 @@ function rocprint(oc, str, nl=false)
         dstr = DeviceStaticString{N}()
         push!(ex.args, :(hostcall!($(esc(oc)).hostcall, $dstr)))
     end
+    push!(ex.args, :(nothing))
     return ex
 end
 function rocprint!(ex, N, oc, str::String)
-    # TODO: push!(ex.args, :($rocprint!($(esc(oc)), $(Val(Symbol(str))))))
-    off = N
-    ptr = :(Base.unsafe_convert(DevicePtr{UInt8,AS.Global}, $(esc(oc)).hostcall.buf_ptr))
-    for byte in codeunits(str)
-        push!(ex.args, :(Base.unsafe_store!($ptr, $byte, $off)))
-        off += 1
-    end
-
-    return off
+    @gensym str_ptr
+    push!(ex.args, :($str_ptr = AMDGPU.alloc_string($(Val(Symbol(str))))))
+    push!(ex.args, :(AMDGPU.memcpy!($(esc(oc)).hostcall.buf_ptr+$(N-1), $str_ptr, $(length(str)))))
+    return N+length(str)
 end
 function rocprint!(ex, N, oc, char::Char)
     @assert char == '\0' "Non-null chars not yet implemented"
@@ -84,29 +103,3 @@ end
 =#
 
 ### runtime helpers
-
-#= TODO: LLVM hates me, but this should eventually work
-# FIXME: Pass N and offset oc.buf_ptr appropriately
-@inline @generated function rocprint!(oc::OutputContext, ::Val{str}) where str
-    T_int1 = LLVM.Int1Type(JuliaContext())
-    T_int32 = LLVM.Int32Type(JuliaContext())
-    T_pint8 = LLVM.PointerType(LLVM.Int8Type(JuliaContext()))
-    T_pint8_global = LLVM.PointerType(LLVM.Int8Type(JuliaContext()), convert(Int, AS.Global))
-    T_nothing = LLVM.VoidType(JuliaContext())
-    llvm_f, _ = create_function(T_nothing, [T_pint8_global])
-    mod = LLVM.parent(llvm_f)
-    T_intr = LLVM.FunctionType(T_nothing, [T_pint8_global, T_pint8, T_int32, T_int32, T_int1])
-    intr = LLVM.Function(mod, "llvm.memcpy.p1i8.p0i8.i32", T_intr)
-    Builder(JuliaContext()) do builder
-        entry = BasicBlock(llvm_f, "entry", JuliaContext())
-        position!(builder, entry)
-        str_ptr = globalstring_ptr!(builder, String(str))
-        buf_ptr = parameters(llvm_f)[1]
-        # NOTE: There's a hidden alignment parameter (argument 4) that's not documented in the LangRef
-        call!(builder, intr, [buf_ptr, str_ptr, ConstantInt(Int32(length(string(str))), JuliaContext()), ConstantInt(Int32(2), JuliaContext()), ConstantInt(T_int1, 0)])
-        ret!(builder)
-    end
-    Core.println(unsafe_string(LLVM.API.LLVMPrintValueToString(LLVM.ref(llvm_f))))
-    call_function(llvm_f, Nothing, Tuple{DevicePtr{UInt8,AS.Global}}, :((oc.hostcall.buf_ptr,)))
-end
-=#

--- a/src/device/pointer.jl
+++ b/src/device/pointer.jl
@@ -91,23 +91,13 @@ Base.:(+)(x::Integer, y::DevicePtr) = y + x
 
 # memory operations
 
-@static if Base.libllvm_version < v"7.0"
-    # Old values (LLVM 6)
-    Base.convert(::Type{Int}, ::Type{AS.Private})  = 0
-    Base.convert(::Type{Int}, ::Type{AS.Global})   = 1
-    Base.convert(::Type{Int}, ::Type{AS.Constant}) = 2
-    Base.convert(::Type{Int}, ::Type{AS.Local})    = 3
-    Base.convert(::Type{Int}, ::Type{AS.Generic})  = 4
-    Base.convert(::Type{Int}, ::Type{AS.Region})   = 5
-else
-    # New values (LLVM 7+)
-    Base.convert(::Type{Int}, ::Type{AS.Generic})  = 0
-    Base.convert(::Type{Int}, ::Type{AS.Global})   = 1
-    Base.convert(::Type{Int}, ::Type{AS.Region})   = 2
-    Base.convert(::Type{Int}, ::Type{AS.Local})    = 3
-    Base.convert(::Type{Int}, ::Type{AS.Constant}) = 4
-    Base.convert(::Type{Int}, ::Type{AS.Private})  = 5
-end
+# New values (LLVM 7+)
+Base.convert(::Type{Int}, ::Type{AS.Generic})  = 0
+Base.convert(::Type{Int}, ::Type{AS.Global})   = 1
+Base.convert(::Type{Int}, ::Type{AS.Region})   = 2
+Base.convert(::Type{Int}, ::Type{AS.Local})    = 3
+Base.convert(::Type{Int}, ::Type{AS.Constant}) = 4
+Base.convert(::Type{Int}, ::Type{AS.Private})  = 5
 
 function tbaa_make_child(name::String, constant::Bool=false; ctx::LLVM.Context=JuliaContext())
     tbaa_root = MDNode([MDString("roctbaa", ctx)], ctx)

--- a/src/device/runtime.jl
+++ b/src/device/runtime.jl
@@ -15,48 +15,60 @@ function load_runtime(dev_isa::String)
     GPUCompiler.load_runtime(job)
 end
 
-#@inline exception_flag() = ccall("extern julia_exception_flag", llvmcall, Ptr{Cvoid}, ())
-
 function signal_exception()
-#=
-    ptr = exception_flag()
-    if ptr !== C_NULL
-        unsafe_store!(convert(Ptr{Int}, ptr), 1)
-        threadfence_system()
-    else
-        @rocprintf("""
-            WARNING: could not signal exception status to the host, execution will continue.
-                     Please file a bug.
-            """)
-    end
-=#
+    flag_ptr = get_global_pointer(Val(:__global_exception_flag), Int64)
+    unsafe_store!(flag_ptr, 1)
+    # TODO: Can we sync here?
+    endpgm() # stop this wavefront
     return
 end
 
 function report_exception(ex)
-#=
-    @rocprintf("""
-        ERROR: a %s was thrown during kernel execution.
-               Run Julia on debug level 2 for device stack traces.
-        """, ex)
-=#
+    # Add kernel ID and exception string to exception ring buffer
+    ring_ptr = get_global_pointer(Val(:__global_exception_ring), DevicePtr{ExceptionEntry,AS.Global})
+    ring_ptr = unsafe_load(ring_ptr)
+    our_signal = _completion_signal()
+    prev = UInt64(1)
+    while prev != UInt64(0)
+        # Try to write to this slot, and skip if we fail (because another wavefront wrote first)
+        prev = atomic_cas!(convert(DevicePtr{UInt64,AS.Global}, ring_ptr), UInt64(0), our_signal)
+        if prev == UInt64(0)
+            # We get a ReadOnlyMemoryError without this copy because the data is pinned to the device
+            # TODO: Don't use an expensive host malloc
+            ex_len = string_length(ex)
+            copy_buf = malloc(ex_len)
+            memcpy!(copy_buf, DevicePtr{UInt8,AS.Global}(ex), ex_len)
+            unsafe_store!(convert(DevicePtr{UInt64}, ring_ptr)+sizeof(UInt64), UInt64(copy_buf))
+            break
+        elseif prev == UInt64(1)
+            # Tail slot, give up
+            break
+        end
+        ring_ptr += sizeof(ExceptionEntry)
+    end
     return
 end
 
-report_oom(sz) = nothing #@rocprintf("ERROR: Out of dynamic GPU memory (trying to allocate %i bytes)\n", sz)
+# FIXME: report_oom(sz) = @rocprintf("ERROR: Out of dynamic GPU memory (trying to allocate %i bytes)\n", sz)
+report_oom(sz) = @rocprintln("ERROR: Out of dynamic GPU memory")
 
 function report_exception_name(ex)
-#=
+    #= FIXME
     @rocprintf("""
         ERROR: a %s was thrown during kernel execution.
         Stacktrace:
         """, ex)
-=#
+    =#
+    @rocprint("""
+        ERROR: an exception was thrown during kernel execution.
+        Stacktrace:
+        """)
     return
 end
 
 function report_exception_frame(idx, func, file, line)
-    #@rocprintf(" [%i] %s at %s:%i\n", idx, func, file, line)
+    # FIXME: @rocprintf(" [%i] %s at %s:%i\n", idx, func, file, line)
+    #@rocprintln(" [%i] %s at %s:%i")
     return
 end
 
@@ -99,6 +111,7 @@ end
 function link_device_libs!(mod::LLVM.Module, dev_isa::String, undefined_fns)
     libs::Vector{LLVM.Module} = load_device_libs(dev_isa)
 
+    ufns = undefined_fns
     # TODO: only link if used
     # TODO: make these globally/locally configurable
     link_oclc_defaults!(mod, dev_isa)

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -1,0 +1,64 @@
+# support for device-side exceptions (from CUDAnative/src/exceptions.jl)
+
+## exception type
+
+struct KernelException <: Exception
+    dev::RuntimeDevice
+    exstr::Union{String,Nothing}
+end
+KernelException(dev) = KernelException(dev, nothing)
+
+function Base.showerror(io::IO, err::KernelException)
+    print(io, "KernelException: exception(s) thrown during kernel execution on device $(err.dev.device)")
+    if err.exstr !== nothing
+        println(io, ":")
+        print(io, err.exstr)
+    end
+end
+
+## exception ring buffer
+
+struct ExceptionEntry
+    kern::UInt64
+    ptr::DevicePtr{UInt8,AS.Global}
+end
+ExceptionEntry(kern) = ExceptionEntry(kern, DevicePtr{UInt8,AS.Global}(0))
+ExceptionEntry() = ExceptionEntry(0)
+
+## exception codegen
+
+# emit a global variable for storing the current exception status
+function emit_exception_user!(mod::LLVM.Module)
+    # add a fake user for __ockl_hsa_signal_store and __ockl_hsa_signal_load
+    if !haskey(LLVM.functions(mod), "__fake_global_exception_flag_user")
+        ctx = JuliaContext()
+        ft = LLVM.FunctionType(LLVM.VoidType(ctx))
+        fn = LLVM.Function(mod, "__fake_global_exception_flag_user", ft)
+        Builder(ctx) do builder
+            entry = BasicBlock(fn, "entry", ctx)
+            position!(builder, entry)
+            T_nothing = LLVM.VoidType(ctx)
+            T_i32 = LLVM.Int32Type(ctx)
+            T_i64 = LLVM.Int64Type(ctx)
+            T_signal_store = LLVM.FunctionType(T_nothing, [T_i64, T_i64, T_i32])
+            signal_store = LLVM.Function(mod, "__ockl_hsa_signal_store", T_signal_store)
+            call!(builder, signal_store, [ConstantInt(0,ctx),
+                                          ConstantInt(0,ctx),
+                                          # __ATOMIC_RELEASE == 3
+                                          ConstantInt(Int32(3), JuliaContext())])
+            T_signal_load = LLVM.FunctionType(T_i64, [T_i64, T_i32])
+            signal_load = LLVM.Function(mod, "__ockl_hsa_signal_load", T_signal_load)
+            loaded_value = call!(builder, signal_load, [ConstantInt(0,ctx),
+                                                        # __ATOMIC_ACQUIRE == 2
+                                                        ConstantInt(Int32(2), JuliaContext())])
+            ret!(builder)
+        end
+    end
+    @assert haskey(LLVM.functions(mod), "__fake_global_exception_flag_user")
+end
+function delete_exception_user!(mod::LLVM.Module)
+    if haskey(LLVM.functions(mod), "__fake_global_exception_flag_user")
+        delete!(mod, LLVM.functions(mod)["__fake_global_exception_flag_user"])
+    end
+    @assert !haskey(LLVM.functions(mod), "__fake_global_exception_flag_user")
+end

--- a/test/device/exceptions.jl
+++ b/test/device/exceptions.jl
@@ -1,0 +1,19 @@
+@testset "Exceptions" begin
+
+function oob_kernel(X)
+    X[0] = 1
+    nothing
+end
+
+HA = HSAArray(ones(Float32, 4))
+try
+    wait(@roc oob_kernel(HA))
+catch err
+    @test err isa AMDGPU.KernelException
+    if err isa AMDGPU.KernelException
+        @test err.exstr !== nothing
+        @test occursin("boundserror", err.exstr)
+    end
+end
+
+end

--- a/test/device/memory.jl
+++ b/test/device/memory.jl
@@ -34,3 +34,50 @@ wait(@roc memory_static_kernel(HA, HB))
 @test Array(HA) ≈ Array(HB)
 
 end
+
+@testset "Memory: Dynamic" begin
+
+function malloc_kernel(X)
+    ptr = AMDGPU.malloc(Csize_t(4))
+    X[1] = ptr
+    AMDGPU.free(ptr)
+    nothing
+end
+
+HA = HSAArray(zeros(UInt64, 1))
+
+wait(@roc malloc_kernel(HA))
+
+@test Array(HA)[1] != 0
+
+end
+
+@testset "Memcpy/Memset" begin
+
+function memcpy_kernel(X,Y)
+    AMDGPU.memcpy!(Y.ptr, X.ptr, sizeof(Float32)*length(X))
+    nothing
+end
+
+A = rand(Float32, 4)
+B = zeros(Float32, 4)
+HA, HB = HSAArray.((A,B))
+
+wait(@roc memcpy_kernel(HA,HB))
+
+@test A == collect(HA) == collect(HB)
+
+function memset_kernel(X,y)
+    AMDGPU.memset!(X.ptr, y, div(length(X),2))
+    nothing
+end
+
+A = zeros(UInt8, 4)
+HA = HSAArray(A)
+
+wait(@roc memset_kernel(HA,0x3))
+
+@test all(collect(HA)[1:2] .== 0x3)
+@test all(collect(HA)[3:4] .== 0x0)
+
+end

--- a/test/device/output.jl
+++ b/test/device/output.jl
@@ -40,6 +40,17 @@ end
     @test String(take!(iob)) == "Hello World!Goodbye World!\n"
 end
 
+@testset "Plain, global context" begin
+    function kernel(x)
+        @rocprint "Hello World!"
+        @rocprintln "Goodbye World!"
+        nothing
+    end
+
+    _, msg = @grab_output wait(@roc kernel(1))
+    @test msg == "Hello World!Goodbye World!\n"
+end
+
 #= TODO
 @testset "Interpolated string" begin
     inner_str = "to the"

--- a/test/hsa/global.jl
+++ b/test/hsa/global.jl
@@ -17,7 +17,7 @@ Base.unsafe_store!(gbl_ptr, 2f0)
 dev = AMDGPU.default_device()
 queue = AMDGPU.default_queue(dev)
 kern = AMDGPU.create_kernel(dev, exe, hk.fun.entry, (Int32(3),))
-signal = AMDGPU.create_event()
+signal = AMDGPU.create_event(hk.mod.exe)
 AMDGPU.launch_kernel(queue, kern, signal; groupsize=(1,1,1), gridsize=(1,1,1))
 wait(signal)
 @test Base.unsafe_load(gbl_ptr) == 3f0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,6 +58,8 @@ if AMDGPU.configured
             include("device/output.jl")
             include("device/globals.jl")
             include("device/math.jl")
+            include("device/execution_control.jl")
+            include("device/exceptions.jl")
         end
         @testset "ROCArray" begin
             @testset "ROCm External Libraries" begin

--- a/test/util.jl
+++ b/test/util.jl
@@ -17,3 +17,24 @@
         end
     end
 end
+
+# NOTE: based on test/pkg.jl::capture_stdout, but doesn't discard exceptions
+macro grab_output(ex, io=stdout)
+    quote
+        mktemp() do fname, fout
+            ret = nothing
+            open(fname, "w") do fout
+                if $io == stdout
+                    redirect_stdout(fout) do
+                        ret = $(esc(ex))
+                    end
+                elseif $io == stderr
+                    redirect_stderr(fout) do
+                        ret = $(esc(ex))
+                    end
+                end
+            end
+            ret, read(fname, String)
+        end
+    end
+end


### PR DESCRIPTION
Removed support for LLVM < 7
Added memcpy! and memset! intrinsics
Added more efficient memcpy! implementation for output
Added global output context support
Added exception flag and exception list
Added malloc and free hostcalls
Added execution control intrinsics
Expanded ROCModule to contain exception ring buffer
Added HSAStatusSignal for exception handling
Worked around broken exception intrinsic emission

Todo:
- [x] Fix memory access fault bug (no idea how, but it's working!)
- [x] Enable and test atomic_cmpxchg implementation
- [ ] ~Test locally with highly-concurrent kernel launches~ Don't know how!
- [x] Documentation