### PR TITLE
fix for finding HIP binaries

### DIFF
--- a/deps/deps.jl
+++ b/deps/deps.jl
@@ -34,6 +34,7 @@ if !ext_libs_configured
     const librocfft = nothing
     const librocrand = nothing
     const libmiopen = nothing
+    const libhip = nothing
 end
 
 const configured = hsa_configured

--- a/deps/hsa/build.jl
+++ b/deps/hsa/build.jl
@@ -85,6 +85,8 @@ function find_ld_lld()
     paths = split(get(ENV, "PATH", ""), ":")
     paths = filter(path->path != "", paths)
     paths = map(Base.Filesystem.abspath, paths)
+    ispath("/opt/rocm/llvm/bin/ld.lld") &&
+        push!(paths, "/opt/rocm/llvm/bin/")
     ispath("/opt/rocm/hcc/bin/ld.lld") &&
         push!(paths, "/opt/rocm/hcc/bin/")
     ispath("/opt/rocm/opencl/bin/x86_64/ld.lld") &&

--- a/deps/rocm-external/build.jl
+++ b/deps/rocm-external/build.jl
@@ -59,13 +59,10 @@ function main()
     end
     
     lib_hip = Symbol("libhip")
-    for name in ("hip_hcc", "amdhip64")
-        config[lib_hip] = find_roc_library("lib$name")
-        config[lib_hip] !== nothing && break
-    end
-    if config[lib_hip] == nothing
-        build_warning("Could not find library HIP")
-    end
+    _paths = String[]
+    config[lib_hip] = Libdl.find_library(["libhip_hcc","libamdhip64"], _paths)
+    config[lib_hip] == nothing && build_warning("Could not find library HIP")
+
     ## (re)generate ext.jl
 
     function globals(mod)

--- a/deps/rocm-external/build.jl
+++ b/deps/rocm-external/build.jl
@@ -57,8 +57,15 @@ function main()
             build_warning("Could not find library '$name'")
         end
     end
-
-
+    
+    lib_hip = Symbol("libhip")
+    for name in ("hip_hcc", "amdhip64")
+        config[lib_hip] = find_roc_library("lib$name")
+        config[lib_hip] !== nothing && break
+    end
+    if config[lib_hip] == nothing
+        build_warning("Could not find library HIP")
+    end
     ## (re)generate ext.jl
 
     function globals(mod)

--- a/src/hip/HIP.jl
+++ b/src/hip/HIP.jl
@@ -1,5 +1,6 @@
 module HIP
 
+import ..AMDGPU.libhip
 using CEnum
 
 include("libhip_common.jl")

--- a/src/hip/libhip.jl
+++ b/src/hip/libhip.jl
@@ -1,11 +1,11 @@
 function hipStreamSynchronize(stream::hipStream_t)
-    @check ccall((:hipStreamSynchronize, "libhip_hcc.so"), hipError_t, (hipStream_t,), stream)
+    @check ccall((:hipStreamSynchronize, libhip), hipError_t, (hipStream_t,), stream)
 end
 
 function hipStreamQuery(stream::hipStream_t)
-    @check ccall((:hipStreamQuery, "libhip_hcc.so"), hipError_t, (hipStream_t,), stream)
+    @check ccall((:hipStreamQuery, libhip), hipError_t, (hipStream_t,), stream)
 end
 
 function hipDeviceSynchronize()
-    @check ccall((:hipDeviceSynchronize, "libhip_hcc.so"), hipError_t, ())
+    @check ccall((:hipDeviceSynchronize, libhip), hipError_t, ())
 end


### PR DESCRIPTION
These changes should allow the HIP library to load regardless of whether it uses the current or older naming convention.
The newer location of ROCm-provided `lld.ld` is also included in the search paths.