### PR TITLE
Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,33 @@
+FROM rocm/dev-ubuntu-20.04:latest
+
+# Install ROCm dependencies
+RUN apt-get update &&\
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl libnuma-dev gnupg &&\
+    curl -sL http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | apt-key add - &&\
+    printf "deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main" | tee /etc/apt/sources.list.d/rocm.list &&\
+    apt-get update &&\
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        libelf1 \
+        rocm-dev \
+        rocblas \
+        rocsparse \
+        rocalution \
+        rocfft \
+        rocrand \
+        miopen-hip \
+        ca-certificates \
+        build-essential &&\
+    apt-get clean &&\
+    rm -rf /var/lib/apt/lists/*
+
+# Install Julia
+RUN curl -L https://julialang-s3.julialang.org/bin/linux/x64/1.5/julia-1.5.1-linux-x86_64.tar.gz > /tmp/julia-1.5.1.tar.gz &&\
+    cd root &&\
+    tar -xzvf /tmp/julia-1.5.1.tar.gz
+
+# Install AMDGPU.jl
+RUN /root/julia-1.5.1/bin/julia -E "using Pkg; Pkg.add(\"AMDGPU\"); Pkg.build(\"AMDGPU\")"
+
+VOLUME ["/root/.julia"]
+ENTRYPOINT ["/root/julia-1.5.1/bin/julia"]
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN curl -L https://julialang-s3.julialang.org/bin/linux/x64/1.5/julia-1.5.1-lin
     tar -xzvf /tmp/julia-1.5.1.tar.gz
 
 # Install AMDGPU.jl
-RUN /root/julia-1.5.1/bin/julia -E "using Pkg; Pkg.add(\"AMDGPU\"); Pkg.build(\"AMDGPU\")"
+RUN /root/julia-1.5.1/bin/julia -E "using Pkg; Pkg.add(\"AMDGPU\");"
 
 VOLUME ["/root/.julia"]
 ENTRYPOINT ["/root/julia-1.5.1/bin/julia"]


### PR DESCRIPTION
Initial attempt to write a Dockerfile for AMDGPU.jl, based on the latest Ubuntu ROCm image.

It seems to work (at least for the simple vector sum in the documentation), however, you have to ignore several error messages.

Unfortunately, the build fails with:
```
 Installing known registries into `~/.julia`
######################################################################## 100.0%
      Added registry `General` to `~/.julia/registries/General`
  Resolving package versions...
  Installed AbstractFFTs ─────── v0.5.0
  Installed TimerOutputs ─────── v0.5.6
  Installed ConstructionBase ─── v1.0.0
  Installed Compat ───────────── v3.15.0
  Installed BinaryProvider ───── v0.5.10
  Installed DataStructures ───── v0.18.2
  Installed LLVM ─────────────── v3.0.0
  Installed AMDGPU ───────────── v0.2.0
  Installed CEnum ────────────── v0.4.1
  Installed MacroTools ───────── v0.5.5
  Installed Adapt ────────────── v2.0.2
  Installed Requires ─────────── v1.0.1
  Installed GPUArrays ────────── v5.1.0
  Installed Setfield ─────────── v0.7.0
  Installed GPUCompiler ──────── v0.7.1
  Installed OrderedCollections ─ v1.3.0
Updating `~/.julia/environments/v1.5/Project.toml`
  [21141c5a] + AMDGPU v0.2.0
Updating `~/.julia/environments/v1.5/Manifest.toml`
  [21141c5a] + AMDGPU v0.2.0
  [621f4979] + AbstractFFTs v0.5.0
  [79e6a3ab] + Adapt v2.0.2
  [b99e7846] + BinaryProvider v0.5.10
  [fa961155] + CEnum v0.4.1
  [34da2185] + Compat v3.15.0
  [187b0558] + ConstructionBase v1.0.0
  [864edb3b] + DataStructures v0.18.2
  [0c68f7d7] + GPUArrays v5.1.0
  [61eb1bfa] + GPUCompiler v0.7.1
  [929cbde3] + LLVM v3.0.0
  [1914dd2f] + MacroTools v0.5.5
  [bac558e1] + OrderedCollections v1.3.0
  [ae029012] + Requires v1.0.1
  [efcf1570] + Setfield v0.7.0
  [a759f4b9] + TimerOutputs v0.5.6
  [2a0f44e3] + Base64
  [ade2ca70] + Dates
  [8bb1440f] + DelimitedFiles
  [8ba89e20] + Distributed
  [9fa8497b] + Future
  [b77e0a4c] + InteractiveUtils
  [76f85450] + LibGit2
  [8f399da3] + Libdl
  [37e2e46d] + LinearAlgebra
  [56ddb016] + Logging
  [d6f4376e] + Markdown
  [a63ad114] + Mmap
  [44cfe95a] + Pkg
  [de0858da] + Printf
  [3fa0cd96] + REPL
  [9a3f8284] + Random
  [ea8e919c] + SHA
  [9e88b42a] + Serialization
  [1a1011a3] + SharedArrays
  [6462fe0b] + Sockets
  [2f01184e] + SparseArrays
  [10745b16] + Statistics
  [8dfed614] + Test
  [cf7118a7] + UUIDs
  [4ec0a83e] + Unicode
   Building AMDGPU → `~/.julia/packages/AMDGPU/nnddY/deps/build.log`
┌ Error: Error building `AMDGPU`:
│ paths = ["/opt/rocm/hsa/lib"]
│ Initializing HSA runtime failed with code 4104.
└ @ Pkg.Operations /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/Pkg/src/Operations.jl:949
   Building AMDGPU → `~/.julia/packages/AMDGPU/nnddY/deps/build.log`
┌ Error: Error building `AMDGPU`:
│ paths = ["/opt/rocm/hsa/lib"]
│ Initializing HSA runtime failed with code 4104.
└ @ Pkg.Operations /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/Pkg/src/Operations.jl:949
```