### PR TITLE
Don't do set_used on GVs

### DIFF
--- a/src/device/globals.jl
+++ b/src/device/globals.jl
@@ -23,7 +23,7 @@
             global_var = GlobalVariable(mod, T_global, global_name_string, 1)
             linkage!(global_var, LLVM.API.LLVMExternalLinkage)
             extinit!(global_var, true)
-            set_used!(mod, global_var)
+            #set_used!(mod, global_var)
         end
 
         # Generate IR that computes the global's address.


### PR DESCRIPTION
Apparently, LLVM's `appendToUsedList` (called from LLVMExtra via `LLVM.set_used!`) tries to bitcast from the provided GV to an `i8*`, which I assume is not valid when the GV has a non-0 addrspace. Whatever the reason, we've been getting an `Invalid constexpr bitcast!` assertion originating from that line in some tests and on all of my systems (which use an LLVM debug build +asserts).

Offending line in LLVM 9.0.1 is `lib/Transforms/Utils/ModuleUtils.cpp +87`.

@maleadt am I doing something wrong, or is LLVM?