### PR TITLE
Add barrier packet support

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -68,8 +68,8 @@ version = "5.1.0"
 
 [[GPUCompiler]]
 deps = ["DataStructures", "InteractiveUtils", "LLVM", "Libdl", "Scratch", "Serialization", "TimerOutputs", "UUIDs"]
-git-tree-sha1 = "55ad1a0ac4067fa469b8676926abd66b190f951c"
-repo-rev = "tb/freeze"
+git-tree-sha1 = "e91429f08114650c5daceeb4ef8f8ab0f739b2f9"
+repo-rev = "jps/gcn-late-alloca-rewrite"
 repo-url = "https://github.com/JuliaGPU/GPUCompiler.jl.git"
 uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
 version = "0.7.3"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,6 +5,7 @@ makedocs(
     pages = [
         "Home" => "index.md",
         "Quick Start" => "quickstart.md",
+        "Kernel Dependencies" => "kernel_deps.md",
         "Global Variables" => "globals.md",
         "Exceptions" => "exceptions.md",
         "Memory" => "memory.md",

--- a/docs/src/kernel_deps.md
+++ b/docs/src/kernel_deps.md
@@ -1,0 +1,53 @@
+# Kernel Dependencies
+
+Unlike CUDA, ROCm does not have blocking queues; instead, all kernels placed on a queue will usually be processed and scheduled immediately. There is one exception: barrier packets may be placed on the queue to block the GPU's queue packet processor from proceeding until a given set of kernels has completed. These barriers come in two flavors: `barrier_and!` and `barrier_or!`. These functions can be called on a queue with a given set of kernel signals (those returned from `@roc`) to wait for all kernels or any one kernel to complete, respectively.
+
+Generally, the `barrier_and!` call should be the most useful tool for most users, since many codes require synchronization of all "threads of execution" at the end of one step before moving onto the next step. For example, the following code may look innocuous, but in fact the kernels might "race" and return unexpected results:
+
+```julia
+function kernel(A)
+    A[1] += 1.0
+    nothing
+end
+
+RA = ROCArray(zeros(Float64, 1))
+@roc kernel(RA)
+@roc kernel(RA)
+@show Array(RA)[1] # could be 1.0 or 2.0
+```
+
+To fix this example, we use a `barrier_and!` call to ensure proper ordering of execution:
+
+```julia
+RA = ROCArray(zeros(Float64, 1))
+s1 = @roc kernel(RA)
+barrier_and!([s1])
+s2 = @roc kernel(RA)
+wait(s2)
+@show Array(RA)[1] # will always be 2.0
+```
+
+While likely less useful for most, `barrier_or!` can be useful in situations where any one of many "input" kernels can satisfy a condition necessary to allow later kernels to execute properly:
+
+```julia
+function kernel1(A, i)
+    A[1] = i
+    nothing
+end
+function kernel2(A, i)
+    A[2] = i/A[1]
+end
+
+RA = ROCArray(zeros(Float64, 2))
+s1 = @roc kernel1(RA, 1.0)
+s2 = @roc kernel1(RA, 2.0)
+barrier_or!([s1,s2])
+s3 = @roc kernel2(RA, 3.0)
+wait(s3)
+@show Array(RA)[1] # will either be 3.0 or 1.5, but will never throw due to divide-by-zero
+```
+
+!!! warning
+    Because of how barrier OR packets work, you can't use queue hardware to do a wait-any on more than 5 signals at a time. If more than 5 signals are specified, then the signals are split into sets of 5, and the total barrier won't be fulfilled until, for each set, one of the signals is satisfied.
+
+    Contributions are welcome to workaround this issue, which will probably need to implemented in software either on the CPU or GPU side.

--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -27,6 +27,8 @@ export HSAArray
 include(joinpath(@__DIR__, "hsa", "HSA.jl"))
 import .HSA: Agent, Queue, Executable, Status, Signal
 
+struct Adaptor end
+
 include("extras.jl")
 include("error.jl")
 include("agent.jl")
@@ -46,8 +48,6 @@ if get(ENV, "AMDGPUNATIVE_OPENCL", "") != ""
 end
 =#
 include("runtime.jl")
-
-struct Adaptor end
 
 # Device sources must load _before_ the compiler infrastructure
 # because of generated functions.

--- a/src/device/gcn/hostcall.jl
+++ b/src/device/gcn/hostcall.jl
@@ -44,6 +44,8 @@ end
 
 ## device signal functions
 # TODO: device_signal_load, device_signal_add!, etc.
+@inline device_signal_store!(signal::HSA.Signal, value::Int64) =
+    device_signal_store!(signal.handle, value)
 @inline @generated function device_signal_store!(signal::UInt64, value::Int64)
     JuliaContext() do ctx
         T_nothing = convert(LLVMType, Nothing, ctx)
@@ -72,6 +74,8 @@ end
         call_function(llvm_f, Nothing, Tuple{UInt64,Int64}, :((signal,value)))
     end
 end
+@inline device_signal_wait(signal::HSA.Signal, value::Int64) =
+    device_signal_wait(signal.handle, value)
 @inline @generated function device_signal_wait(signal::UInt64, value::Int64)
     JuliaContext() do ctx
         T_nothing = convert(LLVMType, Nothing, ctx)

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -362,9 +362,10 @@ function rocfunction_link(@nospecialize(source::FunctionSpec), (obj, kernel_fn, 
         gbl = get_global(exe, :__global_exception_flag)
         gbl_ptr = Base.unsafe_convert(Ptr{Int64}, gbl)
         Base.unsafe_store!(gbl_ptr, 0)
+    end
 
-        # initialize exception ring buffer
-        @assert any(x->x[1]==:__global_exception_ring, globals)
+    # initialize exception ring buffer
+    if any(x->x[1]==:__global_exception_ring, globals)
         gbl = get_global(exe, :__global_exception_ring)
         gbl_ptr = Base.unsafe_convert(Ptr{Ptr{ExceptionEntry}}, gbl)
         ex_ptr = Base.unsafe_convert(Ptr{ExceptionEntry}, mod.exceptions)

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -1,15 +1,15 @@
+export barrier_and!, barrier_or!
 
 mutable struct HSAKernelInstance{T<:Tuple}
     agent::HSAAgent
     exe::HSAExecutable
     sym::String
     args::T
-    # FIXME: Stop being lazy and put in some damn types!
-    kernel_object
-    kernarg_segment_size
-    group_segment_size
-    private_segment_size
-    kernarg_address::Ref{Ptr{Nothing}}
+    kernel_object::UInt64
+    kernarg_segment_size::UInt32
+    group_segment_size::UInt32
+    private_segment_size::UInt32
+    kernarg_address::Ptr{Nothing}
 end
 
 # TODO agent can be inferred from the executable
@@ -70,15 +70,29 @@ function HSAKernelInstance(agent::HSAAgent, exe::HSAExecutable, symbol::String, 
         ctr += sizeof(arg)
     end
 
-    kernel = HSAKernelInstance(agent, exe, symbol, args, kernel_object,
-                               kernarg_segment_size, group_segment_size,
-                               private_segment_size, kernarg_address)
+    kernel = HSAKernelInstance(agent, exe, symbol, args, kernel_object[],
+                               kernarg_segment_size[], group_segment_size[],
+                               private_segment_size[], kernarg_address[])
     hsaref!()
     finalizer(kernel) do kernel
-        HSA.memory_free(kernel.kernarg_address[]) |> check
+        HSA.memory_free(kernel.kernarg_address) |> check
         hsaunref!()
     end
     return kernel
+end
+
+function barrier_and!(queue::HSAQueue, signals::Vector{HSASignal})
+    comp_signal = HSASignal()
+    barrier_and!(queue, comp_signal, signals)
+    comp_signal
+end
+function barrier_and!(queue::HSAQueue, comp_signal::HSASignal, signals::Vector{HSASignal})
+    for signal_set in Iterators.partition(signals, 5)
+        _launch!(HSA.BarrierAndPacket, queue, comp_signal) do _packet
+            @set! _packet.dep_signal = ntuple(i->length(signal_set)>=i ? signal_set[i].signal[] : HSA.Signal(0), 5)
+            _packet
+        end
+    end
 end
 
 # TODO Docstring
@@ -87,20 +101,33 @@ function launch!(queue::HSAQueue, kernel::HSAKernelInstance, signal::HSASignal;
     @assert workgroup_size !== nothing "Must specify workgroup_size kwarg"
     @assert grid_size !== nothing "Must specify grid_size kwarg"
 
-    agent = queue.agent
-    queue = queue.queue
-    signal = signal.signal
-    args = kernel.args
+    _launch!(HSA.KernelDispatchPacket, queue, signal) do _packet
+        @set! _packet.setup = 3 << Int(HSA.KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS)
+        @set! _packet.workgroup_size_x = workgroup_size[1]
+        @set! _packet.workgroup_size_y = workgroup_size[2]
+        @set! _packet.workgroup_size_z = workgroup_size[3]
+        @set! _packet.grid_size_x = grid_size[1]
+        @set! _packet.grid_size_y = grid_size[2]
+        @set! _packet.grid_size_z = grid_size[3]
+        @set! _packet.completion_signal = signal.signal[]
+        @set! _packet.kernel_object = kernel.kernel_object
+        @set! _packet.kernarg_address = kernel.kernarg_address
+        @set! _packet.private_segment_size = kernel.private_segment_size
+        @set! _packet.group_segment_size = kernel.group_segment_size
+        _packet
+    end
+end
 
+function _launch!(f, T, queue::HSAQueue, signal::HSASignal)
     # Obtain the current queue write index and queue size
     _queue_size = Ref{UInt32}(0)
-    getinfo(agent.agent, HSA.AGENT_INFO_QUEUE_MAX_SIZE, _queue_size) |> check
+    getinfo(queue.agent.agent, HSA.AGENT_INFO_QUEUE_MAX_SIZE, _queue_size) |> check
     queue_size = _queue_size[]
-    write_index = HSA.queue_add_write_index_scacq_screl(queue[], UInt64(1))
+    write_index = HSA.queue_add_write_index_scacq_screl(queue.queue[], UInt64(1))
 
     # Yield until queue has space
     while true
-        read_index = HSA.queue_load_read_index_scacquire(queue[])
+        read_index = HSA.queue_load_read_index_scacquire(queue.queue[])
         if write_index < read_index + queue_size
             break
         end
@@ -108,41 +135,32 @@ function launch!(queue::HSAQueue, kernel::HSAKernelInstance, signal::HSASignal;
     end
 
     # TODO: Make this less ugly
-    dispatch_packet = Ref{HSA.KernelDispatchPacket}()
+    dispatch_packet = Ref{T}()
     ccall(:memset, Cvoid,
-        (Ptr{Cvoid}, Cint, Csize_t),
-        dispatch_packet, 0, sizeof(dispatch_packet[]))
+          (Ptr{Cvoid}, Cint, Csize_t),
+          dispatch_packet, 0, sizeof(T))
     _packet = dispatch_packet[]
-    @set! _packet.setup = 0
-    @set! _packet.setup |= 3 << Int(HSA.KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS)
-    @set! _packet.workgroup_size_x = workgroup_size[1]
-    @set! _packet.workgroup_size_y = workgroup_size[2]
-    @set! _packet.workgroup_size_z = workgroup_size[3]
-    @set! _packet.grid_size_x = grid_size[1]
-    @set! _packet.grid_size_y = grid_size[2]
-    @set! _packet.grid_size_z = grid_size[3]
-    @set! _packet.completion_signal = signal[]
-    @set! _packet.kernel_object = kernel.kernel_object[]
-    @set! _packet.kernarg_address = kernel.kernarg_address[]
-    @set! _packet.private_segment_size = kernel.private_segment_size[]
-    @set! _packet.group_segment_size = kernel.group_segment_size[]
-    dispatch_packet = Ref{HSA.KernelDispatchPacket}(_packet)
+    _packet = f(_packet)
+    dispatch_packet = Ref{T}(_packet)
 
-    _queue = unsafe_load(queue[])
+    _queue = unsafe_load(queue.queue[])
     queueMask = UInt32(_queue.size - 1)
     baseaddr_ptr = Ptr{HSA.KernelDispatchPacket}(_queue.base_address)
     baseaddr_ptr += sizeof(HSA.KernelDispatchPacket) * (write_index & queueMask)
-    dispatch_packet_ptr = Base.unsafe_convert(Ptr{HSA.KernelDispatchPacket}, dispatch_packet)
+    dispatch_packet_ptr = convert(Ptr{HSA.KernelDispatchPacket}, Base.unsafe_convert(Ptr{T}, dispatch_packet))
     unsafe_copyto!(baseaddr_ptr, dispatch_packet_ptr, 1)
+
+    packetheadertype(::Type{HSA.KernelDispatchPacket}) = HSA.PACKET_TYPE_KERNEL_DISPATCH
+    packetheadertype(::Type{HSA.BarrierAndPacket}) = HSA.PACKET_TYPE_BARRIER_AND
+    packetheadertype(::Type{HSA.BarrierOrPacket}) = HSA.PACKET_TYPE_BARRIER_OR
 
     # Atomically store the header
     header = Ref{UInt16}(0)
     header[] |= Int(HSA.FENCE_SCOPE_SYSTEM) << Int(HSA.PACKET_HEADER_ACQUIRE_FENCE_SCOPE)
     header[] |= Int(HSA.FENCE_SCOPE_SYSTEM) << Int(HSA.PACKET_HEADER_RELEASE_FENCE_SCOPE)
-    header[] |= Int(HSA.PACKET_TYPE_KERNEL_DISPATCH) << Int(HSA.PACKET_HEADER_TYPE)
+    header[] |= Int(packetheadertype(T)) << Int(HSA.PACKET_HEADER_TYPE)
     atomic_store_n!(Base.unsafe_convert(Ptr{UInt16}, baseaddr_ptr), header[])
 
     # Ring the doorbell to dispatch the kernel
     HSA.signal_store_relaxed(_queue.doorbell_signal, Int64(write_index))
 end
-

--- a/src/queue.jl
+++ b/src/queue.jl
@@ -44,4 +44,3 @@ function get_default_queue(agent::HSAAgent)
         end
     end
 end
-

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -30,6 +30,7 @@ end
 create_event(::typeof(HSA_rt), exe) = HSAStatusSignal(HSASignal(), exe.exe)
 function Base.wait(event::RuntimeEvent{HSAStatusSignal}; check_exceptions=true, cleanup=true, kwargs...)
     wait(event.event.signal; kwargs...) # wait for completion signal
+    unpreserve!(event) # allow kernel-associated objects to be freed
     exe = event.event.exe
     mod = EXE_TO_MODULE_MAP[exe].value
     agent = exe.agent

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -7,8 +7,9 @@ default_device(::typeof(HSA_rt)) = get_default_agent()
 struct RuntimeQueue{Q}
     queue::Q
 end
-default_queue(device) = RuntimeQueue(default_queue(RUNTIME[], device))
-default_queue(::typeof(HSA_rt), device) =
+default_queue() = default_queue(default_device())
+default_queue(device::RuntimeDevice) = RuntimeQueue(default_queue(RUNTIME[], device))
+default_queue(::typeof(HSA_rt), device::RuntimeDevice) =
     get_default_queue(device.device)
 get_device(queue::RuntimeQueue{HSAQueue}) = RuntimeDevice(queue.queue.agent)
 
@@ -112,3 +113,5 @@ function launch_kernel(::typeof(HSA_rt), queue, kern, event;
     launch!(queue.queue, kern.kernel, signal;
                        workgroup_size=groupsize, grid_size=gridsize)
 end
+barrier_and!(queue, events::Vector{<:RuntimeEvent}) = barrier_and!(queue, map(x->x.event,events))
+barrier_and!(queue, signals::Vector{HSAStatusSignal}) = barrier_and!(queue, map(x->x.signal,signals))

--- a/src/runtime.jl
+++ b/src/runtime.jl
@@ -116,3 +116,5 @@ function launch_kernel(::typeof(HSA_rt), queue, kern, event;
 end
 barrier_and!(queue, events::Vector{<:RuntimeEvent}) = barrier_and!(queue, map(x->x.event,events))
 barrier_and!(queue, signals::Vector{HSAStatusSignal}) = barrier_and!(queue, map(x->x.signal,signals))
+barrier_or!(queue, events::Vector{<:RuntimeEvent}) = barrier_or!(queue, map(x->x.event,events))
+barrier_or!(queue, signals::Vector{HSAStatusSignal}) = barrier_or!(queue, map(x->x.signal,signals))

--- a/src/signal.jl
+++ b/src/signal.jl
@@ -4,9 +4,9 @@ mutable struct HSASignal
     signal::Ref{Signal}
 end
 
-function HSASignal()
+function HSASignal(init::Integer=1)
     signal = HSASignal(Ref{Signal}())
-    HSA.signal_create(1, 0, C_NULL, signal.signal)
+    HSA.signal_create(Int64(init), 0, C_NULL, signal.signal)
     hsaref!()
     finalizer(signal) do signal
         HSA.signal_destroy(signal.signal[]) |> check
@@ -14,6 +14,8 @@ function HSASignal()
     end
     return signal
 end
+
+Adapt.adapt_structure(::Adaptor, sig::HSASignal) = sig.signal[]
 
 """
     Base.wait(signal::HSASignal; soft=true, minlat=0.01)

--- a/test/device/deps.jl
+++ b/test/device/deps.jl
@@ -1,0 +1,30 @@
+@testset "Kernel Dependencies" begin
+    function kernel(sig, waitval, A, val)
+        i = workitemIdx().x
+        AMDGPU.device_signal_wait(sig, waitval)
+        A[i] = val
+        return nothing
+    end
+
+    @testset "Barrier And" begin
+        RA = ROCArray(zeros(Float64, 1))
+        sig = AMDGPU.HSASignal(0)
+
+        ret1 = @roc kernel(sig, 5, RA, 1.0)
+
+        queue = AMDGPU.default_queue().queue
+        retb = barrier_and!(queue, [ret1])
+        ret2 = @roc kernel(sig, 0, RA, 2.0)
+
+        sleep(0.5)
+        @test Array(RA)[1] == 0.0
+        HSA.signal_store_relaxed(sig.signal[], 5)
+        wait(ret1)
+        @test Array(RA)[1] == 1.0
+        HSA.signal_store_relaxed(sig.signal[], 0)
+        sleep(0.5)
+        @test Array(RA)[1] == 2.0
+        wait(ret2)
+        wait(retb)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,7 @@ if AMDGPU.configured
             include("device/math.jl")
             include("device/execution_control.jl")
             include("device/exceptions.jl")
+            include("device/deps.jl")
         end
         @testset "ROCArray" begin
             @testset "GPUArrays test suite" begin


### PR DESCRIPTION
Allows us to block a queue until either:
- All kernels in a set complete
- Any kernel in a set complete

This will be necessary for KernelAbstractions integration.

Fixes #63 in the process (and also preserves kernel arguments)

Todo:
- [x] Extensive tests (0, 5, >5 kernel deps)
- [x] Barrier OR packet
- [x] Documentation