### PR TITLE
Remove annoying target-features for now

### DIFF
--- a/src/device/runtime.jl
+++ b/src/device/runtime.jl
@@ -108,6 +108,10 @@ function load_device_libs(dev_isa, ctx)
         name, ext = splitext(file)
         file_path = joinpath(device_libs_path, file)
         lib = parse(LLVM.Module, read(file_path), ctx)
+        for f in LLVM.functions(lib)
+            attrs = function_attributes(f)
+            delete!(attrs, StringAttribute("target-features"))
+        end
         push!(device_libs, lib)
     end
 


### PR DESCRIPTION
Removes these annoying (and probably harmless) warnings:

```
'+fp64-fp16-denormals' is not a recognized feature for this target (ignoring feature)
'-fp32-denormals' is not a recognized feature for this target (ignoring feature)
```