### PR TITLE
Add mark/wait synchronization system

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AMDGPU"
 uuid = "21141c5a-9bdb-4563-92ae-f87d6854732e"
 authors = ["Julian P Samaroo <jpsamaroo@jpsamaroo.me>"]
-version = "0.2.5"
+version = "0.2.6"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -48,6 +48,7 @@ if get(ENV, "AMDGPUNATIVE_OPENCL", "") != ""
 end
 =#
 include("runtime.jl")
+include("sync.jl")
 
 # Device sources must load _before_ the compiler infrastructure
 # because of generated functions.

--- a/src/array.jl
+++ b/src/array.jl
@@ -170,6 +170,7 @@ function Base.copyto!(dest::Array{T}, d_offset::Integer,
     amount == 0 && return dest
     @boundscheck checkbounds(dest, d_offset+amount-1)
     @boundscheck checkbounds(source, s_offset+amount-1)
+    wait!(source)
     Mem.download!(pointer(dest, d_offset),
                   Mem.view(source.buf, (s_offset-1)*sizeof(T)),
                   amount*sizeof(T))
@@ -181,6 +182,7 @@ function Base.copyto!(dest::ROCArray{T}, d_offset::Integer,
     amount == 0 && return dest
     @boundscheck checkbounds(dest, d_offset+amount-1)
     @boundscheck checkbounds(source, s_offset+amount-1)
+    wait!(dest)
     Mem.upload!(Mem.view(dest.buf, (d_offset-1)*sizeof(T)),
                 pointer(source, s_offset),
                 amount*sizeof(T))
@@ -192,6 +194,8 @@ function Base.copyto!(dest::ROCArray{T}, d_offset::Integer,
     amount == 0 && return dest
     @boundscheck checkbounds(dest, d_offset+amount-1)
     @boundscheck checkbounds(source, s_offset+amount-1)
+    wait!(dest)
+    wait!(source)
     Mem.transfer!(Mem.view(dest.buf, (d_offset-1)*sizeof(T)),
                   Mem.view(source.buf, (s_offset-1)*sizeof(T)),
                   amount*sizeof(T))

--- a/src/blas/rocBLAS.jl
+++ b/src/blas/rocBLAS.jl
@@ -1,6 +1,7 @@
 module rocBLAS
 
 using ..AMDGPU
+import AMDGPU: wait!, mark!
 
 using LinearAlgebra
 

--- a/src/device/gcn/hostcall.jl
+++ b/src/device/gcn/hostcall.jl
@@ -213,7 +213,7 @@ function HostCall(func, rettype, argtypes; return_task=false,
         while true
             try
                 try
-                    if !_hostwait(signal.signal[], hc.device_sentinel; maxlat=maxlat, timeout=timeout)
+                    if !_hostwait(signal, hc.device_sentinel; maxlat=maxlat, timeout=timeout)
                         error("Hostwait timeout")
                     end
                 catch err
@@ -288,7 +288,7 @@ function _hostwait(signal, sentinel; maxlat=DEFAULT_HOSTCALL_LATENCY, timeout=no
     @debug "Hostcall: Waiting on signal for sentinel: $sentinel"
     start_time = time_ns()
     while true
-        value = HSA.signal_load_scacquire(signal)
+        value = HSA.signal_load_scacquire(signal.signal[])
         if value == sentinel
             @debug "Hostcall: Signal triggered with sentinel: $sentinel"
             return true

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -190,9 +190,11 @@ macro roc(ex...)
                     local $kernel_args = map($rocconvert, ($(var_exprs...),))
                     local $kernel_tt = Tuple{map(Core.Typeof, $kernel_args)...}
                     local $kernel = $rocfunction($f, $kernel_tt; $(compiler_kwargs...))
+                    foreach($wait!, ($(var_exprs...),))
                     if $launch
                         local $signal = $create_event($kernel.mod.exe)
                         $kernel($kernel_args...; signal=$signal, $(call_kwargs...))
+                        foreach(x->$mark!(x, $signal), ($(var_exprs...),))
                         $signal
                     else
                         $kernel

--- a/src/fft/rocFFT.jl
+++ b/src/fft/rocFFT.jl
@@ -1,8 +1,7 @@
 module rocFFT
 
 using ..AMDGPU
-using ..AMDGPU: librocfft
-using ..HIP: hipStreamSynchronize
+using ..AMDGPU: librocfft, mark!, wait!
 
 using CEnum
 

--- a/src/rand/random.jl
+++ b/src/rand/random.jl
@@ -46,7 +46,9 @@ for (f,T) in ((:rocrand_generate, :UInt32), (:rocrand_generate_char,:Cuchar),
               (:rocrand_generate_uniform_double, :Float64), (:rocrand_generate_uniform_half, :Float16))
     @eval begin
         function Random.rand!(rng::RNG, A::ROCArray{$(T)})
+            wait!(A)
             $(f)(rng, A, length(A))
+            mark!(C_NULL, A)
             return A
         end
     end

--- a/src/rand/rocRAND.jl
+++ b/src/rand/rocRAND.jl
@@ -2,7 +2,7 @@ module rocRAND
 
 using ..HSA
 using ..AMDGPU
-using ..AMDGPU: librocrand
+using ..AMDGPU: librocrand, mark!, wait!
 
 using CEnum
 

--- a/src/signal.jl
+++ b/src/signal.jl
@@ -19,7 +19,7 @@ HSASignal(signal::HSA.Signal) = HSASignal(Ref(signal))
 Adapt.adapt_structure(::Adaptor, sig::HSASignal) = sig.signal[]
 
 """
-    Base.wait(signal::HSASignal; soft=true, minlat=0.01)
+    Base.wait(signal::HSASignal; soft=true, minlat=0.001)
 
 Waits on an `HSASignal` to decrease below 1. If `soft=true` (default), uses
 tasks to poll the signal, otherwise uses HSA's signal waiter. `minlat` sets
@@ -27,7 +27,7 @@ the minimum latency for the software waiter; lower values can decrease latency
 at the cost of increased polling load. `timeout`, if not `nothing`, sets the
 timeout for the signal, after which the call will error.
 """
-function Base.wait(signal::HSASignal; soft=true, minlat=0.01, timeout=nothing)
+function Base.wait(signal::HSASignal; soft=true, minlat=0.001, timeout=nothing)
     if soft
         start_time = time_ns()
         while true

--- a/src/sync.jl
+++ b/src/sync.jl
@@ -1,0 +1,25 @@
+"Tracks HSA signals and HIP streams to sync against."
+struct SyncState
+    signals::Vector{HSAStatusSignal}
+    streams::Vector{Ptr{Cvoid}}
+end
+SyncState() = SyncState(HSAStatusSignal[], Ptr{Cvoid}[])
+
+struct WaitAdaptor end
+struct MarkAdaptor{S}
+    s::S
+end
+
+function wait!(ss::SyncState)
+    # FIXME: Use barrier_and on dedicated queue
+    foreach(wait, ss.signals)
+    empty!(ss.signals)
+    foreach(HIP.hipStreamSynchronize, ss.streams)
+    empty!(ss.streams)
+    nothing
+end
+mark!(ss::SyncState, signal::HSAStatusSignal) = push!(ss.signals, signal)
+mark!(ss::SyncState, stream::Ptr{Cvoid}) = push!(ss.streams, stream)
+
+wait!(x) = adapt(WaitAdaptor(), x)
+mark!(x, s) = adapt(MarkAdaptor(s), x)

--- a/src/sync.jl
+++ b/src/sync.jl
@@ -16,6 +16,7 @@ function wait!(ss::SyncState)
     empty!(ss.signals)
     foreach(HIP.hipStreamSynchronize, ss.streams)
     empty!(ss.streams)
+    HIP.hipStreamSynchronize(C_NULL) # FIXME: This shouldn't be necessary
     nothing
 end
 mark!(ss::SyncState, signal::HSAStatusSignal) = push!(ss.signals, signal)

--- a/test/rocarray/blas.jl
+++ b/test/rocarray/blas.jl
@@ -33,7 +33,6 @@ end
             else
                 rocBLAS.rocblas_dscal(handle, 8, 5.0, RA, 1)
             end
-            HIP.hipDeviceSynchronize()
             _A = Array(RA)
             @test isapprox(A .* 5, _A)
         end
@@ -49,7 +48,6 @@ end
             else
                 rocBLAS.rocblas_dcopy(handle, 8, RA, 1, RB, 1)
             end
-            HIP.hipDeviceSynchronize()
             _A = Array(RA)
             _B = Array(RB)
             @test isapprox(A, _A)
@@ -69,7 +67,6 @@ end
             else
                 rocBLAS.rocblas_ddot(handle, 8, RA, 1, RB, 1, result)
             end
-            HIP.hipDeviceSynchronize()
             @test isapprox(LinearAlgebra.dot(A,B), result[])
         end
     end
@@ -85,7 +82,6 @@ end
             else
                 rocBLAS.rocblas_dswap(handle, 8, RA, 1, RB, 1)
             end
-            HIP.hipDeviceSynchronize()
             _A = Array(RA)
             _B = Array(RB)
             @test isapprox(A, _B)
@@ -112,7 +108,6 @@ end
             else
                 rocBLAS.rocblas_dgemv(handle, op, m, n, 5.0, RA, lda, Rx, incx, 0.0, Ry, incy)
             end
-            HIP.hipDeviceSynchronize()
             _A = Array(RA)
             _x = Array(Rx)
             _y = Array(Ry)

--- a/test/rocarray/fft.jl
+++ b/test/rocarray/fft.jl
@@ -20,17 +20,17 @@ function out_of_place(X::AbstractArray{T,N}) where {T <: Complex,N}
     p = plan_fft(d_X)
     Y = zeros(T, p.osz)
     d_Y = p * d_X;
-    Y = mycollect(d_Y)
+    Y = collect(d_Y)
     @test isapprox(Y, fftw_X, rtol = MYRTOL, atol = MYATOL)
 
     pinv = plan_ifft(d_Y)
     d_Z = pinv * d_Y
-    Z = mycollect(d_Z)
+    Z = collect(d_Z)
     @test isapprox(Z, X, rtol = MYRTOL, atol = MYATOL)
 
     pinv2 = inv(p)
     d_Z = pinv2 * d_Y
-    Z = mycollect(d_Z)
+    Z = collect(d_Z)
     @test isapprox(Z, X, rtol = MYRTOL, atol = MYATOL)
 end
 
@@ -40,12 +40,12 @@ function in_place(X::AbstractArray{T,N}) where {T <: Complex,N}
     copyto!(d_X, X)
     p = plan_fft!(d_X)
     p * d_X
-    Y = mycollect(d_X)
+    Y = collect(d_X)
     @test isapprox(Y, fftw_X, rtol = MYRTOL, atol = MYATOL)
 
     pinv = plan_ifft!(d_X)
     pinv * d_X
-    Z = mycollect(d_X)
+    Z = collect(d_X)
     @test isapprox(Z, X, rtol = MYRTOL, atol = MYATOL)
 end
 
@@ -55,12 +55,12 @@ function batched(X::AbstractArray{T,N},region) where {T <: Complex,N}
     copyto!(d_X, X)
     p = plan_fft!(d_X,region)
     p * d_X
-    Y = mycollect(d_X)
+    Y = collect(d_X)
     @test isapprox(Y, fftw_X, rtol = MYRTOL, atol = MYATOL)
 
     pinv = plan_ifft!(d_X,region)
     pinv * d_X
-    Z = mycollect(d_X)
+    Z = collect(d_X)
     @test isapprox(Z, X, rtol = MYRTOL, atol = MYATOL)
 end
 
@@ -154,22 +154,22 @@ function out_of_place(X::AbstractArray{T,N}) where {T <: Real,N}
     copyto!(d_X, X)
     p = plan_rfft(d_X)
     d_Y = p * d_X
-    Y = mycollect(d_Y)
+    Y = collect(d_Y)
     @test isapprox(Y, fftw_X, rtol = MYRTOL, atol = MYATOL)
 
     pinv = plan_irfft(d_Y,size(X,1))
     d_Z = pinv * d_Y
-    Z = mycollect(d_Z)
+    Z = collect(d_Z)
     @test isapprox(Z, X, rtol = MYRTOL, atol = MYATOL)
 
     pinv2 = inv(p)
     d_Z = pinv2 * d_Y
-    Z = mycollect(d_Z)
+    Z = collect(d_Z)
     @test isapprox(Z, X, rtol = MYRTOL, atol = MYATOL)
 
     pinv3 = inv(pinv)
     d_W = pinv3 * d_X
-    W = mycollect(d_W)
+    W = collect(d_W)
     @test isapprox(W, Y, rtol = MYRTOL, atol = MYATOL)
 end
 
@@ -179,12 +179,12 @@ function batched(X::AbstractArray{T,N},region) where {T <: Real,N}
     copyto!(d_X, X)
     p = plan_rfft(d_X,region)
     d_Y = p * d_X
-    Y = mycollect(d_Y)
+    Y = collect(d_Y)
     @test isapprox(Y, fftw_X, rtol = MYRTOL, atol = MYATOL)
 
     pinv = plan_irfft(d_Y,size(X,region[1]),region)
     d_Z = pinv * d_Y
-    Z = mycollect(d_Z)
+    Z = collect(d_Z)
     @test isapprox(Z, X, rtol = MYRTOL, atol = MYATOL)
 end
 

--- a/test/rocarray/nmf.jl
+++ b/test/rocarray/nmf.jl
@@ -1,0 +1,31 @@
+@testset "NMF" begin
+
+## A simple NMF implementation, which is useful to test mark/wait
+
+function step(X, W, H)
+    # H update
+    H = (H .* (W' * (X ./ (W * H)))
+         ./ (sum(W; dims=1))')
+    # W update
+    W = (W .* ((X ./ (W * H)) * (H'))
+         ./ (sum(H; dims=2)'))
+    # error estimate
+    X - W * H
+end
+
+for scale in (1:5:50)
+    ncol = 2001
+    nrow = 1002*scale
+    nfeatures = 12
+    X = rand(Float32, nrow, ncol)
+    W = rand(Float32, nrow, nfeatures)
+    H = rand(Float32, nfeatures, ncol)
+    cpu_res = step(X, W, H)
+    RX = ROCArray(X)
+    RW = ROCArray(W)
+    RH = ROCArray(H)
+    gpu_res = step(RX, RW, RH)
+    @test Array(gpu_res) ≈ cpu_res
+end
+
+end

--- a/test/rocarray/random.jl
+++ b/test/rocarray/random.jl
@@ -17,7 +17,7 @@ for (f,T) in ((rand!, Float16),
     fill!(A, T(0))
     f(A)
     if f !== rand_poisson!
-        @test !iszero(mycollect(A))
+        @test !iszero(collect(A))
     end
 end
 
@@ -49,7 +49,7 @@ for (f,T) in ((rand!,Int32),),
     A = ROCArray{T}(undef, d)
     fill!(A, T(0))
     f(AMDGPU.gpuarrays_rng(), A)
-    @test !iszero(mycollect(A))
+    @test !iszero(collect(A))
 end
 for (f,T) in ((AMDGPU.rand,Int32),),
     args in ((T, 2), (T, 2, 2), (T, (2, 2)), (T, 3), (T, 3, 3), (T, (3, 3)))
@@ -70,13 +70,13 @@ a = AMDGPU.rand(Float32, 1)
 AMDGPU.seed!(1)
 b = AMDGPU.rand(Float32, 1)
 # fixme: uncomment once mapreduce works
-@test iszero(mycollect(a) - mycollect(b))
+@test iszero(collect(a) - collect(b))
 #@test all(a .== b)
 ## gpuarrays fallback
 AMDGPU.seed!(1)
 a = AMDGPU.rand(Int32, 1)
 AMDGPU.seed!(1)
 b = AMDGPU.rand(Int32, 1)
-@test iszero(mycollect(a) - mycollect(b))
+@test iszero(collect(a) - collect(b))
 #@test all(a .== b)
 end # testset

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,6 +83,7 @@ if AMDGPU.configured
                 isdefined(AMDGPU, :rocBLAS) ? include("rocarray/blas.jl") : @test_skip "rocBLAS"
                 isdefined(AMDGPU, :rocFFT) ? include("rocarray/fft.jl") : @test_skip "rocFFT"
                 isdefined(AMDGPU, :rocRAND) ? include("rocarray/random.jl") : @test_skip "rocRAND"
+                include("rocarray/nmf.jl")
             end
         end
         @testset "External Packages" begin

--- a/test/util.jl
+++ b/test/util.jl
@@ -38,10 +38,3 @@ macro grab_output(ex, io=stdout)
         end
     end
 end
-
-#FIXME: remove once we have a proper sync implementation
-function mycollect(x::ROCArray{T,N}) where {T,N}
-    # need to synchronize otherwise some library functions are not executed
-    HIP.hipDeviceSynchronize()
-    collect(x)
-end


### PR DESCRIPTION
In CUDA, everything uses streams natively, and streams are in-order by default, so things "just work" when launching multiple kernels and using external libraries. With AMDGPU, we use non-blocking queues, however HIP-based libraries use their own stream-like system that uses their own blocking queues. We thus need some way to ensure ordering of operations.

This PR implements a system called "mark/wait", where performing an operation on/with a `ROCArray` "marks" the array as in-use, with a signal or stream becoming associated with that array. When another operation is performed on the array, all signals and streams that were marked on this array are waited on or synchronized, and then the operation will be performed. Notably, this allows us to mix kernel launches with HIP stream-based operations without the user doing any explicit waiting or synchronization.

Should fix #103 

Todo:

- [x] Support rocFFT
- [x] Support rocRAND
- [x] Add some rigorous tests
- [x] Remove explicit device sync in tests
- [x] Make `copyto!` mark/wait
- [ ] Add option to disable automatic mark/wait of specific arrays
- [ ] (Optional) Use HIP events to do fine-grained sync