### PR TITLE
Fix memory leak

### DIFF
--- a/src/device/runtime.jl
+++ b/src/device/runtime.jl
@@ -124,6 +124,7 @@ function link_device_libs!(mod::LLVM.Module, dev_isa::String, undefined_fns)
     end
 
     GPUCompiler.link_library!(mod, libs)
+    dispose.(libs)
 end
 
 function link_oclc_defaults!(mod::LLVM.Module, dev_isa::String, ctx; finite_only=false,

--- a/test/device/launch.jl
+++ b/test/device/launch.jl
@@ -25,6 +25,11 @@
     @test_throws ArgumentError eval(:(@roc groupsize=0 $kernel()))
     eval(:(@roc groupsize=1024 $kernel()))
     @test_throws ArgumentError eval(:(@roc groupsize=1025 $kernel()))
+
+    # No-launch
+    @test eval(:(@roc launch=true $kernel())) isa HSASignal
+    @test eval(:(@roc launch=false $kernel())) isa AMDGPU.HostKernel
+    @test_throws Exception eval(:(@roc launch=1 $kernel())) # TODO: ArgumentError
 end
 
 @testset "No-argument kernel" begin

--- a/test/device/launch.jl
+++ b/test/device/launch.jl
@@ -27,7 +27,7 @@
     @test_throws ArgumentError eval(:(@roc groupsize=1025 $kernel()))
 
     # No-launch
-    @test eval(:(@roc launch=true $kernel())) isa HSASignal
+    @test eval(:(@roc launch=true $kernel())) isa AMDGPU.RuntimeEvent
     @test eval(:(@roc launch=false $kernel())) isa AMDGPU.HostKernel
     @test_throws Exception eval(:(@roc launch=1 $kernel())) # TODO: ArgumentError
 end


### PR DESCRIPTION
We weren't `dispose`-ing our device-libs bitcode modules, so they just accumulated in memory, leading to >32GB memory allocated to run the tests. This brings it down to around 3GB (and further changes should be able to bring it down slightly further).

While troubleshooting, I also added `@roc launch=false ...` for returning the kernel object, which should be useful for more advanced users in some cases.