### PR TITLE
fixes for delayed codegeneration

### DIFF
--- a/src/device/runtime.jl
+++ b/src/device/runtime.jl
@@ -147,6 +147,7 @@ function link_oclc_defaults!(mod::LLVM.Module, dev_isa::String, ctx; finite_only
         initializer!(gv, init)
         unnamed_addr!(gv, true)
         constant!(gv, true)
+        linkage!(gv, LLVM.API.LLVMWeakAnyLinkage)
     end
 
     link!(mod, lib)

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -60,8 +60,9 @@ function emit_exception_user!(mod::LLVM.Module)
     @assert haskey(LLVM.functions(mod), "__fake_global_exception_flag_user")
 end
 function delete_exception_user!(mod::LLVM.Module)
-    if haskey(LLVM.functions(mod), "__fake_global_exception_flag_user")
-        delete!(mod, LLVM.functions(mod)["__fake_global_exception_flag_user"])
+    fns = LLVM.functions(mod)
+    if haskey(fns, "__fake_global_exception_flag_user")
+        unsafe_delete!(mod, fns["__fake_global_exception_flag_user"])
     end
     @assert !haskey(LLVM.functions(mod), "__fake_global_exception_flag_user")
 end


### PR DESCRIPTION
Together with https://github.com/wsmoses/Enzyme.jl/pull/54 allows for using Enzyme.jl with AMGPU.jl

Still leaves us with:

```
warning: Linking two modules of different data layouts: '' is 'e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7-ni:10:11:12:13' whereas 'text' is 'e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128-ni:10:11:12:13'

warning: Linking two modules of different target triples: ' is 'amdgcn-amd-amdhsa' whereas 'text' is 'x86_64-pc-linux-gnu'

warning: Linking two modules of different data layouts: 'text' is 'e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128-ni:10:11:12:13' whereas 'text' is 'e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-ni:7-ni:10:11:12:13'

warning: Linking two modules of different target triples: text' is 'x86_64-pc-linux-gnu' whereas 'text' is 'amdgcn-amd-amdhsa'
```
