### PR TITLE
Implement exponential backoff signal wait

### DIFF
--- a/src/signal.jl
+++ b/src/signal.jl
@@ -21,14 +21,21 @@ Adapt.adapt_structure(::Adaptor, sig::HSASignal) = sig.signal[]
 """
     Base.wait(signal::HSASignal; soft=true, minlat=0.001)
 
-Waits on an `HSASignal` to decrease below 1. If `soft=true` (default), uses
-tasks to poll the signal, otherwise uses HSA's signal waiter. `minlat` sets
-the minimum latency for the software waiter; lower values can decrease latency
-at the cost of increased polling load. `timeout`, if not `nothing`, sets the
-timeout for the signal, after which the call will error.
+Waits on an `HSASignal` to decrease below 1.
+
+Options:
+- `soft::Bool`: Whether to use tasks to poll the signal, or to use HSA's
+  (blocking) signal waiter. Note that the HSA waiter can block forward progress.
+- `minlat::Real`: Minimum initial latency for the software waiter; lower values
+  can decrease latency at the cost of increased polling load
+- `timeout::Union{Real,Nothing}`: If not `nothing`, sets the timeout for the
+  signal, after which the call will error.
+- `backoff::Function`: Selects the backoff algorithm to use (default is clamped exponential)
 """
-function Base.wait(signal::HSASignal; soft=true, minlat=0.001, timeout=nothing)
+function Base.wait(signal::HSASignal; soft=true, minlat=0.001, timeout=nothing, backoff=WaitExpClamped(0.1,1))
     if soft
+        ctr = 1
+        waitlat = minlat
         start_time = time_ns()
         while true
             value = HSA.signal_load_scacquire(signal.signal[])
@@ -42,6 +49,8 @@ function Base.wait(signal::HSASignal; soft=true, minlat=0.001, timeout=nothing)
                     error("Timeout while waiting on signal")
                 end
             end
+            ctr += 1
+            waitlat = backoff(ctr, minlat)
             sleep(minlat)
         end
     else
@@ -51,5 +60,13 @@ function Base.wait(signal::HSASignal; soft=true, minlat=0.001, timeout=nothing)
                                 HSA.WAIT_STATE_BLOCKED)
     end
 end
-
 Base.wait(signal::HSA.Signal; kwargs...) = wait(HSASignal(signal); kwargs...)
+
+struct WaitLinear end
+(::WaitLinear)(ctr, minlat) = minlat*x
+struct WaitExpClamped
+    scale::Float64
+    ceil::Float64
+end
+(w::WaitExpClamped)(ctr, minlat) = Base.min(Base.exp(ctr*w.scale)*minlat,w.ceil)
+# TODO: WaitSigmoidal


### PR DESCRIPTION
Changes signal waiting on the host to use a clamped exponential backoff, with the option for users to define their own backoff implementations.

Closes #84 

Todo:
- [ ] Test that exponential backoff works better for some cases than constant or linear backoff