### PR TITLE
run GPUArrays test-suite

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,21 +63,7 @@ if AMDGPU.configured
             include("rocarray/base.jl")
             include("rocarray/broadcast.jl")
             @testset "GPUArrays test suite" begin
-                #TestSuite.test(ROCArray)
-                for name in keys(TestSuite.tests)
-                    occursin("broadcast", name) && continue
-                    name == "indexing" && continue
-                    name == "linear algebra" && continue
-                    name == "iterator constructors" && continue
-                    name == "uniformscaling" && continue
-                    name == "fft" && continue
-                    name == "random" && continue
-                    name == "base" && continue
-                    name == "mapreduce derivatives" && continue
-                    @testset "$name" begin
-                        TestSuite.tests[name](ROCArray)
-                    end
-                end
+                TestSuite.test(ROCArray)
             end
             @testset "ROCm External Libraries" begin
                 if parse(Bool, get(ENV, "CI", "false"))


### PR DESCRIPTION
Only broken test seem to be:

```
reinterpret: Error During Test at /home/vchuravy/.julia/packages/GPUArrays/8dzSJ/test/testsuite/base.jl:140
  Test threw exception
  Expression: Array(Af0) == af0
  StackOverflowError:
  Stacktrace:
   [1] Array
     @ ./boot.jl:448 [inlined]
   [2] Array
     @ ./boot.jl:457 [inlined]
   [3] similar
     @ ./abstractarray.jl:750 [inlined]
   [4] similar
     @ ./abstractarray.jl:741 [inlined]
   [5] copyto!(dest::Vector{Float32}, dstart::Int64, src::Base.ReinterpretArray{Float32, 1, ComplexF32, ROCVector{ComplexF32}, false}, sstart::Int64, n::Int64)
     @ GPUArrays ~/.julia/packages/GPUArrays/8dzSJ/src/host/abstractarray.jl:128
   [6] copyto!(dest::Vector{Float32}, dstart::Int64, src::Base.ReinterpretArray{Float32, 1, ComplexF32, ROCVector{ComplexF32}, false}, sstart::Int64, n::Int64) (repeats 79980 times)
     @ GPUArrays ~/.julia/packages/GPUArrays/8dzSJ/src/host/abstractarray.jl:129
reinterpret: Error During Test at /home/vchuravy/.julia/packages/GPUArrays/8dzSJ/test/testsuite/base.jl:148
  Test threw exception
  Expression: Array(Af0) == af0
  StackOverflowError:
  Stacktrace:
   [1] Array
     @ ./boot.jl:448 [inlined]
   [2] Array
     @ ./boot.jl:457 [inlined]
   [3] similar
     @ ./abstractarray.jl:750 [inlined]
   [4] similar
     @ ./reshapedarray.jl:207 [inlined]
   [5] similar
     @ ./abstractarray.jl:741 [inlined]
   [6] copyto!(dest::Vector{Float32}, dstart::Int64, src::Base.ReshapedArray{Float32, 2, Base.ReinterpretArray{Float32, 1, ComplexF32, ROCVector{ComplexF32}, false}, Tuple{}}, sstart::Int64, n::Int64)
     @ GPUArrays ~/.julia/packages/GPUArrays/8dzSJ/src/host/abstractarray.jl:128
   [7] copyto!(dest::Vector{Float32}, dstart::Int64, src::Base.ReshapedArray{Float32, 2, Base.ReinterpretArray{Float32, 1, ComplexF32, ROCVector{ComplexF32}, false}, Tuple{}}, sstart::Int64, n::Int64) (repeats 79980 times)
     @ GPUArrays ~/.julia/packages/GPUArrays/8dzSJ/src/host/abstractarray.jl:129
```
