### PR TITLE
Search for device libs relative to LD_LIBRARY_PATH

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -106,6 +106,25 @@ function find_ld_lld()
     return ""
 end
 
+function find_device_libs()
+    if isdir("/opt/rocm/amdgcn/bitcode")
+        return "/opt/rocm/amdgcn/bitcode"
+    end
+    paths = split(get(ENV, "LD_LIBRARY_PATH", ""), ":")
+    paths = filter(path->path != "", paths)
+    paths = map(Base.Filesystem.abspath, paths)
+    for path in paths
+        bitcode_path = joinpath(path, "../amdgcn/bitcode/")
+        if ispath(bitcode_path)
+            if isfile(joinpath(bitcode_path, "ocml.bc")) ||
+               isfile(joinpath(bitcode_path, "ocml.amdgcn.bc"))
+               return bitcode_path
+            end
+        end
+    end
+    return nothing
+end
+
 function find_roc_library(name::String)
     lib = Libdl.find_library(Symbol(name))
     lib == "" && return nothing
@@ -273,12 +292,15 @@ function main()
         device_libs_downloaded = false
     else
         #include("download_device_libs.jl")
-        device_libs_path = "/opt/rocm/amdgcn/bitcode"
+        device_libs_path = find_device_libs()
         device_libs_downloaded = true
+        if device_libs_path === nothing
+            config[:device_libs_build_reason] = "Couldn't find bitcode files in /opt/rocm or relative to entries in LD_LIBRARY_PATH"
+        end
     end
     config[:device_libs_path] = device_libs_path
     config[:device_libs_downloaded] = device_libs_downloaded
-    config[:device_libs_configured] = true
+    config[:device_libs_configured] = device_libs_path !== nothing
 
     ### Find external HIP-based libraries
     for name in ("rocblas", "rocsparse", "rocalution", "rocfft", "rocrand", "MIOpen")

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -107,9 +107,18 @@ function find_ld_lld()
 end
 
 function find_device_libs()
+    # The canonical location
     if isdir("/opt/rocm/amdgcn/bitcode")
         return "/opt/rocm/amdgcn/bitcode"
     end
+
+    # Might be set by tools like Spack or the user
+    hip_devlibs_path = get(ENV, "HIP_DEVICE_LIB_PATH", "")
+    hip_devlibs_path !== "" && return hip_devlibs_path
+    devlibs_path = get(ENV, "DEVICE_LIB_PATH", "")
+    devlibs_path !== "" && return devlibs_path
+
+    # Search relative to LD_LIBRARY_PATH entries
     paths = split(get(ENV, "LD_LIBRARY_PATH", ""), ":")
     paths = filter(path->path != "", paths)
     paths = map(Base.Filesystem.abspath, paths)


### PR DESCRIPTION
@luraess reported that AMDGPU doesn't find bitcode files on systems using Spack-provided ROCm installs. This PR works around this (and similar setups) by searching `../amdgcn/bitcode/ocml.*` relative to all entries in `LD_LIBRARY_PATH`, which Spack and friends usually will set to point to provided libraries.