### PR TITLE
Function overrides lead to undefined functions in KA

### DIFF
--- a/src/device/gcn/math.jl
+++ b/src/device/gcn/math.jl
@@ -99,9 +99,6 @@ end
 @device_override Base.sin(x::Float16) = sin(Float32(x))
 
 @device_override Base.hypot(x::T, y::T) where T <: Integer = hypot(float(x), float(y))
-@device_override Base.abs(z::Complex) = hypot(real(z), imag(z))
-# FIXME
-abs(i::Integer) = Base.abs(i)
 
 # Non-matching types
 @device_override @inline function Base.:(^)(x::T, y::S) where {T<:Union{Float16, Float32,Float64}, S<:Union{Int64,UInt64}}


### PR DESCRIPTION
The function overrides of `sqrt` and `abs` make only these methods available in the namespace of `AMDGPU` from `Kernelabstractions.jl`. This leads to `sqrt(::Float64)` for example missing in KA.

I assume other function overrides lead to the same behavior.