### PR TITLE
utils: Add functional query

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,6 +26,7 @@ steps:
       queue: "juliagpu"
       rocm: "*"
     if: build.message !~ /\[skip tests\]/
+    soft_fail: true
     timeout_in_minutes: 180
     env:
       JULIA_AMDGPU_CORE_MUST_LOAD: "1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,7 +26,7 @@ steps:
       queue: "juliagpu"
       rocm: "*"
     if: build.message !~ /\[skip tests\]/
-    timeout_in_minutes: 120
+    timeout_in_minutes: 180
     env:
       JULIA_AMDGPU_CORE_MUST_LOAD: "1"
       JULIA_AMDGPU_HIP_MUST_LOAD: "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AMDGPU"
 uuid = "21141c5a-9bdb-4563-92ae-f87d6854732e"
 authors = ["Julian P Samaroo <jpsamaroo@jpsamaroo.me>", "Valentin Churavy <v.churavy@gmail.com>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,55 +1,55 @@
 function versioninfo(io::IO=stdout)
-    println("HSA Runtime ($(hsa_configured ? "ready" : "MISSING"))")
-    if hsa_configured
+    println("HSA Runtime ($(functional(:hsa) ? "ready" : "MISSING"))")
+    if functional(:hsa)
         println("- Path: $libhsaruntime_path")
         println("- Version: $(libhsaruntime_version)")
-        println("- Initialized: $(repr(HSA_REFCOUNT[] > 0))")
+        #println("- Initialized: $(repr(HSA_REFCOUNT[] > 0))")
     end
-    println("ld.lld ($(lld_configured ? "ready" : "MISSING"))")
-    if lld_configured
+    println("ld.lld ($(functional(:lld) ? "ready" : "MISSING"))")
+    if functional(:lld)
         println("- Path: $ld_lld_path")
     end
-    println("ROCm-Device-Libs ($(device_libs_configured ? "ready" : "MISSING"))")
-    if device_libs_configured
+    println("ROCm-Device-Libs ($(functional(:device_libs) ? "ready" : "MISSING"))")
+    if functional(:device_libs)
         println("- Path: $device_libs_path")
         # TODO: println("- Version: $(device_libs_version)")
         println("- Downloaded: $(repr(device_libs_downloaded))")
     end
-    println("HIP Runtime ($(hip_configured ? "ready" : "MISSING"))")
-    if hip_configured
+    println("HIP Runtime ($(functional(:hip) ? "ready" : "MISSING"))")
+    if functional(:hip)
         println("- Path: $libhip_path")
         # TODO: println("- Version: $(libhip_version)")
     end
-    println("rocBLAS ($(librocblas !== nothing ? "ready" : "MISSING"))")
-    if librocblas !== nothing
+    println("rocBLAS ($(functional(:rocblas) ? "ready" : "MISSING"))")
+    if functional(:rocblas)
         println("- Path: $(Libdl.dlpath(librocblas))")
     end
-    println("rocSOLVER ($(librocsolver !== nothing ? "ready" : "MISSING"))")
-    if librocsolver !== nothing
+    println("rocSOLVER ($(functional(:rocsolver) ? "ready" : "MISSING"))")
+    if functional(:rocsolver)
         println("- Path: $(Libdl.dlpath(librocsolver))")
     end
-    println("rocFFT ($(librocfft !== nothing ? "ready" : "MISSING"))")
-    if librocfft !== nothing
-        println("- Path: $(Libdl.dlpath(librocfft))")
-    end
-    println("rocRAND ($(librocrand !== nothing ? "ready" : "MISSING"))")
-    if librocrand !== nothing
-        println("- Path: $(Libdl.dlpath(librocrand))")
-    end
-    println("rocSPARSE ($(librocsparse !== nothing ? "ready" : "MISSING"))")
-    if librocsparse !== nothing
-        println("- Path: $(Libdl.dlpath(librocsparse))")
-    end
-    println("rocALUTION ($(librocalution !== nothing ? "ready" : "MISSING"))")
-    if librocalution !== nothing
+    println("rocALUTION ($(functional(:rocalution) ? "ready" : "MISSING"))")
+    if functional(:rocalution)
         println("- Path: $(Libdl.dlpath(librocalution))")
     end
-    println("MIOpen ($(libmiopen !== nothing ? "ready" : "MISSING"))")
-    if libmiopen !== nothing
+    println("rocSPARSE ($(functional(:rocsparse) ? "ready" : "MISSING"))")
+    if functional(:rocsparse)
+        println("- Path: $(Libdl.dlpath(librocsparse))")
+    end
+    println("rocRAND ($(functional(:rocrand) ? "ready" : "MISSING"))")
+    if functional(:rocrand)
+        println("- Path: $(Libdl.dlpath(librocrand))")
+    end
+    println("rocFFT ($(functional(:rocfft) ? "ready" : "MISSING"))")
+    if functional(:rocfft)
+        println("- Path: $(Libdl.dlpath(librocfft))")
+    end
+    println("MIOpen ($(functional(:miopen) ? "ready" : "MISSING"))")
+    if functional(:miopen)
         println("- Path: $(Libdl.dlpath(libmiopen))")
     end
 
-    if hsa_configured && HSA_REFCOUNT[] > 0
+    if functional(:hsa)
         println("HSA Agents ($(length(agents()))):")
         for agent in agents()
             println("- ", repr(agent))
@@ -57,10 +57,106 @@ function versioninfo(io::IO=stdout)
     end
 end
 
+"""
+    functional() -> Bool
+
+Returns `true` if AMDGPU is nominally functional; "functional" currently means
+that HSA, HIP, lld, and device libraries are available (although it does not
+imply that usages of these components will be successful).
+
+Packages may use the result of this query to determine whether it is safe to:
+- Use AMDGPU to compile code
+- Query devices, queues, and other runtime state
+- Launch compiled kernels on a device
+- Wait on launched kernels to complete
+- Utilize external ROCm libraries (rocBLAS et. al)
+
+If the full compilation and launch pipeline is desired, then this query should
+be sufficient for most packages and applications. This query combines
+sub-queries of multiple components; a failing sub-query will propagate to a
+`false` return value. For more fine-grained queries, use `functional(::Symbol)`.
+
+This query should never throw.
+"""
+function functional()
+    return functional(:hsa) &&
+           functional(:hip) &&
+           functional(:lld) &&
+           functional(:device_libs)
+end
+"""
+    functional(component::Symbol) -> Bool
+
+Returns `true` if the ROCm component `component` is configured and expected to
+function correctly. Available `component` values are:
+
+- `:hsa`         - Queries ROCR library availability, initialization status, and GPU device availability
+- `:hip`         - Queries HIP library availability
+- `:lld`         - Queries `ld.lld` tool availability
+- `:device_libs` - Queries ROCm device libraries availability
+- `:rocblas`     - Queries rocBLAS library availability
+- `:rocsolver`   - Queries rocSOLVER library availability
+- `:rocalution`  - Queries rocALUTION library availability
+- `:rocsparse`   - Queries rocSPARSE library availability
+- `:rocrand`     - Queries rocRAND library availability
+- `:rocfft`      - Queries rocFFT library availability
+- `:miopen`      - Queries MIOpen library availability
+- `:all`         - Queries all above components
+
+This query should never throw for valid `component` values.
+"""
+function functional(component::Symbol)
+    if component == :hsa
+        return hsa_configured &&
+               HSA_REFCOUNT[] > 0 &&
+               length(get_agents()) > 0
+    elseif component == :hip
+        return hip_configured
+    elseif component == :lld
+        return lld_configured
+    elseif component == :device_libs
+        return device_libs_configured
+    elseif component == :rocblas
+        return librocblas !== nothing
+    elseif component == :rocsolver
+        return librocsolver !== nothing
+    elseif component == :rocalution
+        return librocalution !== nothing
+    elseif component == :rocsparse
+        return librocsparse !== nothing
+    elseif component == :rocrand
+        return librocrand !== nothing
+    elseif component == :rocfft
+        return librocfft !== nothing
+    elseif component == :miopen
+        return libmiopen !== nothing
+    elseif component == :all
+        for component in (:hsa, :hip, :lld, :device_libs, :rocblas, :rocsolver,
+                          :rocalution, :rocsparse, :rocrand, :rocfft, :miopen)
+            functional(component) || return false
+        end
+        return true
+    else
+        throw(ArgumentError("Unknown component $(repr(component))"))
+    end
+end
+
 function has_rocm_gpu()
-    if !AMDGPU.hsa_configured
+    if !functional(:hsa)
         return false
     else
-        return length(AMDGPU.get_agents(:gpu)) > 0
+        return length(get_agents(:gpu)) > 0
     end
+end
+
+function print_build_diagnostics()
+    println("Diagnostics:")
+    println("-- deps/build.log")
+    println(String(read(joinpath(@__DIR__, "..", "deps", "build.log"))))
+    println("-- deps/ext.jl")
+    println(String(read(joinpath(@__DIR__, "..", "deps", "ext.jl"))))
+    println("-- permissions")
+    run(`ls -lah /dev/kfd`)
+    run(`ls -lah /dev/dri`)
+    run(`id`)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using AMDGPU
 using AMDGPU: HSA, AS
-if AMDGPU.hip_configured
-using AMDGPU: HIP
+if AMDGPU.functional(:hip)
+    using AMDGPU: HIP
 end
 using GPUCompiler
 using LinearAlgebra
@@ -26,7 +26,7 @@ testf(f, xs...; kwargs...) = TestSuite.compare(f, ROCArray, xs...; kwargs...)
 import AMDGPU: allowscalar, @allowscalar
 allowscalar(false)
 
-@info "Testing using device $(get_default_agent())"
+CI = parse(Bool, get(ENV, "CI", "false"))
 
 @testset "AMDGPU" begin
 
@@ -34,75 +34,74 @@ allowscalar(false)
 include("pointer.jl")
 end
 
-if AMDGPU.configured
-    @test length(get_agents()) > 0
-    if length(get_agents()) > 0
-        @testset "HSA" begin
-            include("hsa/error.jl")
-            include("hsa/agent.jl")
-            include("hsa/memory.jl")
-            include("hsa/utils.jl")
+@test AMDGPU.functional()
+@assert AMDGPU.functional()
+
+@test length(get_agents()) > 0
+
+@info "Testing using device $(get_default_agent())"
+
+@testset "HSA" begin
+    include("hsa/error.jl")
+    include("hsa/agent.jl")
+    include("hsa/memory.jl")
+    include("hsa/utils.jl")
+end
+@testset "Codegen" begin
+    include("codegen/synchronization.jl")
+    include("codegen/trap.jl")
+end
+@testset "Device Functions" begin
+    include("device/launch.jl")
+    include("device/vadd.jl")
+    include("device/memory.jl")
+    include("device/indexing.jl")
+    include("device/hostcall.jl")
+    include("device/output.jl")
+    include("device/globals.jl")
+    include("device/math.jl")
+    include("device/wavefront.jl")
+    include("device/execution_control.jl")
+    include("device/exceptions.jl")
+    include("device/deps.jl")
+    include("device/queries.jl")
+end
+@testset "ROCArray" begin
+    include("rocarray/base.jl")
+    include("rocarray/broadcast.jl")
+    @testset "GPUArrays test suite" begin
+        TestSuite.test(ROCArray)
+    end
+    @testset "ROCm External Libraries" begin
+        if CI
+            @test AMDGPU.functional(:rocblas)
+            @test AMDGPU.functional(:rocrand)
+            @test AMDGPU.functional(:rocfft)
         end
-        @testset "Codegen" begin
-            include("codegen/synchronization.jl")
-            include("codegen/trap.jl")
+        if AMDGPU.functional(:rocblas)
+            include("rocarray/blas.jl")
+        else
+            @test_skip "rocBLAS"
         end
-        @testset "Device Functions" begin
-            include("device/launch.jl")
-            include("device/vadd.jl")
-            include("device/memory.jl")
-            include("device/indexing.jl")
-            include("device/hostcall.jl")
-            include("device/output.jl")
-            include("device/globals.jl")
-            include("device/math.jl")
-            include("device/wavefront.jl")
-            include("device/execution_control.jl")
-            include("device/exceptions.jl")
-            include("device/deps.jl")
-            include("device/queries.jl")
+        if AMDGPU.functional(:rocrand)
+            include("rocarray/random.jl")
+        else
+            @test_skip "rocRAND"
         end
-        @testset "ROCArray" begin
-            include("rocarray/base.jl")
-            include("rocarray/broadcast.jl")
-            @testset "GPUArrays test suite" begin
-                TestSuite.test(ROCArray)
-            end
-            @testset "ROCm External Libraries" begin
-                CI = parse(Bool, get(ENV, "CI", "false"))
-                if CI
-                    @test isdefined(AMDGPU, :rocBLAS)
-                    @test isdefined(AMDGPU, :rocFFT)
-                    @test isdefined(AMDGPU, :rocRAND)
-                end
-                if isdefined(AMDGPU, :rocBLAS)
-                    include("rocarray/blas.jl")
-                else
-                    @test_skip "rocBLAS"
-                end
-                if isdefined(AMDGPU, :rocFFT)
-                    include("rocarray/fft.jl")
-                else
-                    @test_skip "rocFFT"
-                end
-                if isdefined(AMDGPU, :rocRAND)
-                    include("rocarray/random.jl")
-                else
-                    @test_skip "rocRAND"
-                end
-                if isdefined(AMDGPU, :rocBLAS)
-                    include("rocarray/nmf.jl")
-                else
-                    @test_skip "NMF"
-                end
-            end
+        if AMDGPU.functional(:rocfft)
+            include("rocarray/fft.jl")
+        else
+            @test_skip "rocFFT"
         end
-        @testset "External Packages" begin
-            include("external/forwarddiff.jl")
+        if AMDGPU.functional(:rocblas)
+            include("rocarray/nmf.jl")
+        else
+            @test_skip "NMF"
         end
     end
-else
-    @warn("AMDGPU.jl has not been configured; skipping on-device tests.")
+end
+@testset "External Packages" begin
+    include("external/forwarddiff.jl")
 end
 
 end


### PR DESCRIPTION
Implements `AMDGPU.functional()` and `AMDGPU.functional(::Symbol)`, which are now the de-facto methods for querying the overall functionality of AMDGPU, and of individual ROCm components, respectively.

@omlins

Closes #198