### PR TITLE
HSAAgent: Add device()/device!() API

### DIFF
--- a/src/agent.jl
+++ b/src/agent.jl
@@ -20,6 +20,8 @@ mutable struct HSAAgent
     end
 end
 
+Base.:(==)(agent1::HSAAgent, agent2::HSAAgent) = agent1.agent == agent2.agent
+
 const DEFAULT_AGENT = Ref{HSAAgent}()
 const AGENTS = IdDict{UInt64, HSAAgent}() # Map from agent handles to HSAAgent structs
 
@@ -119,13 +121,12 @@ function get_default_agent()
     end
     DEFAULT_AGENT[]
 end
-function set_default_agent!(kind::Symbol)
-    DEFAULT_AGENT[] = first(get_agents(kind))
-end
-set_default_agent!() = set_default_agent!(:gpu)
 function set_default_agent!(agent::HSAAgent)
     DEFAULT_AGENT[] = agent
 end
+
+device(kind::Symbol=:gpu) = something(findfirst(a->a==get_default_agent(), get_agents(kind)))
+device!(idx::Integer, kind::Symbol=:gpu) = set_default_agent!(get_agents(kind)[idx])
 
 function get_name(agent::HSAAgent)
     #len = Ref(0)

--- a/test/hsa/agent.jl
+++ b/test/hsa/agent.jl
@@ -2,14 +2,30 @@
     @testset "Default selection" begin
         agent = get_default_agent()
         @test agent !== nothing
-
-        AMDGPU.set_default_agent!(:gpu)
-        agent = get_default_agent()
         @test AMDGPU.device_type(agent) == :gpu
 
         agent_name = AMDGPU.get_name(agent)
         @test length(agent_name) > 0
         @test !occursin('\0', agent_name)
+
+        if length(AMDGPU.get_agents()) > 1
+            @testset "Multi-GPU" begin
+                init_agent = AMDGPU.get_default_agent()
+                init_dev = AMDGPU.device()
+                @test init_dev == 1
+                AMDGPU.device!(2)
+                @test AMDGPU.device() == 2
+                @test AMDGPU.get_default_agent() != init_agent
+                AMDGPU.device!(1)
+                @test AMDGPU.device() == 1
+                @test AMDGPU.get_default_agent() == init_agent
+
+                @test_throws BoundsError AMDGPU.device!(0)
+                @test_throws BoundsError AMDGPU.device!(length(AMDGPU.get_agents())+1)
+            end
+        else
+            @test_skip "Multi-GPU"
+        end
     end
 
     @testset "ISAs" begin


### PR DESCRIPTION
As requested by @luraess and @omlins for MPI integration

Also removes the very silly `set_default_agent!(#=empty=#)` API