### PR TITLE
HSA: Add memory pools API

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -224,7 +224,7 @@ function Base.unsafe_wrap(::Type{<:ROCArray}, ptr::Ptr{T}, dims::NTuple{N,<:Inte
     @assert isbitstype(T) "Cannot wrap a non-bitstype pointer as a ROCArray"
     sz = prod(dims) * sizeof(T)
     device_ptr = Mem.lock(ptr, sz, agent)
-    buf = Mem.Buffer(device_ptr, ptr, sz, agent, false)
+    buf = Mem.Buffer(device_ptr, ptr, sz, agent, false, false)
     ROCArray{T, N}(buf, dims; own=false)
 end
 Base.unsafe_wrap(::Type{ROCArray{T}}, ptr::Ptr, dims) where T =

--- a/src/hsa/HSA.jl
+++ b/src/hsa/HSA.jl
@@ -2,57 +2,6 @@ module HSA
 
 include("LibHSARuntime.jl")
 
-#=
-const Agent = hsa_agent_t
-const AgentInfo = hsa_agent_info_t
-const BarrierAndPacket = hsa_barrier_and_packet_t
-const BarrierOrPacket = hsa_barrier_or_packet_t
-const CodeObjectReader = hsa_code_object_reader_t
-const DefaultFloatRoundingMode = hsa_default_float_rounding_mode_t
-const DeviceType = hsa_device_type_t
-const Executable = hsa_executable_t
-const ExecutableSymbol = hsa_executable_symbol_t
-const ExecutableSymbolInfo = hsa_executable_symbol_info_t
-const ISA = hsa_isa_t
-const ISAInfo = hsa_isa_info_t
-const KernelDispatchPacket = hsa_kernel_dispatch_packet_t
-const KernelDispatchPacketSetup = hsa_kernel_dispatch_packet_setup_t
-const PacketType = hsa_packet_type_t
-const PointerInfo = hsa_amd_pointer_info_t
-const Profile = hsa_profile_t
-const Queue = hsa_queue_t
-const QueueType = hsa_queue_type_t
-const Region = hsa_region_t
-const RegionGlobalFlag = hsa_region_global_flag_t
-const RegionInfo = hsa_region_info_t
-const RegionSegment = hsa_region_segment_t
-const Signal = hsa_signal_t
-const Status = hsa_status_t
-const SymbolKind = hsa_symbol_kind_t
-
-for enum in (AgentInfo,
-             hsa_amd_agent_info_t,
-             DefaultFloatRoundingMode,
-             DeviceType,
-             ExecutableSymbolInfo,
-             hsa_fence_scope_t,
-             KernelDispatchPacketSetup,
-             ISAInfo,
-             PacketType,
-             Profile,
-             QueueType,
-             RegionGlobalFlag,
-             RegionInfo,
-             RegionSegment,
-             Status,
-             SymbolKind)
-    for (name, _) in CEnum.name_value_pairs(enum)
-        newname = Symbol(replace(string(name), "HSA_"=>""))
-        @eval const $newname = $name
-    end
-end
-=#
-
 # Forward prefixed names
 hsa_names = map(string, names(LibHSARuntime))
 for name in filter(n->!(getproperty(LibHSARuntime, Symbol(n)) isa Function), hsa_names)

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -57,12 +57,13 @@ function HSAKernelInstance(agent::HSAAgent, exe::HSAExecutable, symbol::String, 
     getinfo(exec_symbol[], HSA.EXECUTABLE_SYMBOL_INFO_KERNEL_PRIVATE_SEGMENT_SIZE,
             private_segment_size) |> check
 
-    finegrained_region = get_region(agent, :finegrained)
+    # N.B. We use the region API because kernarg allocations don't
+    # show up in the memory pools API
     kernarg_region = get_region(agent, :kernarg)
 
     # Allocate the kernel argument buffer from the correct region
     kernarg_address = Ref{Ptr{Nothing}}()
-    HSA.memory_allocate(kernarg_region[],
+    HSA.memory_allocate(kernarg_region.region,
                         kernarg_segment_size[],
                         kernarg_address) |> check
 

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -131,10 +131,16 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::ROCArray{T},
 
     # group size is restricted by local memory
     agent = R.buf.agent
-    region = first(filter(region->segment_type(region) == HSA.REGION_SEGMENT_GROUP, regions(agent)))
-    max_lmem_elements = max_size(region) ÷ sizeof(T)
-    isa = first(isas(agent))
-    max_items = Base.min(max_group_size(isa), compute_items(max_lmem_elements ÷ 2))
+    pools = filter(pool->pool_segment(pool) == HSA.AMD_SEGMENT_GROUP, memory_pools(agent))
+    max_items = if !isempty(pools)
+        pool = first(pools)
+        max_lmem_elements = pool_size(pool) ÷ sizeof(T)
+        isa = first(isas(agent))
+        Base.min(max_group_size(isa), compute_items(max_lmem_elements ÷ 2))
+    else
+        @warn "No group segment detected for agent $agent; assuming 64 elements\nThis message will not be shown again" maxlog=1
+        64
+    end
     # TODO: dynamic local memory to avoid two compilations
 
     #= TODO: let the runtime suggest a group size

--- a/test/hsa/memory.jl
+++ b/test/hsa/memory.jl
@@ -89,6 +89,82 @@ end
     @test Mem.pointerinfo(plocked).type == HSA.EXT_POINTER_TYPE_UNKNOWN
 end
 
+@testset "Memory Region Queries" begin
+    @testset "Region API Queries" begin
+        for (idx, agent) in enumerate(AMDGPU.get_agents(:gpu))
+            regions = AMDGPU.regions(agent)
+            regions_global = filter(r->AMDGPU.region_segment(r) == AMDGPU.HSA.REGION_SEGMENT_GLOBAL, regions)
+            regions_global_coarse_nohost = filter(r->(AMDGPU.region_global_flags(r) & AMDGPU.HSA.REGION_GLOBAL_FLAG_COARSE_GRAINED > 0) &&
+                                                     !AMDGPU.region_host_accessible(r), regions)
+            regions_group = filter(r->AMDGPU.region_segment(r) == AMDGPU.HSA.REGION_SEGMENT_GROUP, regions)
+            regions_finegrained = filter(r->AMDGPU.region_global_flags(r) & AMDGPU.HSA.REGION_GLOBAL_FLAG_FINE_GRAINED > 0, regions)
+            regions_kernarg = filter(r->AMDGPU.region_global_flags(r) & AMDGPU.HSA.REGION_GLOBAL_FLAG_KERNARG > 0, regions)
+
+            @test length(regions_global) > 0
+            if idx == 1
+                @test length(regions_global_coarse_nohost) >= 1
+                @test length(regions_group) == 1
+            else
+                # BUG: https://github.com/RadeonOpenCompute/ROCR-Runtime/issues/134
+                @test length(regions_global_coarse_nohost) == 0
+                @test length(regions_group) == 0
+            end
+            @test length(regions_finegrained) > 0
+            @test length(regions_kernarg) > 0
+
+            @test all(r->AMDGPU.region_size(r) > 0, regions)
+
+            @test all(AMDGPU.region_runtime_alloc_allowed, regions_global)
+            @test all(r->AMDGPU.region_runtime_alloc_granule(r) > 0, regions_global)
+            @test all(r->AMDGPU.region_runtime_alloc_alignment(r) > 0, regions_global)
+            @test all(r->AMDGPU.region_alloc_max_size(r) > 0, regions_global)
+
+            @test !any(AMDGPU.region_runtime_alloc_allowed, regions_group)
+            @test !any(AMDGPU.region_host_accessible, regions_group)
+
+            @test all(AMDGPU.region_runtime_alloc_allowed, regions_finegrained)
+            @test all(AMDGPU.region_host_accessible, regions_finegrained)
+
+            @test all(AMDGPU.region_runtime_alloc_allowed, regions_kernarg)
+            @test all(AMDGPU.region_host_accessible, regions_kernarg)
+
+            for region in filter(AMDGPU.region_runtime_alloc_allowed, regions)
+                buf = Mem.alloc(agent, region, 8)
+                @test buf.ptr != C_NULL
+                @test !buf.pool_alloc
+                Mem.free(buf)
+            end
+        end
+    end
+    @testset "Memory Pool API Queries" begin
+        for agent in AMDGPU.get_agents(:gpu)
+            pools = AMDGPU.memory_pools(agent)
+            pools_global = filter(r->AMDGPU.pool_segment(r) == AMDGPU.HSA.AMD_SEGMENT_GLOBAL, pools)
+            pools_group = filter(r->AMDGPU.pool_segment(r) == AMDGPU.HSA.AMD_SEGMENT_GROUP, pools)
+
+            @test length(pools_global) >= 1
+            @test length(pools_group) == 1
+
+            @test all(r->AMDGPU.pool_size(r) > 0, pools)
+            @test !any(AMDGPU.pool_accessible_by_all, pools)
+
+            @test all(AMDGPU.pool_runtime_alloc_allowed, pools_global)
+            @test all(r->AMDGPU.pool_runtime_alloc_granule(r) > 0, pools_global)
+            @test all(r->AMDGPU.pool_runtime_alloc_alignment(r) > 0, pools_global)
+            @test all(r->AMDGPU.pool_alloc_max_size(r) > 0, pools_global)
+
+            @test !any(AMDGPU.pool_runtime_alloc_allowed, pools_group)
+
+            for pool in filter(AMDGPU.pool_runtime_alloc_allowed, pools)
+                buf = Mem.alloc(agent, pool, 8)
+                @test buf.ptr != C_NULL
+                @test buf.pool_alloc
+                Mem.free(buf)
+            end
+        end
+    end
+end
+
 @testset "Exceptions" begin
     @test_throws ArgumentError Mem.alloc(Function, 1)   # abstract
     @test_throws ArgumentError Mem.alloc(Array{Int}, 1) # UnionAll


### PR DESCRIPTION
Adds support for HSA's memory pools API, which works around the bug reported in https://github.com/RadeonOpenCompute/ROCR-Runtime/issues/134. We still use HSA's regions API for finegrained and kernarg allocations, because those aren't exposed via this API.

Also fixes #210 

Todo:
- [x] Add allocation API for arbitrary regions/memory pools
- [x] Add tests for regions and memory pools queries
- [x] Add multi-GPU test for coarsegrained allocations
- [x] Add basic docs