### PR TITLE
Add async memcpy functionality

### DIFF
--- a/src/execution_utils.jl
+++ b/src/execution_utils.jl
@@ -39,44 +39,6 @@ mutable struct ROCFunction
 end
 
 """
-    ROCDim3(x)
-    ROCDim3((x,))
-    ROCDim3((x, y))
-    ROCDim3((x, y, x))
-
-A type used to specify dimensions, consisting of 3 integers for the `x`, `y`,
-and `z` dimension, respectively. Unspecified dimensions default to `1`.
-
-Often accepted as argument through the `ROCDim` type alias, eg. in the case of
-[`roccall`](@ref) or [`launch`](@ref), allowing to pass dimensions as a plain
-integer or a tuple without having to construct an explicit `ROCDim3` object.
-"""
-struct ROCDim3
-    x::Cuint
-    y::Cuint
-    z::Cuint
-end
-
-ROCDim3(dims::Integer)             = ROCDim3(dims,    Cuint(1), Cuint(1))
-ROCDim3(dims::NTuple{1,<:Integer}) = ROCDim3(dims[1], Cuint(1), Cuint(1))
-ROCDim3(dims::NTuple{2,<:Integer}) = ROCDim3(dims[1], dims[2],  Cuint(1))
-ROCDim3(dims::NTuple{3,<:Integer}) = ROCDim3(dims[1], dims[2],  dims[3])
-
-# Type alias for conveniently specifying the dimensions
-# (e.g. `(len, 2)` instead of `ROCDim3((len, 2))`)
-const ROCDim = Union{Integer,
-                    Tuple{Integer},
-                    Tuple{Integer, Integer},
-                    Tuple{Integer, Integer, Integer}}
-
-function Base.getindex(dims::ROCDim3, idx::Int)
-    return idx == 1 ? dims.x :
-           idx == 2 ? dims.y :
-           idx == 3 ? dims.z :
-           error("Invalid dimension: $idx")
-end
-
-"""
     roccall(f::ROCFunction, types, values...;
             queue::RuntimeQueue, signal::RuntimeEvent,
             groupsize::ROCDim, gridsize::ROCDim)

--- a/src/extras.jl
+++ b/src/extras.jl
@@ -1,5 +1,45 @@
 # Extra stuff
 
+
+"""
+    ROCDim3(x)
+    ROCDim3((x,))
+    ROCDim3((x, y))
+    ROCDim3((x, y, x))
+
+A type used to specify dimensions, consisting of 3 integers for the `x`, `y`,
+and `z` dimension, respectively. Unspecified dimensions default to `1`.
+
+Often accepted as argument through the `ROCDim` type alias, eg. in the case of
+[`roccall`](@ref) or [`launch`](@ref), allowing to pass dimensions as a plain
+integer or a tuple without having to construct an explicit `ROCDim3` object.
+"""
+struct ROCDim3
+    x::Cuint
+    y::Cuint
+    z::Cuint
+end
+
+ROCDim3(dims::Integer)             = ROCDim3(dims,    Cuint(1), Cuint(1))
+ROCDim3(dims::NTuple{1,<:Integer}) = ROCDim3(dims[1], Cuint(1), Cuint(1))
+ROCDim3(dims::NTuple{2,<:Integer}) = ROCDim3(dims[1], dims[2],  Cuint(1))
+ROCDim3(dims::NTuple{3,<:Integer}) = ROCDim3(dims[1], dims[2],  dims[3])
+
+# Type alias for conveniently specifying the dimensions
+# (e.g. `(len, 2)` instead of `ROCDim3((len, 2))`)
+const ROCDim = Union{Integer,
+                    Tuple{Integer},
+                    Tuple{Integer, Integer},
+                    Tuple{Integer, Integer, Integer}}
+
+function Base.getindex(dims::ROCDim3, idx::Int)
+    return idx == 1 ? dims.x :
+           idx == 2 ? dims.y :
+           idx == 3 ? dims.z :
+           error("Invalid dimension: $idx")
+end
+
+
 newref!(::Type{Ref{HSA.Region}}, value) = Ref{HSA.Region}(HSA.Region(value))
 
 # Memory

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -393,13 +393,11 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
     srcOffsetRef = Ref(HSA.Dim3(srcOffset...))
     rangeRef     = Ref(HSA.Dim3(width, height, depth))
 
-    dstPtr       = Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef)
-    srcPtr       = Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef)
-    dstOffsetPtr = Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef)
-    srcOffsetPtr = Base.unsafe_convert(Ptr{HSA.Dim3},       srcOffsetRef)
-    rangePtr     = Base.unsafe_convert(Ptr{HSA.Dim3},       rangeRef)
-
-    AMDGPU.HSA.amd_memory_async_copy_rect(dstPtr,dstOffsetPtr,srcPtr,srcOffsetPtr,rangePtr,
+    AMDGPU.HSA.amd_memory_async_copy_rect(Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef),
+                                          Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef),
+                                          Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef),
+                                          Base.unsafe_convert(Ptr{HSA.Dim3},       srcOffsetRef),
+                                          Base.unsafe_convert(Ptr{HSA.Dim3},       rangeRef),
                                           get_default_agent().agent,hsaCopyDir,UInt32(0),C_NULL,signal.signal[]) |> check
     
     async || wait(signal)

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -394,7 +394,8 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
     rangeRef     = Ref(HSA.Dim3(sizeof(T)*width, height, depth))
 
     # println("One needs something here")
-    Libc.systemsleep(0.000001); yield()
+    # Libc.systemsleep(0.000001); yield()
+    1==2 && println("no reason to print")
 
     AMDGPU.HSA.amd_memory_async_copy_rect(Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef),
                                           Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef),

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -392,7 +392,7 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
     dstOffsetRef = Ref(HSA.Dim3(dstOffset...))
     srcOffsetRef = Ref(HSA.Dim3(srcOffset...))
     rangeRef     = Ref(HSA.Dim3(sizeof(T)*width, height, depth))
-
+    println("tag 0")
     dstPtr       = Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef)
     dstOffsetPtr = Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef)
     srcPtr       = Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef)

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -363,14 +363,14 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
                         srcPos::ROCDim=(1,1,1), srcPitch=0, srcSlice=0,
                         async::Bool=false, signal::HSASignal=nothing) where T
     (T == Nothing) && error("Type of Ptr is Nothing")
-    println("tag 1")
+
     dstPtr_info = pointerinfo(dst)
     srcPtr_info = pointerinfo(src)
-    println("tag 2")
+
     if dstPtr_info.type == HSA.EXT_POINTER_TYPE_UNKNOWN || srcPtr_info.type == HSA.EXT_POINTER_TYPE_UNKNOWN
         error("Only device pointers or locked host pointers are supported, see unsafe_wrap and Mem.lock")
     end
-    println("tag 3")
+
     if dstPtr_info.type == HSA.EXT_POINTER_TYPE_HSA && srcPtr_info.type == HSA.EXT_POINTER_TYPE_LOCKED
         device_type(dstPtr_info.agentOwner) == HSA.DEVICE_TYPE_GPU || error("dst should point to device memory")
         hsaCopyDir  = HSA.LibHSARuntime.hsaHostToDevice
@@ -383,7 +383,7 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
     else
         error("Only device to device, host to device, and device to host memory transfer is supported")
     end
-    println("tag 4")
+
     dstOffset = (sizeof(T)*(dstPos[1]-1), dstPos[2]-1, dstPos[3]-1)
     srcOffset = (sizeof(T)*(srcPos[1]-1), srcPos[2]-1, srcPos[3]-1)
 
@@ -392,7 +392,7 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
     dstOffsetRef = Ref(HSA.Dim3(dstOffset...))
     srcOffsetRef = Ref(HSA.Dim3(srcOffset...))
     rangeRef     = Ref(HSA.Dim3(sizeof(T)*width, height, depth))
-    println("tag 5")
+
     AMDGPU.HSA.amd_memory_async_copy_rect(Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef),
                                           Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef),
                                           Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef),

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -392,7 +392,9 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
     dstOffsetRef = Ref(HSA.Dim3(dstOffset...))
     srcOffsetRef = Ref(HSA.Dim3(srcOffset...))
     rangeRef     = Ref(HSA.Dim3(sizeof(T)*width, height, depth))
-    # println("tag 0")
+
+    println("One needs something here")
+    
     # dstPtr       = Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef)
     # dstOffsetPtr = Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef)
     # srcPtr       = Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef)
@@ -401,7 +403,7 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
 
     # AMDGPU.HSA.amd_memory_async_copy_rect(dstPtr,dstOffsetPtr,srcPtr,srcOffsetPtr,rangePtr,
     #                                       get_default_agent().agent,hsaCopyDir,UInt32(0),C_NULL,signal.signal[]) |> check
-    println("One needs something here")
+
     AMDGPU.HSA.amd_memory_async_copy_rect(Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef),
                                           Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef),
                                           Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef),

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -373,7 +373,7 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
 
     if dstPtr_info.type == HSA.EXT_POINTER_TYPE_HSA && srcPtr_info.type == HSA.EXT_POINTER_TYPE_LOCKED
         device_type(dstPtr_info.agentOwner) == HSA.DEVICE_TYPE_GPU || error("dst should point to device memory")
-        hsaCopyDir  = HSA.LibHSARuntime.hsaHostToDevice
+        hsaCopyDir = HSA.LibHSARuntime.hsaHostToDevice
     elseif dstPtr_info.type == HSA.EXT_POINTER_TYPE_LOCKED && srcPtr_info.type == HSA.EXT_POINTER_TYPE_HSA
         device_type(srcPtr_info.agentOwner) == HSA.DEVICE_TYPE_GPU || error("src should point to device memory")
         hsaCopyDir = HSA.LibHSARuntime.hsaDeviceToHost
@@ -387,12 +387,12 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
     dstOffset = (sizeof(T)*(dstPos[1]-1), dstPos[2]-1, dstPos[3]-1)
     srcOffset = (sizeof(T)*(srcPos[1]-1), srcPos[2]-1, srcPos[3]-1)
 
-    dstRef       = Ref(HSA.PitchedPtr(dst, dstPitch, dstSlice))
-    srcRef       = Ref(HSA.PitchedPtr(src, srcPitch, srcSlice))
+    dstRef = Ref(HSA.PitchedPtr(dst, dstPitch, dstSlice))
+    srcRef = Ref(HSA.PitchedPtr(src, srcPitch, srcSlice))
     dstOffsetRef = Ref(HSA.Dim3(dstOffset...))
     srcOffsetRef = Ref(HSA.Dim3(srcOffset...))
-    rangeRef     = Ref(HSA.Dim3(sizeof(T)*width, height, depth))
-    sig          = signal.signal[]
+    rangeRef = Ref(HSA.Dim3(sizeof(T)*width, height, depth))
+    sig = signal.signal[]
 
     AMDGPU.HSA.amd_memory_async_copy_rect(Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef),
                                           Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef),

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -393,21 +393,21 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
     srcOffsetRef = Ref(HSA.Dim3(srcOffset...))
     rangeRef     = Ref(HSA.Dim3(sizeof(T)*width, height, depth))
     println("tag 0")
-    dstPtr       = Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef)
-    dstOffsetPtr = Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef)
-    srcPtr       = Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef)
-    srcOffsetPtr = Base.unsafe_convert(Ptr{HSA.Dim3},       srcOffsetRef)
-    rangePtr     = Base.unsafe_convert(Ptr{HSA.Dim3},       rangeRef)
+    # dstPtr       = Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef)
+    # dstOffsetPtr = Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef)
+    # srcPtr       = Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef)
+    # srcOffsetPtr = Base.unsafe_convert(Ptr{HSA.Dim3},       srcOffsetRef)
+    # rangePtr     = Base.unsafe_convert(Ptr{HSA.Dim3},       rangeRef)
 
-    AMDGPU.HSA.amd_memory_async_copy_rect(dstPtr,dstOffsetPtr,srcPtr,srcOffsetPtr,rangePtr,
-                                          get_default_agent().agent,hsaCopyDir,UInt32(0),C_NULL,signal.signal[]) |> check
-
-    # AMDGPU.HSA.amd_memory_async_copy_rect(Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef),
-    #                                       Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef),
-    #                                       Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef),
-    #                                       Base.unsafe_convert(Ptr{HSA.Dim3},       srcOffsetRef),
-    #                                       Base.unsafe_convert(Ptr{HSA.Dim3},       rangeRef),
+    # AMDGPU.HSA.amd_memory_async_copy_rect(dstPtr,dstOffsetPtr,srcPtr,srcOffsetPtr,rangePtr,
     #                                       get_default_agent().agent,hsaCopyDir,UInt32(0),C_NULL,signal.signal[]) |> check
+
+    AMDGPU.HSA.amd_memory_async_copy_rect(Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef),
+                                          Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef),
+                                          Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef),
+                                          Base.unsafe_convert(Ptr{HSA.Dim3},       srcOffsetRef),
+                                          Base.unsafe_convert(Ptr{HSA.Dim3},       rangeRef),
+                                          get_default_agent().agent,hsaCopyDir,UInt32(0),C_NULL,signal.signal[]) |> check
 
     async || wait(signal)
     return nothing

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -394,11 +394,11 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
     rangeRef     = Ref(HSA.Dim3(sizeof(T)*width, height, depth))
 
     dstPtr       = Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef)
-    srcPtr       = Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef)
     dstOffsetPtr = Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef)
+    srcPtr       = Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef)
     srcOffsetPtr = Base.unsafe_convert(Ptr{HSA.Dim3},       srcOffsetRef)
     rangePtr     = Base.unsafe_convert(Ptr{HSA.Dim3},       rangeRef)
-
+    println("tag 1")
     AMDGPU.HSA.amd_memory_async_copy_rect(dstPtr,dstOffsetPtr,srcPtr,srcOffsetPtr,rangePtr,
                                           get_default_agent().agent,hsaCopyDir,UInt32(0),C_NULL,signal.signal[]) |> check
 
@@ -408,7 +408,7 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
     #                                       Base.unsafe_convert(Ptr{HSA.Dim3},       srcOffsetRef),
     #                                       Base.unsafe_convert(Ptr{HSA.Dim3},       rangeRef),
     #                                       get_default_agent().agent,hsaCopyDir,UInt32(0),C_NULL,signal.signal[]) |> check
-
+    println("tag 2")
     async || wait(signal)
     return nothing
 end

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -393,9 +393,7 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
     srcOffsetRef = Ref(HSA.Dim3(srcOffset...))
     rangeRef     = Ref(HSA.Dim3(sizeof(T)*width, height, depth))
 
-    # println("One needs something here")
     # Libc.systemsleep(0.000001); yield()
-    # 1==2 && println("no reason to print")
 
     AMDGPU.HSA.amd_memory_async_copy_rect(Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef),
                                           Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef),

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -392,7 +392,7 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
     dstOffsetRef = Ref(HSA.Dim3(dstOffset...))
     srcOffsetRef = Ref(HSA.Dim3(srcOffset...))
     rangeRef     = Ref(HSA.Dim3(sizeof(T)*width, height, depth))
-
+    println("tag 5")
     AMDGPU.HSA.amd_memory_async_copy_rect(Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef),
                                           Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef),
                                           Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef),

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -11,7 +11,7 @@ module Mem
 
 using ..AMDGPU
 using ..AMDGPU.HSA
-import AMDGPU: check, get_region, get_memory_pool, AGENTS
+import AMDGPU: check, get_region, get_memory_pool, AGENTS, ROCDim, ROCDim3
 
 ## buffer type
 
@@ -337,47 +337,110 @@ end
 
 #################################################################################
 
-function write_d2h_async!(sendbuf::AbstractArray{T}, A::ROCArray{T}, sendranges::Array{UnitRange{T2},1}, signal::HSASignal) where T <: GGNumber where T2 <: Integer
-    locked_ptr = AMDGPU.Mem.lock(pointer(sendbuf), sizeof(sendbuf), get_default_agent())
-    dstPitch   = sizeof(T)*length(sendranges[1])
-    dstWidth   = sizeof(T)*length(sendranges[1])*length(sendranges[2])
-    srcPitch   = sizeof(T)*size(A,1)
-    srcWidth   = sizeof(T)*size(A,1)*size(A,2)
-    srcOff     = (sizeof(T)*(sendranges[1][1]-1), sendranges[2][1]-1, sendranges[3][1]-1)
-    range      = (sizeof(T)*(length(sendranges[1])), length(sendranges[2]), length(sendranges[3]))
-    cpy_dir    = "d2h"
-    async_copy_rect!(locked_ptr, dstPitch, dstWidth, pointer(A), srcPitch, srcWidth, range, cpy_dir, signal; srcOff=srcOff)
-end
+# function write_d2h_async!(sendbuf::AbstractArray{T}, A::ROCArray{T}, sendranges::Array{UnitRange{T2},1}, signal::HSASignal) where T <: GGNumber where T2 <: Integer
+#     locked_ptr = AMDGPU.Mem.lock(pointer(sendbuf), sizeof(sendbuf), get_default_agent())
+#     dstPitch   = sizeof(T)*length(sendranges[1])
+#     dstWidth   = sizeof(T)*length(sendranges[1])*length(sendranges[2])
+#     srcPitch   = sizeof(T)*size(A,1)
+#     srcWidth   = sizeof(T)*size(A,1)*size(A,2)
+#     srcOff     = (sizeof(T)*(sendranges[1][1]-1), sendranges[2][1]-1, sendranges[3][1]-1)
+#     range      = (sizeof(T)*(length(sendranges[1])), length(sendranges[2]), length(sendranges[3]))
+#     cpy_dir    = "d2h"
+#     async_copy_rect!(locked_ptr, dstPitch, dstWidth, pointer(A), srcPitch, srcWidth, range, cpy_dir, signal; srcOff=srcOff)
+# end
 
-function read_h2d_async!(recvbuf::AbstractArray{T}, A::ROCArray{T}, recvranges::Array{UnitRange{T2},1}, signal::HSASignal) where T <: GGNumber where T2 <: Integer
-    locked_ptr = AMDGPU.Mem.lock(pointer(recvbuf), sizeof(recvbuf), get_default_agent())
-    srcPitch   = sizeof(T)*length(recvranges[1])
-    srcWidth   = sizeof(T)*length(recvranges[1])*length(recvranges[2])
-    dstPitch   = sizeof(T)*size(A,1)
-    dstWidth   = sizeof(T)*size(A,1)*size(A,2)
-    dstOff     = (sizeof(T)*(recvranges[1][1]-1), recvranges[2][1]-1, recvranges[3][1]-1)
-    range      = (sizeof(T)*(length(recvranges[1])), length(recvranges[2]), length(recvranges[3]))
-    cpy_dir    = "h2d"
-    async_copy_rect!(pointer(A), dstPitch, dstWidth, locked_ptr, srcPitch, srcWidth, range, cpy_dir, signal; dstOff=dstOff)
-end
+# function read_h2d_async!(recvbuf::AbstractArray{T}, A::ROCArray{T}, recvranges::Array{UnitRange{T2},1}, signal::HSASignal) where T <: GGNumber where T2 <: Integer
+#     locked_ptr = AMDGPU.Mem.lock(pointer(recvbuf), sizeof(recvbuf), get_default_agent())
+#     srcPitch   = sizeof(T)*length(recvranges[1])
+#     srcWidth   = sizeof(T)*length(recvranges[1])*length(recvranges[2])
+#     dstPitch   = sizeof(T)*size(A,1)
+#     dstWidth   = sizeof(T)*size(A,1)*size(A,2)
+#     dstOff     = (sizeof(T)*(recvranges[1][1]-1), recvranges[2][1]-1, recvranges[3][1]-1)
+#     range      = (sizeof(T)*(length(recvranges[1])), length(recvranges[2]), length(recvranges[3]))
+#     cpy_dir    = "h2d"
+#     async_copy_rect!(pointer(A), dstPitch, dstWidth, locked_ptr, srcPitch, srcWidth, range, cpy_dir, signal; dstOff=dstOff)
+# end
 
-function async_copy_rect!(dst, dstPitch, dstWidth, src, srcPitch, srcWidth, range, cpy_dir, signal; srcOff=(0,0,0), dstOff=(0,0,0), copy_agent=get_default_agent())
-    dst_ptr     = Base.unsafe_convert(Ptr{AMDGPU.HSA.PitchedPtr}, Ref(AMDGPU.HSA.PitchedPtr(dst, dstPitch, dstWidth)))
-    dst_off_ptr = Base.unsafe_convert(Ptr{AMDGPU.HSA.Dim3},       Ref(AMDGPU.HSA.Dim3(dstOff)))
-    src_ptr     = Base.unsafe_convert(Ptr{AMDGPU.HSA.PitchedPtr}, Ref(AMDGPU.HSA.PitchedPtr(src, srcPitch, srcWidth)))
-    src_off_ptr = Base.unsafe_convert(Ptr{AMDGPU.HSA.Dim3},       Ref(AMDGPU.HSA.Dim3(srcOff...)))
-    range_ptr   = Base.unsafe_convert(Ptr{AMDGPU.HSA.Dim3},       Ref(AMDGPU.HSA.Dim3(range...)))
+# function async_copy_rect!(dst, dstPitch, dstWidth, src, srcPitch, srcWidth, range, cpy_dir, signal; srcOff=(0,0,0), dstOff=(0,0,0), copy_agent=get_default_agent())
+#     dst_ptr     = Base.unsafe_convert(Ptr{AMDGPU.HSA.PitchedPtr}, Ref(AMDGPU.HSA.PitchedPtr(dst, dstPitch, dstWidth)))
+#     dst_off_ptr = Base.unsafe_convert(Ptr{AMDGPU.HSA.Dim3},       Ref(AMDGPU.HSA.Dim3(dstOff)))
+#     src_ptr     = Base.unsafe_convert(Ptr{AMDGPU.HSA.PitchedPtr}, Ref(AMDGPU.HSA.PitchedPtr(src, srcPitch, srcWidth)))
+#     src_off_ptr = Base.unsafe_convert(Ptr{AMDGPU.HSA.Dim3},       Ref(AMDGPU.HSA.Dim3(srcOff...)))
+#     range_ptr   = Base.unsafe_convert(Ptr{AMDGPU.HSA.Dim3},       Ref(AMDGPU.HSA.Dim3(range...)))
 
-    if cpy_dir=="d2h"
-        dir = AMDGPU.HSA.LibHSARuntime.hsaDeviceToHost
-    elseif cpy_dir == "h2d"
-        dir = AMDGPU.HSA.LibHSARuntime.hsaHostToDevice
+#     if cpy_dir=="d2h"
+#         dir = AMDGPU.HSA.LibHSARuntime.hsaDeviceToHost
+#     elseif cpy_dir == "h2d"
+#         dir = AMDGPU.HSA.LibHSARuntime.hsaHostToDevice
+#     else
+#         error("Throw some error")
+#     end
+#     HSA.amd_memory_async_copy_rect(dst_ptr,dst_off_ptr,src_ptr,src_off_ptr,range_ptr,
+#                                    copy_agent.agent,dir,UInt32(0),C_NULL,signal.signal[]) |> AMDGPU.check
+# end
+
+
+function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, copyDir, width, height=1, depth=1;
+                        dstPos::ROCDim=(1,1,1), dstPitch=0, dstSlice=0,
+                        srcPos::ROCDim=(1,1,1), srcPitch=0, srcSlice=0,
+                        async::Bool=false, signal::HSASignal=nothing) where T
+    srcPos    = ROCDim3(srcPos)
+    dstPos    = ROCDim3(dstPos)
+    srcPitch *= sizeof(T)
+    dstPitch *= sizeof(T)
+    srcSlice *= sizeof(T)
+    dstSlice *= sizeof(T)
+    width    *= sizeof(T)
+    srcOffset = ((srcPos.x-1)*sizeof(T), srcPos.y-1, srcPos.z-1)
+    dstOffset = ((dstPos.x-1)*sizeof(T), dstPos.y-1, dstPos.z-1)
+
+    @assert convert(Int,dst) % 4 == 0 "dst base % 4 != 0"
+    @assert convert(Int,src) % 4 == 0 "src base % 4 != 0"
+
+    @assert dstPitch % 4 == 0 "dst pitch % 4 != 0"
+    @assert srcPitch % 4 == 0 "src pitch % 4 != 0"
+
+    @assert dstSlice % 4 == 0 "dst slice % 4 != 0"
+    @assert srcSlice % 4 == 0 "src slice % 4 != 0"
+
+    @assert srcOffset[1] + width <= srcPitch "Src rect width out of range"
+    @assert dstOffset[1] + width <= dstPitch "Dst rect width out of range"
+    
+    @assert srcSlice == 0 || (srcOffset[2] + height) <= srcSlice ÷ srcPitch "Src rect height out of range"
+    @assert dstSlice == 0 || (dstOffset[2] + height) <= dstSlice ÷ dstPitch "Dst rect height out of range"
+
+    @assert depth <= 1 || (srcSlice != 0 && dstSlice != 0) "Copy rect slice needed."
+
+    hsaCopyDir = if copyDir == :device_to_device
+        HSA.LibHSARuntime.hsaDeviceToDevice
+    elseif copyDir == :device_to_host
+        HSA.LibHSARuntime.hsaDeviceToHost
+    elseif copyDir == :host_to_device
+        HSA.LibHSARuntime.hsaHostToDevice
     else
-        error("Throw some error")
+        error("Only device to device, host to device, and device to host memory transfer is supported")
     end
-    HSA.amd_memory_async_copy_rect(dst_ptr,dst_off_ptr,src_ptr,src_off_ptr,range_ptr,
-                                   copy_agent.agent,dir,UInt32(0),C_NULL,signal.signal[]) |> AMDGPU.check
+
+    srcRef       = Ref(AMDGPU.HSA.PitchedPtr(src, srcPitch, srcSlice))
+    dstRef       = Ref(AMDGPU.HSA.PitchedPtr(dst, dstPitch, dstSlice))
+    srcOffsetRef = Ref(AMDGPU.HSA.Dim3(srcOffset...))
+    dstOffsetRef = Ref(AMDGPU.HSA.Dim3(dstOffset...))
+    rangePtrRef  = Ref(AMDGPU.HSA.Dim3(width, height, depth))
+    
+    srcPtr       = Base.unsafe_convert(Ptr{AMDGPU.HSA.PitchedPtr}, srcRef)
+    dstPtr       = Base.unsafe_convert(Ptr{AMDGPU.HSA.PitchedPtr}, dstRef)
+    srcOffsetPtr = Base.unsafe_convert(Ptr{AMDGPU.HSA.Dim3},       srcOffsetRef)
+    dstOffsetPtr = Base.unsafe_convert(Ptr{AMDGPU.HSA.Dim3},       dstOffsetRef)
+    rangePtr     = Base.unsafe_convert(Ptr{AMDGPU.HSA.Dim3},       rangePtrRef)
+
+    signal = HSASignal(1)
+    HSA.amd_memory_async_copy_rect(dstPtr,dstOffsetPtr,srcPtr,srcOffsetPtr,rangePtr,
+                                   get_default_agent().agent,hsaCopyDir,UInt32(0),C_NULL,signal.signal[]) |> AMDGPU.check
+    # async || wait(signal)
+    wait(signal)
+    return
 end
+
 #################################################################################
 
 ## array based

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -393,16 +393,8 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
     srcOffsetRef = Ref(HSA.Dim3(srcOffset...))
     rangeRef     = Ref(HSA.Dim3(sizeof(T)*width, height, depth))
 
-    println("One needs something here")
-    
-    # dstPtr       = Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef)
-    # dstOffsetPtr = Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef)
-    # srcPtr       = Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef)
-    # srcOffsetPtr = Base.unsafe_convert(Ptr{HSA.Dim3},       srcOffsetRef)
-    # rangePtr     = Base.unsafe_convert(Ptr{HSA.Dim3},       rangeRef)
-
-    # AMDGPU.HSA.amd_memory_async_copy_rect(dstPtr,dstOffsetPtr,srcPtr,srcOffsetPtr,rangePtr,
-    #                                       get_default_agent().agent,hsaCopyDir,UInt32(0),C_NULL,signal.signal[]) |> check
+    # println("One needs something here")
+    Libc.systemsleep(0.000001); yield()
 
     AMDGPU.HSA.amd_memory_async_copy_rect(Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef),
                                           Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef),

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -398,7 +398,7 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
     srcPtr       = Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef)
     srcOffsetPtr = Base.unsafe_convert(Ptr{HSA.Dim3},       srcOffsetRef)
     rangePtr     = Base.unsafe_convert(Ptr{HSA.Dim3},       rangeRef)
-    println("tag 1")
+
     AMDGPU.HSA.amd_memory_async_copy_rect(dstPtr,dstOffsetPtr,srcPtr,srcOffsetPtr,rangePtr,
                                           get_default_agent().agent,hsaCopyDir,UInt32(0),C_NULL,signal.signal[]) |> check
 
@@ -408,7 +408,7 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
     #                                       Base.unsafe_convert(Ptr{HSA.Dim3},       srcOffsetRef),
     #                                       Base.unsafe_convert(Ptr{HSA.Dim3},       rangeRef),
     #                                       get_default_agent().agent,hsaCopyDir,UInt32(0),C_NULL,signal.signal[]) |> check
-    println("tag 2")
+
     async || wait(signal)
     return nothing
 end

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -392,14 +392,23 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
     dstOffsetRef = Ref(HSA.Dim3(dstOffset...))
     srcOffsetRef = Ref(HSA.Dim3(srcOffset...))
     rangeRef     = Ref(HSA.Dim3(sizeof(T)*width, height, depth))
-    println("tag 5")
-    AMDGPU.HSA.amd_memory_async_copy_rect(Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef),
-                                          Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef),
-                                          Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef),
-                                          Base.unsafe_convert(Ptr{HSA.Dim3},       srcOffsetRef),
-                                          Base.unsafe_convert(Ptr{HSA.Dim3},       rangeRef),
+
+    dstPtr       = Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef)
+    srcPtr       = Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef)
+    dstOffsetPtr = Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef)
+    srcOffsetPtr = Base.unsafe_convert(Ptr{HSA.Dim3},       srcOffsetRef)
+    rangePtr     = Base.unsafe_convert(Ptr{HSA.Dim3},       rangeRef)
+
+    AMDGPU.HSA.amd_memory_async_copy_rect(dstPtr,dstOffsetPtr,srcPtr,srcOffsetPtr,rangePtr,
                                           get_default_agent().agent,hsaCopyDir,UInt32(0),C_NULL,signal.signal[]) |> check
-    println("tag 6")
+
+    # AMDGPU.HSA.amd_memory_async_copy_rect(Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef),
+    #                                       Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef),
+    #                                       Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef),
+    #                                       Base.unsafe_convert(Ptr{HSA.Dim3},       srcOffsetRef),
+    #                                       Base.unsafe_convert(Ptr{HSA.Dim3},       rangeRef),
+    #                                       get_default_agent().agent,hsaCopyDir,UInt32(0),C_NULL,signal.signal[]) |> check
+
     async || wait(signal)
     return nothing
 end

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -394,13 +394,13 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
     rangeRef     = Ref(HSA.Dim3(sizeof(T)*width, height, depth))
 
     # Libc.systemsleep(0.000001); yield()
-
+    sig = signal.signal[]
     AMDGPU.HSA.amd_memory_async_copy_rect(Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef),
                                           Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef),
                                           Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef),
                                           Base.unsafe_convert(Ptr{HSA.Dim3},       srcOffsetRef),
                                           Base.unsafe_convert(Ptr{HSA.Dim3},       rangeRef),
-                                          get_default_agent().agent,hsaCopyDir,UInt32(0),C_NULL,signal.signal[]) |> check
+                                          get_default_agent().agent,hsaCopyDir,UInt32(0),C_NULL,sig) |> check
 
     async || wait(signal)
     return nothing

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -391,7 +391,7 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
     srcRef       = Ref(HSA.PitchedPtr(src, srcPitch, srcSlice))
     dstOffsetRef = Ref(HSA.Dim3(dstOffset...))
     srcOffsetRef = Ref(HSA.Dim3(srcOffset...))
-    rangeRef     = Ref(HSA.Dim3(width, height, depth))
+    rangeRef     = Ref(HSA.Dim3(sizeof(T)*width, height, depth))
 
     AMDGPU.HSA.amd_memory_async_copy_rect(Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef),
                                           Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef),

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -392,9 +392,8 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
     dstOffsetRef = Ref(HSA.Dim3(dstOffset...))
     srcOffsetRef = Ref(HSA.Dim3(srcOffset...))
     rangeRef     = Ref(HSA.Dim3(sizeof(T)*width, height, depth))
+    sig          = signal.signal[]
 
-    # Libc.systemsleep(0.000001); yield()
-    sig = signal.signal[]
     AMDGPU.HSA.amd_memory_async_copy_rect(Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef),
                                           Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef),
                                           Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef),

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -363,14 +363,14 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
                         srcPos::ROCDim=(1,1,1), srcPitch=0, srcSlice=0,
                         async::Bool=false, signal::HSASignal=nothing) where T
     (T == Nothing) && error("Type of Ptr is Nothing")
-
+    println("tag 1")
     dstPtr_info = pointerinfo(dst)
     srcPtr_info = pointerinfo(src)
-
+    println("tag 2")
     if dstPtr_info.type == HSA.EXT_POINTER_TYPE_UNKNOWN || srcPtr_info.type == HSA.EXT_POINTER_TYPE_UNKNOWN
         error("Only device pointers or locked host pointers are supported, see unsafe_wrap and Mem.lock")
     end
-
+    println("tag 3")
     if dstPtr_info.type == HSA.EXT_POINTER_TYPE_HSA && srcPtr_info.type == HSA.EXT_POINTER_TYPE_LOCKED
         device_type(dstPtr_info.agentOwner) == HSA.DEVICE_TYPE_GPU || error("dst should point to device memory")
         hsaCopyDir  = HSA.LibHSARuntime.hsaHostToDevice
@@ -383,7 +383,7 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
     else
         error("Only device to device, host to device, and device to host memory transfer is supported")
     end
-
+    println("tag 4")
     dstOffset = (sizeof(T)*(dstPos[1]-1), dstPos[2]-1, dstPos[3]-1)
     srcOffset = (sizeof(T)*(srcPos[1]-1), srcPos[2]-1, srcPos[3]-1)
 
@@ -392,14 +392,14 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
     dstOffsetRef = Ref(HSA.Dim3(dstOffset...))
     srcOffsetRef = Ref(HSA.Dim3(srcOffset...))
     rangeRef     = Ref(HSA.Dim3(sizeof(T)*width, height, depth))
-
+    println("tag 5")
     AMDGPU.HSA.amd_memory_async_copy_rect(Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef),
                                           Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef),
                                           Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef),
                                           Base.unsafe_convert(Ptr{HSA.Dim3},       srcOffsetRef),
                                           Base.unsafe_convert(Ptr{HSA.Dim3},       rangeRef),
                                           get_default_agent().agent,hsaCopyDir,UInt32(0),C_NULL,signal.signal[]) |> check
-    
+    println("tag 6")
     async || wait(signal)
     return nothing
 end

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -395,7 +395,7 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
 
     # println("One needs something here")
     # Libc.systemsleep(0.000001); yield()
-    1==2 && println("no reason to print")
+    # 1==2 && println("no reason to print")
 
     AMDGPU.HSA.amd_memory_async_copy_rect(Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef),
                                           Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef),

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -392,7 +392,7 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
     dstOffsetRef = Ref(HSA.Dim3(dstOffset...))
     srcOffsetRef = Ref(HSA.Dim3(srcOffset...))
     rangeRef     = Ref(HSA.Dim3(sizeof(T)*width, height, depth))
-    println("tag 0")
+    # println("tag 0")
     # dstPtr       = Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef)
     # dstOffsetPtr = Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef)
     # srcPtr       = Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef)
@@ -401,7 +401,7 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
 
     # AMDGPU.HSA.amd_memory_async_copy_rect(dstPtr,dstOffsetPtr,srcPtr,srcOffsetPtr,rangePtr,
     #                                       get_default_agent().agent,hsaCopyDir,UInt32(0),C_NULL,signal.signal[]) |> check
-
+    signal = HSASignal()
     AMDGPU.HSA.amd_memory_async_copy_rect(Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef),
                                           Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef),
                                           Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef),

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -401,7 +401,7 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
 
     # AMDGPU.HSA.amd_memory_async_copy_rect(dstPtr,dstOffsetPtr,srcPtr,srcOffsetPtr,rangePtr,
     #                                       get_default_agent().agent,hsaCopyDir,UInt32(0),C_NULL,signal.signal[]) |> check
-    signal = HSASignal()
+    println("One needs something here")
     AMDGPU.HSA.amd_memory_async_copy_rect(Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef),
                                           Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef),
                                           Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef),

--- a/test/hsa/agent.jl
+++ b/test/hsa/agent.jl
@@ -8,7 +8,7 @@
         @test length(agent_name) > 0
         @test !occursin('\0', agent_name)
 
-        if length(AMDGPU.get_agents()) > 1
+        if length(AMDGPU.get_agents(:gpu)) > 1
             @testset "Multi-GPU" begin
                 init_agent = AMDGPU.get_default_agent()
                 init_dev = AMDGPU.device()

--- a/test/hsa/memory.jl
+++ b/test/hsa/memory.jl
@@ -40,7 +40,6 @@
         # device to host
         P_Ptr   = convert(Ptr{eltype(buf)}, pointer(P))
         signal1 = HSASignal()
-        print("unsafe_copy3d! device to host...")
         Mem.unsafe_copy3d!(
             buf_Ptr, P_Ptr, length(ranges[1]), length(ranges[2]), length(ranges[3]);
             dstPitch=sizeof(eltype(buf))*length(ranges[1]), dstSlice=sizeof(eltype(buf))*length(ranges[1])*length(ranges[2]),
@@ -48,12 +47,10 @@
             async=true, signal=signal1
         )
         wait(signal1)
-        println("done")
         @test all(buf[:] .== Array(P[ranges[1],ranges[2],ranges[3]][:]))
         # host to device
         P2_Ptr  = convert(Ptr{eltype(buf)}, pointer(P2))
         signal2 = HSASignal()
-        print("unsafe_copy3d! host to device...")
         Mem.unsafe_copy3d!(
             P2_Ptr, buf_Ptr, length(ranges[1]), length(ranges[2]), length(ranges[3]);
             dstPos=(ranges[1][1], ranges[2][1], ranges[3][1]), dstPitch=sizeof(eltype(buf))*size(P,1), dstSlice=sizeof(eltype(buf))*size(P,1)*size(P,2),
@@ -61,7 +58,6 @@
             async=true, signal=signal2
         )
         wait(signal2)
-        println("done")
         @test all(buf[:] .== Array(P2[ranges[1],ranges[2],ranges[3]][:]))
         # unlock host pointer
         Mem.unlock(pointer(buf))

--- a/test/hsa/memory.jl
+++ b/test/hsa/memory.jl
@@ -40,8 +40,12 @@
         buf_Ptr = convert(Ptr{eltype(buf)}, AMDGPU.Mem.lock(pointer(buf), sizeof(buf), get_default_agent()))
         println("done")
         # device to host
+        print("Convert pointer(P)...")
         P_Ptr   = convert(Ptr{eltype(buf)}, pointer(P))
+        println("done")
+        print("Init HSASignal()...")
         signal1 = HSASignal()
+        println("done")
         print("unsafe_copy3d! device to host...")
         Mem.unsafe_copy3d!(
             buf_Ptr, P_Ptr, length(ranges[1]), length(ranges[2]), length(ranges[3]);

--- a/test/hsa/memory.jl
+++ b/test/hsa/memory.jl
@@ -36,16 +36,10 @@
         buf     = zeros(size(P))
         ranges  = [1:size(P,1), 1:size(P,2), 1:size(P,3)]
         # lock host pointer and convert it to eltype(buf)
-        print("Allocate buffer...")
         buf_Ptr = convert(Ptr{eltype(buf)}, AMDGPU.Mem.lock(pointer(buf), sizeof(buf), get_default_agent()))
-        println("done")
         # device to host
-        print("Convert pointer(P)...")
         P_Ptr   = convert(Ptr{eltype(buf)}, pointer(P))
-        println("done")
-        print("Init HSASignal()...")
         signal1 = HSASignal()
-        println("done")
         print("unsafe_copy3d! device to host...")
         Mem.unsafe_copy3d!(
             buf_Ptr, P_Ptr, length(ranges[1]), length(ranges[2]), length(ranges[3]);

--- a/test/hsa/memory.jl
+++ b/test/hsa/memory.jl
@@ -1,30 +1,67 @@
 @testset "Memory" begin
 
 @testset "Pointer-based" begin
-    src = 42
-
-    buf1 = Mem.alloc(sizeof(src); coherent=true)
-
-    Mem.set!(buf1, UInt32(57), 1)
-    x = Mem.download(UInt32, buf1)
-    @test x[1] == UInt32(57)
-
-    GC.@preserve Mem.upload!(buf1, pointer_from_objref(Ref(src)), sizeof(src))
-
-    dst1 = Ref(0)
-    GC.@preserve Mem.download!(pointer_from_objref(dst1), buf1, sizeof(src))
-    @test src == dst1[]
-
-    buf2 = Mem.alloc(sizeof(src))
-
-    Mem.transfer!(buf2, buf1, sizeof(src))
-
-    dst2 = Ref(0)
-    GC.@preserve Mem.download!(pointer_from_objref(dst2), buf2, sizeof(src))
-    @test src == dst2[]
-
-    Mem.free(buf2)
-    Mem.free(buf1)
+    @testset "Mem transfers" begin
+        src = 42
+        
+        buf1 = Mem.alloc(sizeof(src); coherent=true)
+        
+        Mem.set!(buf1, UInt32(57), 1)
+        x = Mem.download(UInt32, buf1)
+        @test x[1] == UInt32(57)
+        
+        GC.@preserve Mem.upload!(buf1, pointer_from_objref(Ref(src)), sizeof(src))
+        
+        dst1 = Ref(0)
+        GC.@preserve Mem.download!(pointer_from_objref(dst1), buf1, sizeof(src))
+        @test src == dst1[]
+        
+        buf2 = Mem.alloc(sizeof(src))
+        
+        Mem.transfer!(buf2, buf1, sizeof(src))
+        
+        dst2 = Ref(0)
+        GC.@preserve Mem.download!(pointer_from_objref(dst2), buf2, sizeof(src))
+        @test src == dst2[]
+        
+        Mem.free(buf2)
+        Mem.free(buf1)
+    end
+    @testset "Unsafe copy h2d and d2h" begin
+        nx,ny,nz = 33,17,11
+        P       = zeros(nx, ny, nz)
+        P      .= [iz*1e2 + iy*1e1 + ix for ix=1:size(P,1), iy=1:size(P,2), iz=1:size(P,3)]
+        P       = ROCArray(P)
+        P2      = AMDGPU.zeros(eltype(P),size(P));
+        buf     = zeros(size(P))
+        ranges  = [1:size(P,1), 1:size(P,2), 1:size(P,3)]
+        # lock host pointer and convert it to eltype(buf)
+        buf_Ptr = convert(Ptr{eltype(buf)}, AMDGPU.Mem.lock(pointer(buf), sizeof(buf), get_default_agent()))
+        # device to host
+        P_Ptr   = convert(Ptr{eltype(buf)}, pointer(P))
+        signal1 = HSASignal(1)
+        Mem.unsafe_copy3d!(
+            buf_Ptr, P_Ptr, sizeof(eltype(buf))*length(ranges[1]), length(ranges[2]), length(ranges[3]);
+            dstPitch=sizeof(eltype(buf))*length(ranges[1]), dstSlice=sizeof(eltype(buf))*length(ranges[1])*length(ranges[2]),
+            srcPos=(ranges[1][1], ranges[2][1], ranges[3][1]), srcPitch=sizeof(eltype(buf))*size(P,1), srcSlice=sizeof(eltype(buf))*size(P,1)*size(P,2),
+            async=true, signal=signal1
+        )
+        wait(signal1)
+        @test all(buf[:] .== Array(P[ranges[1],ranges[2],ranges[3]][:]))
+        # host to device
+        P2_Ptr  = convert(Ptr{eltype(buf)}, pointer(P2))
+        signal2 = HSASignal(1)
+        Mem.unsafe_copy3d!(
+            P2_Ptr, buf_Ptr, sizeof(eltype(buf))*length(ranges[1]), length(ranges[2]), length(ranges[3]);
+            dstPos=(ranges[1][1], ranges[2][1], ranges[3][1]), dstPitch=sizeof(eltype(buf))*size(P,1), dstSlice=sizeof(eltype(buf))*size(P,1)*size(P,2),
+            srcPitch=sizeof(eltype(buf))*length(ranges[1]), srcSlice=sizeof(eltype(buf))*length(ranges[1])*length(ranges[2]),
+            async=true, signal=signal2
+        )
+        wait(signal2)
+        @test all(buf[:] .== Array(P2[ranges[1],ranges[2],ranges[3]][:]))
+        # unlock host pointer
+        Mem.unlock(pointer(buf))
+    end
 end
 
 @testset "Array-based" begin

--- a/test/hsa/memory.jl
+++ b/test/hsa/memory.jl
@@ -43,17 +43,17 @@
         print("Convert pointer(P)...")
         P_Ptr   = convert(Ptr{eltype(buf)}, pointer(P))
         println("done")
-        # print("Init HSASignal()...")
-        # signal1 = HSASignal()
-        # println("done")
+        print("Init HSASignal()...")
+        signal1 = HSASignal()
+        println("done")
         print("unsafe_copy3d! device to host...")
         Mem.unsafe_copy3d!(
             buf_Ptr, P_Ptr, length(ranges[1]), length(ranges[2]), length(ranges[3]);
             dstPitch=sizeof(eltype(buf))*length(ranges[1]), dstSlice=sizeof(eltype(buf))*length(ranges[1])*length(ranges[2]),
             srcPos=(ranges[1][1], ranges[2][1], ranges[3][1]), srcPitch=sizeof(eltype(buf))*size(P,1), srcSlice=sizeof(eltype(buf))*size(P,1)*size(P,2),
-            async=false, signal=HSASignal()
+            async=true, signal=signal1
         )
-        # wait(signal1)
+        wait(signal1)
         println("done")
         @test all(buf[:] .== Array(P[ranges[1],ranges[2],ranges[3]][:]))
         # host to device

--- a/test/hsa/memory.jl
+++ b/test/hsa/memory.jl
@@ -45,7 +45,7 @@
             buf_Ptr, P_Ptr, length(ranges[1]), length(ranges[2]), length(ranges[3]);
             dstPitch=sizeof(eltype(buf))*length(ranges[1]), dstSlice=sizeof(eltype(buf))*length(ranges[1])*length(ranges[2]),
             srcPos=(ranges[1][1], ranges[2][1], ranges[3][1]), srcPitch=sizeof(eltype(buf))*size(P,1), srcSlice=sizeof(eltype(buf))*size(P,1)*size(P,2),
-            async=false, signal=signal1
+            async=true, signal=signal1
         )
         wait(signal1)
         println("done")

--- a/test/hsa/memory.jl
+++ b/test/hsa/memory.jl
@@ -43,17 +43,17 @@
         print("Convert pointer(P)...")
         P_Ptr   = convert(Ptr{eltype(buf)}, pointer(P))
         println("done")
-        print("Init HSASignal()...")
-        signal1 = HSASignal()
-        println("done")
+        # print("Init HSASignal()...")
+        # signal1 = HSASignal()
+        # println("done")
         print("unsafe_copy3d! device to host...")
         Mem.unsafe_copy3d!(
             buf_Ptr, P_Ptr, length(ranges[1]), length(ranges[2]), length(ranges[3]);
             dstPitch=sizeof(eltype(buf))*length(ranges[1]), dstSlice=sizeof(eltype(buf))*length(ranges[1])*length(ranges[2]),
             srcPos=(ranges[1][1], ranges[2][1], ranges[3][1]), srcPitch=sizeof(eltype(buf))*size(P,1), srcSlice=sizeof(eltype(buf))*size(P,1)*size(P,2),
-            async=true, signal=signal1
+            async=true, signal=HSASignal()
         )
-        wait(signal1)
+        # wait(signal1)
         println("done")
         @test all(buf[:] .== Array(P[ranges[1],ranges[2],ranges[3]][:]))
         # host to device

--- a/test/hsa/memory.jl
+++ b/test/hsa/memory.jl
@@ -45,7 +45,7 @@
             buf_Ptr, P_Ptr, length(ranges[1]), length(ranges[2]), length(ranges[3]);
             dstPitch=sizeof(eltype(buf))*length(ranges[1]), dstSlice=sizeof(eltype(buf))*length(ranges[1])*length(ranges[2]),
             srcPos=(ranges[1][1], ranges[2][1], ranges[3][1]), srcPitch=sizeof(eltype(buf))*size(P,1), srcSlice=sizeof(eltype(buf))*size(P,1)*size(P,2),
-            async=true, signal=signal1
+            async=false, signal=signal1
         )
         wait(signal1)
         println("done")

--- a/test/hsa/memory.jl
+++ b/test/hsa/memory.jl
@@ -41,7 +41,7 @@
         P_Ptr   = convert(Ptr{eltype(buf)}, pointer(P))
         signal1 = HSASignal(1)
         Mem.unsafe_copy3d!(
-            buf_Ptr, P_Ptr, sizeof(eltype(buf))*length(ranges[1]), length(ranges[2]), length(ranges[3]);
+            buf_Ptr, P_Ptr, length(ranges[1]), length(ranges[2]), length(ranges[3]);
             dstPitch=sizeof(eltype(buf))*length(ranges[1]), dstSlice=sizeof(eltype(buf))*length(ranges[1])*length(ranges[2]),
             srcPos=(ranges[1][1], ranges[2][1], ranges[3][1]), srcPitch=sizeof(eltype(buf))*size(P,1), srcSlice=sizeof(eltype(buf))*size(P,1)*size(P,2),
             async=true, signal=signal1
@@ -52,7 +52,7 @@
         P2_Ptr  = convert(Ptr{eltype(buf)}, pointer(P2))
         signal2 = HSASignal(1)
         Mem.unsafe_copy3d!(
-            P2_Ptr, buf_Ptr, sizeof(eltype(buf))*length(ranges[1]), length(ranges[2]), length(ranges[3]);
+            P2_Ptr, buf_Ptr, length(ranges[1]), length(ranges[2]), length(ranges[3]);
             dstPos=(ranges[1][1], ranges[2][1], ranges[3][1]), dstPitch=sizeof(eltype(buf))*size(P,1), dstSlice=sizeof(eltype(buf))*size(P,1)*size(P,2),
             srcPitch=sizeof(eltype(buf))*length(ranges[1]), srcSlice=sizeof(eltype(buf))*length(ranges[1])*length(ranges[2]),
             async=true, signal=signal2

--- a/test/hsa/memory.jl
+++ b/test/hsa/memory.jl
@@ -51,7 +51,7 @@
             buf_Ptr, P_Ptr, length(ranges[1]), length(ranges[2]), length(ranges[3]);
             dstPitch=sizeof(eltype(buf))*length(ranges[1]), dstSlice=sizeof(eltype(buf))*length(ranges[1])*length(ranges[2]),
             srcPos=(ranges[1][1], ranges[2][1], ranges[3][1]), srcPitch=sizeof(eltype(buf))*size(P,1), srcSlice=sizeof(eltype(buf))*size(P,1)*size(P,2),
-            async=true, signal=HSASignal()
+            async=false, signal=HSASignal()
         )
         # wait(signal1)
         println("done")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,10 +42,14 @@ end
 @info "Testing using device $(get_default_agent())"
 
 @testset "HSA" begin
-    include("hsa/error.jl")
-    include("hsa/agent.jl")
-    include("hsa/memory.jl")
-    include("hsa/utils.jl")
+    println("testing hsa/error.jl")
+    @time include("hsa/error.jl")
+    println("testing hsa/agent.jl")
+    @time include("hsa/agent.jl")
+    println("testing hsa/memory.jl")
+    @time include("hsa/memory.jl")
+    println("testing hsa/utils.jl")
+    @time include("hsa/utils.jl")
 end
 @testset "Codegen" begin
     include("codegen/synchronization.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,10 +42,10 @@ end
 @info "Testing using device $(get_default_agent())"
 
 @testset "HSA" begin
-    # println("testing hsa/error.jl")
-    # @time include("hsa/error.jl")
-    # println("testing hsa/agent.jl")
-    # @time include("hsa/agent.jl")
+    println("testing hsa/error.jl")
+    @time include("hsa/error.jl")
+    println("testing hsa/agent.jl")
+    @time include("hsa/agent.jl")
     println("testing hsa/memory.jl")
     @time include("hsa/memory.jl")
     println("testing hsa/utils.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,10 +42,10 @@ end
 @info "Testing using device $(get_default_agent())"
 
 @testset "HSA" begin
-    println("testing hsa/error.jl")
-    @time include("hsa/error.jl")
-    println("testing hsa/agent.jl")
-    @time include("hsa/agent.jl")
+    # println("testing hsa/error.jl")
+    # @time include("hsa/error.jl")
+    # println("testing hsa/agent.jl")
+    # @time include("hsa/agent.jl")
     println("testing hsa/memory.jl")
     @time include("hsa/memory.jl")
     println("testing hsa/utils.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,14 +42,10 @@ end
 @info "Testing using device $(get_default_agent())"
 
 @testset "HSA" begin
-    println("testing hsa/error.jl")
-    @time include("hsa/error.jl")
-    println("testing hsa/agent.jl")
-    @time include("hsa/agent.jl")
-    println("testing hsa/memory.jl")
-    @time include("hsa/memory.jl")
-    println("testing hsa/utils.jl")
-    @time include("hsa/utils.jl")
+    include("hsa/error.jl")
+    include("hsa/agent.jl")
+    include("hsa/memory.jl")
+    include("hsa/utils.jl")
 end
 @testset "Codegen" begin
     include("codegen/synchronization.jl")


### PR DESCRIPTION
Provide an async memcpy function `AMDGPU.Mem.unsafe_copy3d!` analogous to CUDA.jl's `CUDA.Mem.unsafe_copy3d!`, relying on HSA's `AMDGPU.HSA.amd_memory_async_copy_rect` functionality. Adresses #204 
Co-authored by @utkinis