### PR TITLE
HSA: Don't always load hsa_rocr_jll

### DIFF
--- a/src/hsa/LibHSARuntime.jl
+++ b/src/hsa/LibHSARuntime.jl
@@ -1,8 +1,5 @@
 module LibHSARuntime
 
-using hsa_rocr_jll
-export hsa_rocr_jll
-
 using CEnum
 
 import ...AMDGPU: libhsaruntime


### PR DESCRIPTION
@michel2323 this should fix the missing agents on Crusher