### PR TITLE
Restrict multi-GPU test to GPU agent only

### DIFF
--- a/test/hsa/agent.jl
+++ b/test/hsa/agent.jl
@@ -8,7 +8,7 @@
         @test length(agent_name) > 0
         @test !occursin('\0', agent_name)
 
-        if length(AMDGPU.get_agents()) > 1
+        if length(AMDGPU.get_agents(:gpu)) > 1
             @testset "Multi-GPU" begin
                 init_agent = AMDGPU.get_default_agent()
                 init_dev = AMDGPU.device()


### PR DESCRIPTION
Restrict agent to `:gpu` in HSA agent test. Closes #223.