### PR TITLE
build/init: Skip if GPUs are not available

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -209,6 +209,12 @@ function main()
         return
     end
 
+    # Skip build if KFD is not available
+    if !ispath("/dev/kfd")
+        build_warning("/dev/kfd not available, cannot use ROCm Runtime.")
+        return
+    end
+
     # find some paths for library search
     roc_dirs = find_roc_paths()
 

--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -143,6 +143,10 @@ check_library("MIOpen", libmiopen)
 end # functional(:hip)
 
 function __init__()
+    if !ispath("/dev/kfd")
+        @debug "/dev/kfd not available, skipping initialization"
+        return
+    end
     if !configured && build_reason != "unknown"
         if build_reason == "Build did not occur"
             @warn """


### PR DESCRIPTION
This skips most of the build step and initialization if AMD GPU devices are not available on the system.

Closes #199 