### PR TITLE
Mem: Retry failing allocations

### DIFF
--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -150,19 +150,15 @@ include("deprecations.jl")
 
 const HSA_REFCOUNT = Threads.Atomic{UInt}(0)
 function hsaref!()
-    #=
     if Threads.atomic_add!(HSA_REFCOUNT, UInt(1)) > typemax(UInt)-10
         Core.println("HSA_REFCOUNT OVERFLOW!")
         exit(1)
     end
-    =#
 end
 function hsaunref!()
-    #=
     if Threads.atomic_sub!(HSA_REFCOUNT, UInt(1)) == 1
         HSA.shut_down()
     end
-    =#
 end
 
 # Load ROCm external libraries
@@ -245,7 +241,6 @@ function __init__()
         status = HSA.init()
         if status == HSA.STATUS_SUCCESS
             hsaref!()
-            HSA_REFCOUNT[] = 1
             # Register shutdown hook
             atexit() do
                 hsaunref!()

--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -87,7 +87,6 @@ module Device
     # Device sources must load _before_ the compiler infrastructure
     # because of generated functions.
     include(joinpath("device", "addrspaces.jl"))
-    include(joinpath("device", "array.jl"))
     include(joinpath("device", "gcn.jl"))
     include(joinpath("device", "runtime.jl"))
     include(joinpath("device", "llvm.jl"))

--- a/src/device/gcn.jl
+++ b/src/device/gcn.jl
@@ -1,4 +1,5 @@
 include(joinpath("gcn", "helpers.jl"))
+include(joinpath("gcn", "array.jl"))
 include(joinpath("gcn", "math.jl"))
 include(joinpath("gcn", "wavefront.jl"))
 include(joinpath("gcn", "indexing.jl"))

--- a/src/queue.jl
+++ b/src/queue.jl
@@ -89,6 +89,14 @@ function ROCQueue(device::ROCDevice; priority::Symbol=:normal)
     AMDGPU.hsaref!()
     finalizer(queue) do queue
         kill_queue!(queue)
+        while !trylock(RT_LOCK)
+        end
+        try
+            delete!(QUEUES, queue_ptr)
+            delete!(_active_kernels, queue)
+        finally
+            unlock(RT_LOCK)
+        end
         AMDGPU.hsaunref!()
     end
     return queue
@@ -121,7 +129,6 @@ function kill_queue!(queue::ROCQueue; force=false)
     @atomic queue.active = false
 
     lock(RT_LOCK) do
-        delete!(QUEUES, queue.queue)
         if get(DEFAULT_QUEUES, queue.device, nothing) == queue
             delete!(DEFAULT_QUEUES, queue.device)
         end
@@ -135,8 +142,6 @@ function kill_queue!(queue::ROCQueue; force=false)
                 notify(signal)
             end
         end
-
-        delete!(_active_kernels, queue)
     end
     HSA.queue_destroy(queue.queue) |> check
 

--- a/src/queue.jl
+++ b/src/queue.jl
@@ -6,7 +6,7 @@ Each queue is uniquely associated with an device.
 """
 mutable struct ROCQueue
     device::ROCDevice
-    queue::Ptr{HSA.Queue}
+    @atomic queue::Ptr{HSA.Queue}
     status::HSA.Status
     cond::Base.AsyncCondition
     @atomic active::Bool
@@ -40,7 +40,7 @@ function ROCQueue(device::ROCDevice; priority::Symbol=:normal)
     HSA.queue_create(device.agent, queue_size[], HSA.QUEUE_TYPE_MULTI,
                      @cfunction(queue_error_handler, Cvoid, (HSA.Status, Ptr{HSA.Queue}, Ptr{Cvoid})), pointer_from_objref(queue),
                      typemax(UInt32), typemax(UInt32), r_queue) |> check
-    queue.queue = r_queue[]
+    @atomic queue.queue = r_queue[]
 
     lock(RT_LOCK) do
         @assert !haskey(QUEUES, queue.queue)
@@ -123,6 +123,8 @@ end
 
 "Kills all kernels executing on the given queue, and destroys the queue."
 function kill_queue!(queue::ROCQueue; force=false)
+    #queue_ptr = @atomicswap queue.queue = Ptr{HSA.Queue}(0)
+    queue_ptr = queue.queue
     if !force && !replacefield!(queue, :active, true, false, :acquire_release, :acquire).success
         return false # We didn't destroy the queue
     end
@@ -136,14 +138,14 @@ function kill_queue!(queue::ROCQueue; force=false)
 
         # Send exception to all waiter signals
         if queue.status != HSA.STATUS_SUCCESS
-            err = QueueError(queue.queue, HSAError(queue.status))
+            err = QueueError(queue_ptr, HSAError(queue.status))
             for signal in _active_kernels[queue]
                 signal.exception = err
                 notify(signal)
             end
         end
     end
-    HSA.queue_destroy(queue.queue) |> check
+    HSA.queue_destroy(queue_ptr) |> check
 
     return true # We actually destroyed the queue
 end

--- a/test/device/array.jl
+++ b/test/device/array.jl
@@ -1,0 +1,26 @@
+@testset "ROCDeviceArray" begin
+    RA = ROCArray(rand(4,4))
+    RD = rocconvert(RA)
+    @test RD isa AMDGPU.Device.ROCDeviceMatrix
+
+    # Host indexing is disallowed
+    @test_throws Exception RD[1]
+    @test_throws Exception RD[1,1]
+    RD_view = @view RD[2:3, 2:3]
+    @test RD_view isa SubArray
+    @test_throws Exception RD_view[1]
+    @test_throws Exception RD_view[1,1]
+    RD_adj = RD'
+    @test RD_adj isa LinearAlgebra.Adjoint
+    @test_throws Exception RD_adj[1]
+    @test_throws Exception RD_adj[1,1]
+
+    # Custom show methods are defined
+    @test occursin("4×4 device array at", sprint(io->show(io, RD)))
+    @test occursin("2×2 device array view", sprint(io->show(io, RD_view)))
+    @test occursin("4×4 device array wrapper Adjoint", sprint(io->show(io, RD_adj)))
+
+    # Custom hash methods are defined
+    @test hash(RD) isa UInt # test that hashing doesn't segfault
+    @test hash(RD_view) isa UInt # test that SubArray hashing works
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,7 @@ end
 end
 @testset "Device Functions" begin
     include("device/launch.jl")
+    include("device/array.jl")
     include("device/vadd.jl")
     include("device/memory.jl")
     include("device/indexing.jl")


### PR DESCRIPTION
This automatically retries HSA allocations up to 3 times if they initially fail with an `OUT_OF_RESOURCES` code, with calls to the GC in-between to try to free up allocated objects.

@claforte @pxl-th