### PR TITLE
device: Add device_id method

### DIFF
--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -38,6 +38,15 @@ default_device_id!(idx::Integer, kind::Symbol=:gpu) =
     default_device!(devices(kind)[idx])
 
 """
+    device_id(device::ROCDevice, kind::Symbol=:gpu) -> Int
+
+Returns the numerical device ID for `device`. See [`default_device_id`](@ref)
+for details on the numbering semantics.
+"""
+device_id(device::ROCDevice, kind::Symbol=:gpu) =
+    something(findfirst(dev->dev === device, devices(kind)))
+
+"""
     device_type(device::ROCDevice) -> Symbol
 
 Return the kind of `device` as a `Symbol`. CPU devices return `:cpu`, GPU

--- a/test/hsa/device.jl
+++ b/test/hsa/device.jl
@@ -1,4 +1,13 @@
-@testset "Agent" begin
+@testset "Devices" begin
+    @testset "Device IDs" begin
+        for kind in (:cpu, :gpu)
+            devices = AMDGPU.devices()
+            for (idx,device) in enumerate(devices)
+                @test AMDGPU.device_id(device) == idx
+            end
+        end
+    end
+
     @testset "Default selection" begin
         agent = AMDGPU.default_device()
         @test agent !== nothing


### PR DESCRIPTION
For querying the device ID of a given `ROCDevice`.