### PR TITLE
Run wavefront tests with detected wavefrontsize

### DIFF
--- a/src/device.jl
+++ b/src/device.jl
@@ -145,8 +145,8 @@ function device_type(agent::HSA.Agent)
     return devtype[]
 end
 
-wavefront_size(device::ROCDevice) = wavefront_size(device.agent)
-function wavefront_size(agent::HSA.Agent)
+wavefrontsize(device::ROCDevice) = wavefrontsize(device.agent)
+function wavefrontsize(agent::HSA.Agent)
     wfsize = Ref{UInt32}()
     getinfo(agent, HSA.AGENT_INFO_WAVEFRONT_SIZE, wfsize) |> check
     return wfsize[]

--- a/src/device.jl
+++ b/src/device.jl
@@ -145,6 +145,13 @@ function device_type(agent::HSA.Agent)
     return devtype[]
 end
 
+wavefront_size(device::ROCDevice) = wavefront_size(device.agent)
+function wavefront_size(agent::HSA.Agent)
+    wfsize = Ref{UInt32}()
+    getinfo(agent, HSA.AGENT_INFO_WAVEFRONT_SIZE, wfsize) |> check
+    return wfsize[]
+end
+
 function getinfo(agent::HSA.Agent, attribute::HSA.AgentInfo,
                  value::Union{Vector,Base.RefValue,String})
     # TODO: allocation/create Refs here

--- a/test/device/wavefront.jl
+++ b/test/device/wavefront.jl
@@ -1,10 +1,5 @@
 @testset "Wavefront Operations" begin
-    wavefrontsize = Ref{UInt32}()
-    AMDGPU.HSA.LibHSARuntime.hsa_agent_get_info(
-        AMDGPU.default_device().agent,
-        AMDGPU.HSA.AGENT_INFO_WAVEFRONT_SIZE,
-        wavefrontsize
-    )
+    wavefrontsize = AMDGPU.Runtime.wavefront_size(AMDGPU.default_device())
 
     function reduce_kernel(op,X,Y)
         idx = workitemIdx().x
@@ -25,35 +20,35 @@
     end
 
     for T in (Cint, Clong, Cuint, Culong)
-        X = rand(T(1):T(100), wavefrontsize[])
+        X = rand(T(1):T(100), wavefrontsize)
         for op in (Base.:+, max, min, Base.:&, Base.:|, Base.:⊻)
             RX, RY = ROCArray(X), ROCArray(zeros(T,1))
-            wait(@roc groupsize=wavefrontsize[] reduce_kernel(op,RX,RY))
+            wait(@roc groupsize=wavefrontsize reduce_kernel(op,RX,RY))
             @test Array(RY)[1] == reduce(op,X)
 
-            RX, RY = ROCArray(X), ROCArray(zeros(T,wavefrontsize[]))
-            wait(@roc groupsize=wavefrontsize[] scan_kernel(op,RX,RY))
+            RX, RY = ROCArray(X), ROCArray(zeros(T,wavefrontsize))
+            wait(@roc groupsize=wavefrontsize scan_kernel(op,RX,RY))
             @test Array(RY) == accumulate(op,X)
         end
     end
     for T in (Float32, Float64)
-        X = rand(T, wavefrontsize[])
+        X = rand(T, wavefrontsize)
         for op in (Base.:+, max, min)
             RX, RY = ROCArray(X), ROCArray(zeros(T,1))
-            wait(@roc groupsize=wavefrontsize[] reduce_kernel(op,RX,RY))
+            wait(@roc groupsize=wavefrontsize reduce_kernel(op,RX,RY))
             @test Array(RY)[1] ≈ reduce(op,X)
 
-            RX, RY = ROCArray(X), ROCArray(zeros(T,wavefrontsize[]))
-            wait(@roc groupsize=wavefrontsize[] scan_kernel(op,RX,RY))
+            RX, RY = ROCArray(X), ROCArray(zeros(T,wavefrontsize))
+            wait(@roc groupsize=wavefrontsize scan_kernel(op,RX,RY))
             @test Array(RY) ≈ accumulate(op,X)
         end
     end
-    for X in (rand(Cint(0):Cint(1), wavefrontsize[]),
-              zeros(Cint, wavefrontsize[]),
-              ones(Cint, wavefrontsize[]),
+    for X in (rand(Cint(0):Cint(1), wavefrontsize),
+              zeros(Cint, wavefrontsize),
+              ones(Cint, wavefrontsize),
               )
         RX, RY = ROCArray(X), ROCArray(zeros(Bool,3))
-        wait(@roc groupsize=wavefrontsize[] bool_kernel(RX,RY))
+        wait(@roc groupsize=wavefrontsize bool_kernel(RX,RY))
         Y = Array(RY)
         @test_skip Y[1] == all(x->x==1,X)
         @test_skip Y[2] == any(x->x==1,X)
@@ -62,14 +57,9 @@
 end
 
 @testset "Wavefront Information" begin
-    wavefrontsize = Ref{UInt32}()
-    AMDGPU.HSA.LibHSARuntime.hsa_agent_get_info(
-        AMDGPU.default_device().agent,
-        AMDGPU.HSA.AGENT_INFO_WAVEFRONT_SIZE,
-        wavefrontsize
-    )
+    wavefrontsize = AMDGPU.Runtime.wavefront_size(AMDGPU.default_device())
 
-    @test wavefrontsize[] == 32 || wavefrontsize[] == 64
+    @test wavefrontsize == 32 || wavefrontsize == 64
 
     function kernel(X)
         X[1] = Device.wavefrontsize()
@@ -77,5 +67,5 @@ end
     end
     RX = ROCArray(zeros(UInt32, 1))
     wait(@roc kernel(RX))
-    @allowscalar @test RX[1] == wavefrontsize[]
+    @allowscalar @test RX[1] == wavefrontsize
 end

--- a/test/device/wavefront.jl
+++ b/test/device/wavefront.jl
@@ -1,5 +1,5 @@
 @testset "Wavefront Operations" begin
-    wavefrontsize = AMDGPU.Runtime.wavefront_size(AMDGPU.default_device())
+    wavefrontsize = AMDGPU.Runtime.wavefrontsize(AMDGPU.default_device())
 
     function reduce_kernel(op,X,Y)
         idx = workitemIdx().x
@@ -57,7 +57,7 @@
 end
 
 @testset "Wavefront Information" begin
-    wavefrontsize = AMDGPU.Runtime.wavefront_size(AMDGPU.default_device())
+    wavefrontsize = AMDGPU.Runtime.wavefrontsize(AMDGPU.default_device())
 
     @test wavefrontsize == 32 || wavefrontsize == 64
 

--- a/test/device/wavefront.jl
+++ b/test/device/wavefront.jl
@@ -1,4 +1,11 @@
 @testset "Wavefront Operations" begin
+    wavefrontsize = Ref{UInt32}()
+    AMDGPU.HSA.LibHSARuntime.hsa_agent_get_info(
+        AMDGPU.default_device().agent,
+        AMDGPU.HSA.AGENT_INFO_WAVEFRONT_SIZE,
+        wavefrontsize
+    )
+
     function reduce_kernel(op,X,Y)
         idx = workitemIdx().x
         Y[1] = AMDGPU.Device.wfred(op,X[idx])
@@ -18,35 +25,35 @@
     end
 
     for T in (Cint, Clong, Cuint, Culong)
-        X = rand(T(1):T(100), 64)
+        X = rand(T(1):T(100), wavefrontsize[])
         for op in (Base.:+, max, min, Base.:&, Base.:|, Base.:⊻)
             RX, RY = ROCArray(X), ROCArray(zeros(T,1))
-            wait(@roc groupsize=64 reduce_kernel(op,RX,RY))
+            wait(@roc groupsize=wavefrontsize[] reduce_kernel(op,RX,RY))
             @test Array(RY)[1] == reduce(op,X)
 
-            RX, RY = ROCArray(X), ROCArray(zeros(T,64))
-            wait(@roc groupsize=64 scan_kernel(op,RX,RY))
+            RX, RY = ROCArray(X), ROCArray(zeros(T,wavefrontsize[]))
+            wait(@roc groupsize=wavefrontsize[] scan_kernel(op,RX,RY))
             @test Array(RY) == accumulate(op,X)
         end
     end
     for T in (Float32, Float64)
-        X = rand(T, 64)
+        X = rand(T, wavefrontsize[])
         for op in (Base.:+, max, min)
             RX, RY = ROCArray(X), ROCArray(zeros(T,1))
-            wait(@roc groupsize=64 reduce_kernel(op,RX,RY))
+            wait(@roc groupsize=wavefrontsize[] reduce_kernel(op,RX,RY))
             @test Array(RY)[1] ≈ reduce(op,X)
 
-            RX, RY = ROCArray(X), ROCArray(zeros(T,64))
-            wait(@roc groupsize=64 scan_kernel(op,RX,RY))
+            RX, RY = ROCArray(X), ROCArray(zeros(T,wavefrontsize[]))
+            wait(@roc groupsize=wavefrontsize[] scan_kernel(op,RX,RY))
             @test Array(RY) ≈ accumulate(op,X)
         end
     end
-    for X in (rand(Cint(0):Cint(1), 64),
-              zeros(Cint, 64),
-              ones(Cint, 64),
+    for X in (rand(Cint(0):Cint(1), wavefrontsize[]),
+              zeros(Cint, wavefrontsize[]),
+              ones(Cint, wavefrontsize[]),
               )
         RX, RY = ROCArray(X), ROCArray(zeros(Bool,3))
-        wait(@roc groupsize=64 bool_kernel(RX,RY))
+        wait(@roc groupsize=wavefrontsize[] bool_kernel(RX,RY))
         Y = Array(RY)
         @test_skip Y[1] == all(x->x==1,X)
         @test_skip Y[2] == any(x->x==1,X)
@@ -55,11 +62,20 @@
 end
 
 @testset "Wavefront Information" begin
+    wavefrontsize = Ref{UInt32}()
+    AMDGPU.HSA.LibHSARuntime.hsa_agent_get_info(
+        AMDGPU.default_device().agent,
+        AMDGPU.HSA.AGENT_INFO_WAVEFRONT_SIZE,
+        wavefrontsize
+    )
+
+    @test wavefrontsize[] == 32 || wavefrontsize[] == 64
+
     function kernel(X)
         X[1] = Device.wavefrontsize()
         nothing
     end
     RX = ROCArray(zeros(UInt32, 1))
     wait(@roc kernel(RX))
-    @allowscalar @test RX[1] == 64
+    @allowscalar @test RX[1] == wavefrontsize[]
 end


### PR DESCRIPTION
Previously this was hardcarded to a wavefrontsize of 64, however some older cards use 32.