### PR TITLE
Ensure killqueue!() updated global QUEUES list

### DIFF
--- a/src/queue.jl
+++ b/src/queue.jl
@@ -134,6 +134,7 @@ function kill_queue!(queue::ROCQueue; force=false)
         if get(DEFAULT_QUEUES, queue.device, nothing) == queue
             delete!(DEFAULT_QUEUES, queue.device)
         end
+        delete!(QUEUES, queue.queue)
         close(queue.cond)
 
         # Send exception to all waiter signals

--- a/test/hsa/queue.jl
+++ b/test/hsa/queue.jl
@@ -7,4 +7,13 @@
         end
         @test_throws ArgumentError ROCQueue(device; priority=:fake)
     end
+
+    @testset "KillQueue cleanup" begin
+        queue = AMDGPU.default_queue()
+        AMDGPU.Runtime.kill_queue!(queue)
+
+        @test queue.active == false
+        @test haskey(AMDGPU.Runtime.QUEUES, queue.queue) == false
+        @test get(AMDGPU.Runtime.DEFAULT_QUEUES, queue.device, nothing) != queue
+    end
 end

--- a/test/hsa/queue.jl
+++ b/test/hsa/queue.jl
@@ -8,7 +8,7 @@
         @test_throws ArgumentError ROCQueue(device; priority=:fake)
     end
 
-    @testset "KillQueue cleanup" begin
+    @testset "kill_queue! cleanup" begin
         queue = AMDGPU.default_queue()
         AMDGPU.Runtime.kill_queue!(queue)
 


### PR DESCRIPTION
Previously, a call to `killqueue()` would not clean up the global `QUEUES` list. On my device, a new call to `Queue()` would reuse the same queue pointer, and this would cause `Queue()` to throw an error since it detected duplicate queue pointers in the `QUEUES` list. This was causing tests related to queues to fail.

This PR ensures `killqueue()` will clean up the `QUEUES` list.

It also adds documentation and cleanup to `kill_queues()`.