### PR TITLE
During HostCall, ensure device has finished using buffers before freeing

### DIFF
--- a/src/device/gcn/hostcall.jl
+++ b/src/device/gcn/hostcall.jl
@@ -327,15 +327,19 @@ function HostCall(func, rettype, argtypes; return_task=false,
             HSA.signal_store_screlease(signal.signal[], HOST_ERR_SENTINEL)
             rethrow(err)
         finally
-            # TODO: This is probably a bad idea to free while the kernel might
-            # still hold a reference. We should probably have some way to
-            # reference count these buffers from kernels (other than just
-            # using a ROCArray, which can't currently be serialized to the
-            # GPU).
-            if isassigned(ret_buf)
-                Mem.free(ret_buf[])
+            # We need to free the memory buffers, but first we need to ensure that
+            # the device has read from these buffers. Therefore we wait either for
+            # READY_SENTINEL or else an error signal.
+            while !Runtime.RT_EXITING[]
+                prev = HSA.signal_load_scacquire(signal.signal[])
+
+                if prev == READY_SENTINEL || prev == HOST_ERR_SENTINEL || prev == DEVICE_ERR_SENTINEL
+                    Mem.free(ret_buf[])
+                    Mem.free(Mem.Buffer(reinterpret(Ptr{Cvoid}, hc.buf_ptr), C_NULL, 0, device, true, false))
+                    break
+                end
             end
-            Mem.free(Mem.Buffer(reinterpret(Ptr{Cvoid}, hc.buf_ptr), C_NULL, 0, device, true, false))
+
         end
     end
 

--- a/test/device/hostcall.jl
+++ b/test/device/hostcall.jl
@@ -24,7 +24,6 @@ import AMDGPU: HostCall, hostcall!
     wait(@roc kernel(RA, RB, hc))
 
     @test Array(RB)[1] == 1f0
-    sleep(1)
     @test dref[] == true
 end
 
@@ -52,7 +51,6 @@ end
         end
 
         @test_throws Runtime.KernelException wait(@roc kernel(RA, RB, hc))
-        sleep(1)
 
         empty!(RB.syncstate.signals)
         @test Array(RB)[1] == 0f0
@@ -80,7 +78,6 @@ end
 
     wait(@roc kernel(RA, RB, hc))
 
-    sleep(1)
     @test Array(RB)[1] == 2f0
 end
 
@@ -103,7 +100,6 @@ end
 
     wait(@roc kernel(RA, RB, hc))
 
-    sleep(1)
     @test Array(RB)[1] == 44f0
 end
 
@@ -126,7 +122,6 @@ end
 
     wait(@roc kernel(RA, RB, hc))
 
-    sleep(1)
     @test Array(RB)[1] == 47f0
 end
 
@@ -149,7 +144,6 @@ end
 
     wait(@roc kernel(RA, RB, hc))
 
-    sleep(1)
     @test Array(RB)[1] == 47f0
 end
 
@@ -172,7 +166,6 @@ end
 
     wait(@roc kernel(RA, RB, hc))
 
-    sleep(1)
     @test Array(RB)[1] == 48f0
 end
 
@@ -195,7 +188,6 @@ end
 
     wait(@roc kernel(RA, RB, hc))
 
-    sleep(1)
     @test Array(RB)[1] == 48f0
 end
 
@@ -244,7 +236,6 @@ end
     wait(@roc kernel(RA, RB, hc))
     wait(@roc kernel(RA, RB, hc))
 
-    sleep(1)
     @test Array(RB)[1] == 5f0
 end
 


### PR DESCRIPTION
As was warned in the comments in `device/gc/hostcall.jl`, these `free()` operations were indeed dangerous: I was seeing irregular but routine segfualts when running the tests that were a result of freeing too early.

This `HostCall()` code rather confusing to me, but I think (??) I've done the right thing here by requiring the signal to shift from `HOST_MSG_SENTINEL` to either an OK or ERROR code by the device. At least, I can no longer reproduce the segfaults!

I've also removed the calls to `sleep(1)` in the tests, which I assume were a mitigation against these race conditions.