### PR TITLE
Remove code that duplicates AbstractFFTs; add tests for casting

### DIFF
--- a/src/fft/fft.jl
+++ b/src/fft/fft.jl
@@ -224,20 +224,6 @@ function create_plan(xtype::rocfft_transform_type, xdims, T, inplace, region)
     return handle_ref[], workarea
 end
 
-# promote to a complex floating-point type (out-of-place only),
-# so implementations only need Complex{Float} methods
-for f in (:fft, :bfft, :ifft)
-    pf = Symbol("plan_", f)
-    @eval begin
-        $f(x::ROCArray{<:Real}, region=1:ndims(x)) = $f(complexfloat(x), region)
-        $pf(x::ROCArray{<:Real}, region) = $pf(complexfloat(x), region)
-        $f(x::ROCArray{<:Complex{<:Union{Integer,Rational}}}, region=1:ndims(x)) = $f(complexfloat(x), region)
-        $pf(x::ROCArray{<:Complex{<:Union{Integer,Rational}}}, region) = $pf(complexfloat(x), region)
-    end
-end
-rfft(x::ROCArray{<:Union{Integer,Rational}}, region=1:ndims(x)) = rfft(realfloat(x), region)
-plan_rfft(x::ROCArray{<:Real}, region) = plan_rfft(realfloat(x), region)
-
 # inplace/notinplace complex
 for (f,xtype,inplace,forward) in ((:plan_fft!, :rocfft_transform_type_complex_forward, :true, :true),
                           (:plan_bfft!, :rocfft_transform_type_complex_inverse, :true, :false),

--- a/src/fft/util.jl
+++ b/src/fft/util.jl
@@ -1,19 +1,2 @@
 const rocfftComplexes = Union{ComplexF32, ComplexF64}
 const rocfftReals = Union{Float32, Float64}
-
-rocfftfloat(::Type{T}) where {T} = error("type $T not supported")
-rocfftfloat(::Type{Float16}) = FLoat32
-rocfftfloat(::Type{T}) where {T<:rocfftReals} = T
-rocfftfloat(::Type{Complex{T}}) where {T} = Complex{rocfftfloat(T)}
-
-complexfloat(x::ROCArray{Complex{T}}) where {T<:rocfftReals} = x
-complexfloat(x::ROCArray{T}) where {T<:Complex} = copy1(rocfftfloat(T), x)
-complexfloat(x::ROCArray{T}) where {T<:Real} = copy1(complex(rocfftfloat(T)), x)
-
-realfloat(x::ROCArray{T}) where {T<:Real} = copy1(rocfftfloat(T), x)
-
-# TODO: use undef alloco
-function copy1(::Type{T}, x) where T
-    y = ROCArray(T, map(length, axes(x)))
-    y .= broadcast(xi->convert(T,xi), x)
-end

--- a/test/rocarray/fft.jl
+++ b/test/rocarray/fft.jl
@@ -246,7 +246,7 @@ end
 
 end
 
-@testset "Casted types" begin
+@testset "Promoted types" begin
     @testset for T in (Float32, Float64)
         X = rand(T, 10, 10)
         d_X = ROCArray(X)

--- a/test/rocarray/fft.jl
+++ b/test/rocarray/fft.jl
@@ -245,4 +245,42 @@ end
 end
 
 end
+
+@testset "Casted types" begin
+    @testset for T in (Float32, Float64)
+        X = rand(T, 10, 10)
+        d_X = ROCArray(X)
+
+        Y = fft(X)
+        d_Y = fft(d_X)
+        @test isapprox(collect(d_Y), Y, rtol=MYRTOL, atol=MYATOL)
+
+        Y = ifft(X)
+        d_Y = ifft(d_X)
+        @test isapprox(collect(d_Y), Y, rtol=MYRTOL, atol=MYATOL)
+    end
+
+    @testset "Complex{Int}" begin
+        X = rand(Complex{Int}, 10, 10)
+        d_X = ROCArray(X)
+
+        Y = fft(X)
+        d_Y = fft(d_X)
+        @test isapprox(collect(d_Y), Y, rtol=MYRTOL, atol=MYATOL)
+
+        Y = ifft(X)
+        d_Y = ifft(d_X)
+        @test isapprox(collect(d_Y), Y, rtol=MYRTOL, atol=MYATOL)
+    end
+
+    @testset "Int" begin
+        X = rand(Int, 10, 10)
+        d_X = ROCArray(X)
+
+        Y = rfft(X)
+        d_Y = rfft(d_X)
+        @test isapprox(collect(d_Y), Y, rtol=MYRTOL, atol=MYATOL)
+    end
+end
+
 end # testset FFT


### PR DESCRIPTION
This code is duplicated from AbstractFFTs; no need to copy it. (Additionally, `Float16` was misspelled as `FLoat16`.)

Add tests for casting to complex floats for FFTs, and for handing Integer inputs.

Note: Float16 is not tested as the casting is broken upstream in AbstractFFTs.