### PR TITLE
tests: Execute GPUArrays testsuite later

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,9 +86,6 @@ end
 @testset "ROCArray" begin
     include("rocarray/base.jl")
     include("rocarray/broadcast.jl")
-    @testset "GPUArrays test suite" begin
-        TestSuite.test(ROCArray)
-    end
     @testset "ROCm External Libraries" begin
         if CI
             @test AMDGPU.functional(:rocblas)
@@ -118,6 +115,9 @@ end
         else
             @test_skip "NMF"
         end
+    end
+    @testset "GPUArrays test suite" begin
+        TestSuite.test(ROCArray)
     end
 end
 @testset "External Packages" begin


### PR DESCRIPTION
Moves the GPUArrays testsuite to run after we've tested our ROCm libraries (rocBLAS et. al). In the absence of a parallel test runner, and with total test time being over 3 hours, this is a temporary band-aid to ensure that we can test changes to our ROCm library bindings with the current CI setup.