### PR TITLE
Fix precompilation

### DIFF
--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -226,9 +226,6 @@ function __init__()
         else
             @warn "HSA initialization failed with code $status"
         end
-
-        # Detect HSA version
-        @eval const libhsaruntime_version = hsa_version()
     else
         @warn """
         HSA runtime is unavailable, compilation and runtime functionality will be disabled.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -15,7 +15,7 @@ function versioninfo(io::IO=stdout)
     println("HSA Runtime ($(functional(:hsa) ? "ready" : "MISSING"))")
     if functional(:hsa)
         println("- Path: $libhsaruntime_path")
-        println("- Version: $libhsaruntime_version")
+        println("- Version: $(hsa_version())")
         #println("- Initialized: $(repr(HSA_REFCOUNT[] > 0))")
     end
     println("ld.lld ($(functional(:lld) ? "ready" : "MISSING"))")


### PR DESCRIPTION
On Julia 1.9 when using AMDGPU & ROCKernels in another project, ROCKernels fails to precompile (see error below). Specifically, it complains at `src/AMDGPU.jl:231`.

We can use `hsa_version()` function directly instead of storing it in the variable during `__init__`. I didn't see `libhsaruntime_version` being used anywhere else.

```
Precompiling project...
  ✗ ROCKernels
  ✗ INGP
  1 dependency successfully precompiled in 14 seconds. 184 already precompiled.

ERROR: The following 2 direct dependencies failed to precompile:

INGP [3003bbbd-5e0c-4496-81c4-ba6063c314ae]

Failed to precompile INGP [3003bbbd-5e0c-4496-81c4-ba6063c314ae] to /home/pxl-th/.julia/compiled/v1.9/INGP/jl_Lzl3vl.
ERROR: LoadError: InitError: Evaluation into the closed module `AMDGPU` breaks incremental compilation because the side effects will not be permanent. This is likely due to some other module mutating `AMDGPU` with `eval` during precompilation - don't do this.
Stacktrace:
  [1] eval
    @ ./boot.jl:370 [inlined]
  [2] __init__()
    @ AMDGPU ~/.julia/dev/AMDGPU/src/AMDGPU.jl:231
  [3] _include_from_serialized(pkg::Base.PkgId, path::String, depmods::Vector{Any})
    @ Base ./loading.jl:928
  [4] _require_search_from_serialized(pkg::Base.PkgId, sourcepath::String, build_id::UInt64)
    @ Base ./loading.jl:1136
  [5] _require(pkg::Base.PkgId, env::String)
    @ Base ./loading.jl:1412
  [6] _require_prelocked(uuidkey::Base.PkgId, env::String)
    @ Base ./loading.jl:1298
  [7] macro expansion
    @ ./loading.jl:1278 [inlined]
  [8] macro expansion
    @ ./lock.jl:267 [inlined]
  [9] require(into::Module, mod::Symbol)
    @ Base ./loading.jl:1241
 [10] top-level scope
    @ ~/code/INGP.jl/src/INGP.jl:51
 [11] include
    @ ./Base.jl:439 [inlined]
 [12] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt64}}, source::Nothing)
    @ Base ./loading.jl:1651
 [13] top-level scope
    @ stdin:1
during initialization of module AMDGPU
in expression starting at /home/pxl-th/code/INGP.jl/src/INGP.jl:1
in expression starting at stdin:1

ROCKernels [7eb9e9f0-4bd3-4c4c-8bef-26bd9629d9b9]
```