### PR TITLE
Fix several device tests

### DIFF
--- a/test/device/queries.jl
+++ b/test/device/queries.jl
@@ -1,11 +1,11 @@
 @testset "Active kernels" begin
     function kernel(sig)
-        hostcall!(sig)
+        AMDGPU.Device.hostcall!(sig)
         nothing
     end
 
     wait_ev = Base.Event()
-    hc = HostCall(Nothing, Tuple{}) do
+    hc = AMDGPU.Device.HostCall(Nothing, Tuple{}) do
         wait(wait_ev)
     end
 


### PR DESCRIPTION
- Use actual wavefront size instead of assumed 64 in output tests.
It basically changes how target message is computed.
On RX6700 xt wavefront size is 32, so these tests were failing.
- Prepend hostcalls with `AMDGPU.Device.`.