### PR TITLE
Do not rethrow EOF

### DIFF
--- a/src/device/gcn/hostcall.jl
+++ b/src/device/gcn/hostcall.jl
@@ -375,9 +375,13 @@ function HostCall(func, rettype, argtypes; return_task=false,
             end
         catch err
             # Gracefully terminate all waiters
-            @error "HostCall error" exception=(err,catch_backtrace())
             HSA.signal_store_screlease(signal.signal[], HOST_ERR_SENTINEL)
-            rethrow(err)
+            if err isa EOFError
+                # If EOF, then Julia is exiting. Do not rethrow.
+            else
+                @error "HostCall error" exception=(err,catch_backtrace())
+                rethrow(err)
+            end
         finally
             # We need to free the memory buffers, but first we need to ensure that
             # the device has read from these buffers. Therefore we wait either for

--- a/test/hsa/error.jl
+++ b/test/hsa/error.jl
@@ -5,5 +5,5 @@ end
 
 @testset "HSA Async Queue Error" begin
     kernel() = (Device.trap(); nothing)
-    @test_throws Runtime.SignalTimeoutException wait(@roc kernel())
+    @test_throws Runtime.QueueError wait(@roc kernel())
 end

--- a/test/hsa/error.jl
+++ b/test/hsa/error.jl
@@ -5,5 +5,5 @@ end
 
 @testset "HSA Async Queue Error" begin
     kernel() = (Device.trap(); nothing)
-    @test_throws Runtime.QueueError wait(@roc kernel())
+    @test_throws Runtime.SignalTimeoutException wait(@roc kernel())
 end


### PR DESCRIPTION
- Do not rethrow `EOFError`.
This happens when Julia process is exiting, but hostcalls are sleeping.

This gets rid of confusing error messages at the end of program execution:
```
┌ Error: HostCall error
│   exception =
│    EOFError: read end of file
│    Stacktrace:
│     [1] wait
│       @ ./asyncevent.jl:155 [inlined]
│     [2] sleep(sec::Float64)
│       @ Base ./asyncevent.jl:240
│     [3] hostcall_host_wait(signal::ROCSignal; maxlat::Float64, timeout::Nothing)
│       @ AMDGPU.Device ~/.julia/dev/AMDGPU/src/device/gcn/hostcall.jl:441
│     [4] macro expansion
│       @ ~/.julia/dev/AMDGPU/src/device/gcn/hostcall.jl:325 [inlined]
│     [5] (::AMDGPU.Device.var"#90#91"{ROCDevice, Float64, Nothing, Bool, AMDGPU.Compiler.var"#43#47", DataType, DataType, AMDGPU.Device.HostCall{UInt64, Int64, Tuple{Core.LLVMPtr{UInt8, 1}}}, ROCSignal})()
│       @ AMDGPU.Device ./threadingconstructs.jl:322
└ @ AMDGPU.Device ~/.julia/dev/AMDGPU/src/device/gcn/hostcall.jl:378
```

- Change `QueueError` to `SignalTimeoutException` in HSA error test. @jpsamaroo, without timeout that kernel never ends. So I think this is the error to check for.