### PR TITLE
Use correct queue for kernels

### DIFF
--- a/src/execution.jl
+++ b/src/execution.jl
@@ -67,7 +67,7 @@ end
 
 @inline function roccall(kernel::HostKernel, tt, args...; config=nothing, signal, device=nothing, kwargs...)
     device = something(device, AMDGPU.default_device())
-    queue = get(kwargs, :queue, AMDGPU.default_queue(device))
+    queue = signal.queue
     if config !== nothing
         roccall(kernel.fun, tt, args...; kwargs..., config(kernel)..., queue, signal)
     else

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -361,8 +361,6 @@ macro roc(ex...)
         # convert the function, its arguments, call the compiler and launch the kernel
         # while keeping the original arguments alive
 
-        call_kwargs_signal = [filter(x->x.args[1] != :signal, call_kwargs)...,
-                              Expr(:(=), :signal, signal)]
         push!(code.args,
             quote
                 GC.@preserve $(vars...) begin
@@ -376,7 +374,7 @@ macro roc(ex...)
                     if $launch
                         local $kernel_instance = $create_kernel($kernel, $kernel_f, $kernel_args)
                         local $signal = $create_event($kernel_instance; $(signal_kwargs...))
-                        $kernel($kernel_args...; $(call_kwargs_signal...))
+                        $kernel($kernel_args...; signal=$signal, $(call_kwargs...))
                         if $mark
                             foreach(x->$mark!(x, $signal), ($(var_exprs...),))
                         end

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -160,9 +160,9 @@ rocconvert(arg) = adapt(Runtime.Adaptor(), arg)
 function split_kwargs(kwargs)
     alias_kws    = Dict(:stream=>:queue)
     macro_kws    = [:dynamic, :launch, :wait, :mark]
-    compiler_kws = [:name, :device, :queue, :global_hooks]
-    call_kws     = [:gridsize, :groupsize, :config, :device, :queue]
-    signal_kws   = [:signal, :soft, :minlat, :timeout]
+    compiler_kws = [:name, :device, :global_hooks]
+    call_kws     = [:gridsize, :groupsize, :config, :device]
+    signal_kws   = [:queue, :signal, :soft, :minlat, :timeout]
     computed_kws = [:threads, :blocks]
 
     macro_kwargs = []
@@ -250,7 +250,7 @@ function assign_args!(code, args)
     # convert the arguments, compile the function and call the kernel
     # while keeping the original arguments alive
     var_exprs = map(vars, args, splats) do var, arg, splat
-         splat ? Expr(:(...), var) : var
+        splat ? Expr(:(...), var) : var
     end
 
     return vars, var_exprs

--- a/test/device/launch.jl
+++ b/test/device/launch.jl
@@ -37,6 +37,11 @@
     eval(:(@roc queue=$queue $kernel()))
     eval(:(@roc stream=$queue $kernel()))
 
+    # Non-default queue
+    queue2 = ROCQueue()
+    sig = @roc queue=queue2 kernel()
+    @test sig.queue === queue2
+
     # Group size validity
     @test_throws ArgumentError eval(:(@roc groupsize=0 $kernel()))
     eval(:(@roc groupsize=1024 $kernel()))
@@ -93,6 +98,7 @@ end
     wait(sig)
     wait(sig.signal)
     wait(sig.signal.signal[])
+    @test sig.queue === AMDGPU.default_queue()
 end
 
 @testset "Custom signal" begin


### PR DESCRIPTION
In [`macro roc`](https://github.com/JuliaGPU/AMDGPU.jl/blob/c85bc0a2ef0b9a939016a71e201c0ded0d1f58c1/src/highlevel.jl#L313) `signal_kwargs` does not contain `queue` argument, which leads to usage of the default queue in [`create_event`](https://github.com/JuliaGPU/AMDGPU.jl/blob/c85bc0a2ef0b9a939016a71e201c0ded0d1f58c1/src/highlevel.jl#L106) thus making `queue` args basically useless.

To fix this I added `:queue` to `signal_kwargs` and use signal's queue when calling kernels.
`:queue` in `compiler_kwargs` and `call_kwargs` is thus not needed.