### PR TITLE
Implement kernel hashing system

### DIFF
--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -61,6 +61,7 @@ module Runtime
         include("memory.jl")
     end
     include("executable.jl")
+    include("hashing.jl")
     include("kernel.jl")
     include("kernel-signal.jl")
     include("launch.jl")

--- a/src/device/gcn/array.jl
+++ b/src/device/gcn/array.jl
@@ -90,15 +90,8 @@ Base.IndexStyle(::Type{<:ROCDeviceArray}) = Base.IndexLinear()
 
 # comparisons
 
-Base.hash(a::R, h::UInt) where R<:ROCDeviceArray =
-    hash(a.shape, hash(a.ptr, hash(R, h)))
 Base.isequal(a1::R1, a2::R2) where {R1<:ROCDeviceArray,R2<:ROCDeviceArray} =
     R1 == R2 && a1.shape == a2.shape && a1.ptr == a2.ptr
-
-Base.hash(a::S, h::UInt) where S<:SubArray{<:Any, <:Any, <:ROCDeviceArray, <:Any, <:Any} =
-    hash(a.indices, hash(parent(a), hash(S, h)))
-Base.hash(a::S, h::UInt) where S<:AnyROCDeviceArray =
-    hash(parent(a), hash(S, h))
 
 # other
 

--- a/src/hashing.jl
+++ b/src/hashing.jl
@@ -1,0 +1,23 @@
+# Kernel argument hashing
+
+## Arguments which are written to the kernarg buffer identically should have
+## the same khash value. Array contents are not hashed; instead, we hash the
+## array pointer.
+
+function khash(x::T, h::UInt=UInt(0)) where T
+    # Generic hashing
+    h = khash(T, h)
+    if isstructtype(T)
+        for idx in 1:fieldcount(T)
+            name = fieldname(T, idx)
+            h = khash(getfield(x, name), h)
+        end
+    elseif isprimitivetype(T)
+        h = hash(x, h)
+    else
+        error("Can't hash: $T")
+    end
+    return h
+end
+khash(::Type{T}, h::UInt=UInt(0)) where T = hash(T, h)
+khash(x::Symbol, h::UInt=UInt(0)) = hash(x, h)

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -99,7 +99,7 @@ function ROCKernel(kernel, f::Core.Function, args::Tuple)
             private_segment_size) |> check
 
     # Allocate the kernel argument buffer
-    key = hash(f, hash(args))
+    key = khash(f, khash(args))
     kernarg_address, do_write = Mem.alloc_pooled(device, key, :kernarg, kernarg_segment_size[])
 
     if do_write

--- a/test/hsa/hashing.jl
+++ b/test/hsa/hashing.jl
@@ -1,0 +1,100 @@
+@testset "Kernel Argument Hashing" begin
+    khash = AMDGPU.Runtime.khash
+
+    @testset "Primitives" begin
+        x = UInt8(1)
+        y = UInt8(2)
+
+        @test khash(x) == khash(x)
+        @test khash(y) == khash(y)
+        @test khash(x) != khash(y)
+
+        @test khash(x, UInt(1)) == khash(x, UInt(1))
+        @test khash(y, UInt(1)) == khash(y, UInt(1))
+        @test khash(x, UInt(1)) != khash(y, UInt(1))
+
+        @test khash(x, UInt(1)) != khash(x, UInt(2))
+        @test khash(y, UInt(1)) != khash(y, UInt(2))
+        @test khash(x, UInt(1)) != khash(y, UInt(2))
+
+        for T in [UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64, Float32, Float64]
+            xc = convert(T, x)
+            yc = convert(T, y)
+            @test khash(xc) == khash(xc)
+            @test khash(yc) == khash(yc)
+            @test khash(xc) != khash(yc)
+
+            @test khash(xc, UInt(1)) == khash(xc, UInt(1))
+            @test khash(yc, UInt(1)) == khash(yc, UInt(1))
+            @test khash(xc, UInt(1)) != khash(yc, UInt(1))
+
+            @test khash(xc, UInt(1)) != khash(xc, UInt(2))
+            @test khash(yc, UInt(1)) != khash(yc, UInt(2))
+            @test khash(xc, UInt(1)) != khash(yc, UInt(2))
+        end
+    end
+
+    @testset "Tuples" begin
+        z1 = (UInt8(1), UInt8(2), UInt8(3))
+        z2 = (UInt8(1), UInt8(2), UInt8(4))
+        z3 = (UInt8(1), UInt8(2), UInt16(3))
+
+        @test khash(z1) == khash(z1)
+        @test khash(z1, UInt(1)) == khash(z1, UInt(1))
+        @test khash(z1, UInt(1)) != khash(z1, UInt(2))
+
+        @test khash(z1) != khash(z2)
+        @test khash(z1, UInt(1)) != khash(z2, UInt(1))
+
+        @test khash(z1) != khash(z3)
+        @test khash(z1, UInt(1)) != khash(z3, UInt(1))
+    end
+
+    @testset "Functions" begin
+        @test khash(+) == khash(+)
+        @test khash(+, UInt(1)) == khash(+, UInt(1))
+        @test khash(+, UInt(1)) != khash(+, UInt(2))
+        @test khash(+) != khash(-) != khash(/) != khash(identity)
+
+        x = 1
+        f() = x
+        @test khash(f) == khash(f)
+        @test khash(f, UInt(1)) == khash(f, UInt(1))
+
+        g() = x
+        @test khash(f) != khash(g)
+        @test khash(f, UInt(1)) != khash(g, UInt(1))
+    end
+
+    @testset "ROCDeviceArray" begin
+        RA = ROCArray(rand(4))
+        DA = rocconvert(RA)
+
+        @test khash(DA) == khash(DA)
+        @test khash(DA, UInt(1)) == khash(DA, UInt(1))
+        @test khash(DA, UInt(1)) != khash(DA, UInt(2))
+
+        A_hash = khash(DA)
+        RA .= RA .+ 1
+        @test khash(DA) == A_hash
+
+        RB = copy(RA)
+        DB = rocconvert(RB)
+
+        @test khash(RA) != khash(RB)
+    end
+
+    @testset "ROCDeviceArray wrappers" begin
+        RC = ROCArray(rand(4, 4))
+        DC = rocconvert(RC)
+        RCv = @view RC[2:3, 2:3]
+        DCv = rocconvert(RCv)
+
+        @test khash(DC) != khash(DCv)
+        @test khash(DC, UInt(1)) != khash(DCv, UInt(1))
+
+        @test khash(DCv) == khash(DCv)
+        @test khash(DCv, UInt(1)) == khash(DCv, UInt(1))
+        @test khash(DCv, UInt(1)) != khash(DCv, UInt(2))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,7 @@ push!(tests, "HSA" => ()->begin
     include("hsa/device.jl")
     include("hsa/queue.jl")
     include("hsa/memory.jl")
+    include("hsa/hashing.jl")
 end)
 push!(tests, "Codegen" => ()->begin
     include("codegen/synchronization.jl")


### PR DESCRIPTION
Switches kernarg argument hashing from `Base.hash` to custom `khash` implementation, which doesn't attempt to hash array contents. This implementation hashes mainly on argument types and array pointers, ensuring that two identical `ROCDeviceArray` objects (pointing to the same memory) hash to identical values.