### PR TITLE
Update bindeps search path

### DIFF
--- a/deps/bindeps.jl
+++ b/deps/bindeps.jl
@@ -18,6 +18,9 @@ function find_roc_paths()
     paths = filter(path->path != "", paths)
     paths = map(Base.Filesystem.abspath, paths)
     push!(paths, "/opt/rocm/lib") # shim for Ubuntu rocm packages...
+    if haskey(ENV, "ROCM_PATH")
+        push!(paths, joinpath(ENV["ROCM_PATH"], "lib"))
+    end
     paths = filter(isdir, paths)
     @debug "bindeps: ROCm library search paths:"
     for path in paths


### PR DESCRIPTION
Update the binders code to also search for `ROCM_PATH` as suggested by @jpsamaroo . This is needed to build AMDGPU using system libs on LUMI with Julia 1.8.2.