### PR TITLE
Prioritise ENV var to use or not artifacts

### DIFF
--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -182,6 +182,17 @@ function __init__()
         Runtime.RT_EXITING[] = true
     end
 
+    if haskey(ENV, "JULIA_AMDGPU_DISABLE_ARTIFACTS")
+        env_use_artifacts = !parse(Bool, get(ENV, "JULIA_AMDGPU_DISABLE_ARTIFACTS", "false"))
+        if use_artifacts != env_use_artifacts
+            enable_artifacts!(env_use_artifacts)
+            @warn """
+            The environment variable JULIA_AMDGPU_DISABLE_ARTIFACTS does not match the value from preferences.
+            Forcing the preferences value to $(env_use_artifacts); please restart Julia for changes to take effect.
+            """
+        end
+    end
+
     # Quiet path first, in case this system doesn't have AMD GPUs
     if !ispath("/dev/kfd")
         @debug "/dev/kfd not available, silently skipping initialization"


### PR DESCRIPTION
Enforce following behaviour to decide whether to use artifact:
Allows `ENV` var to set LocalPreferences. If value mismatch, `ENV` var will override LocalPreferences value with warning. 