### PR TITLE
Fix GEMM (regular & batched) and support batched GEMM for 3D array

### DIFF
--- a/src/blas/librocblas.jl
+++ b/src/blas/librocblas.jl
@@ -137,6 +137,26 @@ function rocblas_sgemv(handle, trans::rocblas_operation_t, m::rocblas_int, n::ro
     end
 end
 
+function rocblas_sgemm(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+    @check ccall((:rocblas_sgemm, librocblas), rocblas_status_t, (rocblas_handle, rocblas_operation_t, rocblas_operation_t, rocblas_int, rocblas_int, rocblas_int, Ptr{Cfloat}, Ptr{Cfloat}, rocblas_int, Ptr{Cfloat}, rocblas_int, Ptr{Cfloat}, Ptr{Cfloat}, rocblas_int), handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function rocblas_dgemm(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+    @check ccall((:rocblas_dgemm, librocblas), rocblas_status_t, (rocblas_handle, rocblas_operation_t, rocblas_operation_t, rocblas_int, rocblas_int, rocblas_int, Ptr{Cdouble}, Ptr{Cdouble}, rocblas_int, Ptr{Cdouble}, rocblas_int, Ptr{Cdouble}, Ptr{Cdouble}, rocblas_int), handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function rocblas_hgemm(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+    @check ccall((:rocblas_hgemm, librocblas), rocblas_status_t, (rocblas_handle, rocblas_operation_t, rocblas_operation_t, rocblas_int, rocblas_int, rocblas_int, Ptr{rocblas_half}, Ptr{rocblas_half}, rocblas_int, Ptr{rocblas_half}, rocblas_int, Ptr{rocblas_half}, Ptr{rocblas_half}, rocblas_int), handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function rocblas_cgemm(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+    @check ccall((:rocblas_cgemm, librocblas), rocblas_status_t, (rocblas_handle, rocblas_operation_t, rocblas_operation_t, rocblas_int, rocblas_int, rocblas_int, Ptr{rocblas_float_complex}, Ptr{rocblas_float_complex}, rocblas_int, Ptr{rocblas_float_complex}, rocblas_int, Ptr{rocblas_float_complex}, Ptr{rocblas_float_complex}, rocblas_int), handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
+function rocblas_zgemm(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+    @check ccall((:rocblas_zgemm, librocblas), rocblas_status_t, (rocblas_handle, rocblas_operation_t, rocblas_operation_t, rocblas_int, rocblas_int, rocblas_int, Ptr{rocblas_double_complex}, Ptr{rocblas_double_complex}, rocblas_int, Ptr{rocblas_double_complex}, rocblas_int, Ptr{rocblas_double_complex}, Ptr{rocblas_double_complex}, rocblas_int), handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
+end
+
 function rocblas_sgemm_batched(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc, batch_count)
     @check ccall((:rocblas_sgemm_batched, librocblas), rocblas_status_t, (rocblas_handle, rocblas_operation_t, rocblas_operation_t, rocblas_int, rocblas_int, rocblas_int, Ptr{Cfloat}, Ptr{Ptr{Cfloat}}, rocblas_int, Ptr{Ptr{Cfloat}}, rocblas_int, Ptr{Cfloat}, Ptr{Ptr{Cfloat}}, rocblas_int, rocblas_int), handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc, batch_count)
 end

--- a/src/blas/librocblas.jl
+++ b/src/blas/librocblas.jl
@@ -136,3 +136,23 @@ function rocblas_sgemv(handle, trans::rocblas_operation_t, m::rocblas_int, n::ro
                      handle, trans, m, n, ref_alpha, pointer(A), lda, pointer(x), incx, ref_beta, pointer(y), incy)
     end
 end
+
+function rocblas_sgemm_batched(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc, batch_count)
+    @check ccall((:rocblas_sgemm_batched, librocblas), rocblas_status_t, (rocblas_handle, rocblas_operation_t, rocblas_operation_t, rocblas_int, rocblas_int, rocblas_int, Ptr{Cfloat}, Ptr{Ptr{Cfloat}}, rocblas_int, Ptr{Ptr{Cfloat}}, rocblas_int, Ptr{Cfloat}, Ptr{Ptr{Cfloat}}, rocblas_int, rocblas_int), handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc, batch_count)
+end
+
+function rocblas_dgemm_batched(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc, batch_count)
+    @check ccall((:rocblas_dgemm_batched, librocblas), rocblas_status_t, (rocblas_handle, rocblas_operation_t, rocblas_operation_t, rocblas_int, rocblas_int, rocblas_int, Ptr{Cdouble}, Ptr{Ptr{Cdouble}}, rocblas_int, Ptr{Ptr{Cdouble}}, rocblas_int, Ptr{Cdouble}, Ptr{Ptr{Cdouble}}, rocblas_int, rocblas_int), handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc, batch_count)
+end
+
+function rocblas_hgemm_batched(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc, batch_count)
+    @check ccall((:rocblas_hgemm_batched, librocblas), rocblas_status_t, (rocblas_handle, rocblas_operation_t, rocblas_operation_t, rocblas_int, rocblas_int, rocblas_int, Ptr{rocblas_half}, Ptr{Ptr{rocblas_half}}, rocblas_int, Ptr{Ptr{rocblas_half}}, rocblas_int, Ptr{rocblas_half}, Ptr{Ptr{rocblas_half}}, rocblas_int, rocblas_int), handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc, batch_count)
+end
+
+function rocblas_cgemm_batched(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc, batch_count)
+    @check ccall((:rocblas_cgemm_batched, librocblas), rocblas_status_t, (rocblas_handle, rocblas_operation_t, rocblas_operation_t, rocblas_int, rocblas_int, rocblas_int, Ptr{rocblas_float_complex}, Ptr{Ptr{rocblas_float_complex}}, rocblas_int, Ptr{Ptr{rocblas_float_complex}}, rocblas_int, Ptr{rocblas_float_complex}, Ptr{Ptr{rocblas_float_complex}}, rocblas_int, rocblas_int), handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc, batch_count)
+end
+
+function rocblas_zgemm_batched(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc, batch_count)
+    @check ccall((:rocblas_zgemm_batched, librocblas), rocblas_status_t, (rocblas_handle, rocblas_operation_t, rocblas_operation_t, rocblas_int, rocblas_int, rocblas_int, Ptr{rocblas_double_complex}, Ptr{Ptr{rocblas_double_complex}}, rocblas_int, Ptr{Ptr{rocblas_double_complex}}, rocblas_int, Ptr{rocblas_double_complex}, Ptr{Ptr{rocblas_double_complex}}, rocblas_int, rocblas_int), handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc, batch_count)
+end

--- a/src/blas/librocblas_types.jl
+++ b/src/blas/librocblas_types.jl
@@ -9,7 +9,7 @@ const rocblas_int = Int32
 const rocblas_long = Int64
 const rocblas_float_complex = ComplexF32
 const rocblas_double_complex = ComplexF64
-const rocblas_half = Int16
+const rocblas_half = Float16
 const rocblas_half_complex = ComplexF32 # wtf???
 const rocblas_handle = Ptr{Nothing}
 

--- a/src/blas/wrappers.jl
+++ b/src/blas/wrappers.jl
@@ -922,7 +922,7 @@ for (fname, elty) in
             $(fname)(
                 handle(), rocblasop(transA), rocblasop(transB),
                 m, n, k, Ref(alpha), A, lda, B, ldb, Ref(beta), C, ldc)
-            mark!((A,B,C),rocblas_get_stream(handle()))
+            mark!((A, B, C),rocblas_get_stream(handle()))
             C
         end
         function gemm(transA::Char,

--- a/src/blas/wrappers.jl
+++ b/src/blas/wrappers.jl
@@ -958,81 +958,161 @@ end
 
 # helper function to get a device array of device pointers
 function device_batch(batch::Array{T}) where {T<:ROCArray}
-  E = eltype(T)
-  ptrs = [Base.unsafe_convert(Ptr{E}, arr.buf) for arr in batch]
-  ROCArray(ptrs)
+    E = eltype(T)
+    ptrs = [Base.unsafe_convert(Ptr{E}, arr.buf) for arr in batch]
+    ROCArray(ptrs)
+end
+
+function device_batch(x::ROCArray{T, 3}) where T
+    batch_count = size(x, 3)
+    shift = size(x, 1) * size(x, 2) * sizeof(T)
+    ptrs = [
+        Base.unsafe_convert(Ptr{T}, AMDGPU.Mem.view(x.buf, shift * (i - 1)))
+        for i in 1:batch_count]
+    ROCArray(ptrs)
+end
+
+@inline function check_gemm_batched_dims(
+    transA::Char, transB::Char, A::ROCArray, B::ROCArray, C::ROCArray,
+)
+    if (size(A, 3) != size(B, 3)) || (size(A, 3) != size(C, 3))
+        throw(DimensionMismatch(
+            "Last dimension (batch count) must be the same " *
+            "for `A`, `B` and `C`, instead:\n" *
+            "- size(A, 3)=$(size(A, 3))\n" *
+            "- size(B, 3)=$(size(B, 3))\n" *
+            "- size(C, 3)=$(size(C, 3))\n"))
+    end
+    m, k = size(A, transA == 'N' ? 1 : 2), size(A, transA == 'N' ? 2 : 1)
+    n, g = size(B, transB == 'N' ? 2 : 1), size(B, transB == 'N' ? 1 : 2)
+    if m != size(C, 1) || n != size(C, 2) || k != g
+        throw(DimensionMismatch(
+            "Invalid dimensions for `A`, `B` and `C`.\n" *
+            "- size(A)=$(size(A)), transA=$transA \n" *
+            "- size(B)=$(size(B)), transB=$transB \n" *
+            "- size(C)=$(size(C))\n"))
+    end
+end
+
+@inline function check_gemm_batched_dims(
+    transA::Char, transB::Char, A::Array, B::Array, C::Array,
+)
+    if length(A) != length(B) || length(A) != length(C)
+        throw(DimensionMismatch(
+            "Batch count must be the same for `A`, `B` and `C`, instead:\n" *
+            "- length(A)=$(length(A))\n" *
+            "- length(B)=$(length(B))\n" *
+            "- length(C)=$(length(C))\n"))
+    end
+    for (i, (As, Bs, Cs)) in enumerate(zip(A, B, C))
+        m = size(As, transA == 'N' ? 1 : 2)
+        k = size(As, transA == 'N' ? 2 : 1)
+        n = size(Bs, transB == 'N' ? 2 : 1)
+        g = size(Bs, transB == 'N' ? 1 : 2)
+        if m != size(Cs, 1) || n != size(Cs, 2) || k != g
+            throw(DimensionMismatch(
+                "Invalid dimensions for $i-th entry in `A`, `B` and `C`.\n" *
+                "- size(A[$i])=$(size(As)), transA=$transA \n" *
+                "- size(B[$i])=$(size(Bs)), transB=$transB \n" *
+                "- size(C[$i])=$(size(Cs))\n"))
+        end
+    end
 end
 
 ## (GE) general matrix-matrix multiplication batched
 for (fname, elty) in
-        ((:rocblas_dgemmBatched,:Float64),
-         (:rocblas_sgemmBatched,:Float32),
-         (:rocblas_zgemmBatched,:ComplexF64),
-         (:rocblas_cgemmBatched,:ComplexF32))
+        ((:rocblas_dgemm_batched,:Float64),
+         (:rocblas_sgemm_batched,:Float32),
+         (:rocblas_hgemm_batched,:Float16),
+         (:rocblas_zgemm_batched,:ComplexF64),
+         (:rocblas_cgemm_batched,:ComplexF32))
     @eval begin
-        # rocblas_status_t rocblas_dgemmBatched(
-        #   rocblas_handle handle, rocblas_operation_t transa, rocblas_operation_t transb,
-        #   int m, int n, int k,
-        #   const double *alpha, const double **A, int lda,
-        #   const double **B, int ldb, const double *beta,
-        #   double **C, int ldc, int batchCount)
-        function gemm_batched!(transA::Char,
-                               transB::Char,
-                               alpha::($elty),
-                               A::Array{ROCMatrix{$elty},1},
-                               B::Array{ROCMatrix{$elty},1},
-                               beta::($elty),
-                               C::Array{ROCMatrix{$elty},1})
-            if( length(A) != length(B) || length(A) != length(C) )
-                throw(DimensionMismatch(""))
-            end
-            for (As,Bs,Cs) in zip(A,B,C)
-                m = size(As, transA == 'N' ? 1 : 2)
-                k = size(As, transA == 'N' ? 2 : 1)
-                n = size(Bs, transB == 'N' ? 2 : 1)
-                if m != size(Cs,1) || n != size(Cs,2) || k != size(Bs, transB == 'N' ? 1 : 2)
-                    throw(DimensionMismatch(""))
-                end
-            end
+        function gemm_batched!(
+            transA::Char, transB::Char, alpha::($elty),
+            A::Array{ROCMatrix{$elty},1},
+            B::Array{ROCMatrix{$elty},1}, beta::($elty),
+            C::Array{ROCMatrix{$elty},1},
+        )
+            check_gemm_batched_dims(transA, transB, A, B, C)
+
             m = size(A[1], transA == 'N' ? 1 : 2)
             k = size(A[1], transA == 'N' ? 2 : 1)
             n = size(B[1], transB == 'N' ? 2 : 1)
-            roctransA = rocblasop(transA)
-            roctransB = rocblasop(transB)
-            lda = max(1,stride(A[1],2))
-            ldb = max(1,stride(B[1],2))
-            ldc = max(1,stride(C[1],2))
-            Aptrs = device_batch(A)
-            Bptrs = device_batch(B)
-            Cptrs = device_batch(C)
+            lda = max(1, stride(A[1], 2))
+            ldb = max(1, stride(B[1], 2))
+            ldc = max(1, stride(C[1], 2))
             wait!(A)
             wait!(B)
             wait!(C)
-            @check ccall(($(string(fname)),librocblas), rocblas_status_t,
-                         (rocblas_handle, rocblas_operation_t,
-                          rocblas_operation_t, Cint, Cint, Cint, Ptr{$elty},
-                          Ptr{Ptr{$elty}}, Cint, Ptr{Ptr{$elty}}, Cint, Ptr{$elty},
-                          Ptr{Ptr{$elty}}, Cint, Cint),
-                         handle(), roctransA,
-                         roctransB, m, n, k, Ref(alpha), Aptrs, lda, Bptrs, ldb, Ref(beta),
-                         Cptrs, ldc, length(A))
-            mark!(A,rocblas_get_stream(handle()))
-            mark!(B,rocblas_get_stream(handle()))
-            mark!(C,rocblas_get_stream(handle()))
+
+            $(fname)(
+                handle(), rocblasop(transA), rocblasop(transB),
+                m, n, k, Ref(alpha),
+                device_batch(A), lda, device_batch(B), ldb, Ref(beta),
+                device_batch(C), ldc, length(A))
+            mark!(A, rocblas_get_stream(handle()))
+            mark!(B, rocblas_get_stream(handle()))
+            mark!(C, rocblas_get_stream(handle()))
             C
         end
-        function gemm_batched(transA::Char,
-                      transB::Char,
-                      alpha::($elty),
-                      A::Array{ROCMatrix{$elty},1},
-                      B::Array{ROCMatrix{$elty},1})
-            C = ROCMatrix{$elty}[similar( B[1], $elty, (size(A[1], transA == 'N' ? 1 : 2),size(B[1], transB == 'N' ? 2 : 1))) for i in 1:length(A)]
+        function gemm_batched!(
+            transA::Char, transB::Char, alpha::($elty),
+            A::ROCArray{$elty, 3},
+            B::ROCArray{$elty, 3}, beta::($elty),
+            C::ROCArray{$elty, 3},
+        )
+            check_gemm_batched_dims(transA, transB, A, B, C)
+
+            m = size(A, transA == 'N' ? 1 : 2)
+            k = size(A, transA == 'N' ? 2 : 1)
+            n = size(B, transB == 'N' ? 2 : 1)
+            lda = max(1, stride(A, 2))
+            ldb = max(1, stride(B, 2))
+            ldc = max(1, stride(C, 2))
+            wait!(A)
+            wait!(B)
+            wait!(C)
+
+            $(fname)(
+                handle(), rocblasop(transA), rocblasop(transB),
+                m, n, k, Ref(alpha),
+                device_batch(A), lda, device_batch(B), ldb, Ref(beta),
+                device_batch(C), ldc, size(A, 3))
+            mark!(A, rocblas_get_stream(handle()))
+            mark!(B, rocblas_get_stream(handle()))
+            mark!(C, rocblas_get_stream(handle()))
+            C
+        end
+        function gemm_batched(
+            transA::Char, transB::Char, alpha::($elty),
+            A::Array{ROCMatrix{$elty},1}, B::Array{ROCMatrix{$elty},1},
+        )
+            C = ROCMatrix{$elty}[
+                similar(B[i], $elty, (
+                    size(A[i], transA == 'N' ? 1 : 2),
+                    size(B[i], transB == 'N' ? 2 : 1))) for i in 1:length(A)]
             gemm_batched!(transA, transB, alpha, A, B, zero($elty), C )
         end
-        function gemm_batched(transA::Char,
-                      transB::Char,
-                      A::Array{ROCMatrix{$elty},1},
-                      B::Array{ROCMatrix{$elty},1})
+        function gemm_batched(
+            transA::Char, transB::Char, alpha::($elty),
+            A::ROCArray{$elty, 3}, B::ROCArray{$elty, 3},
+        )
+            m = size(A, transA == 'N' ? 1 : 2)
+            k = size(B, transB == 'N' ? 2 : 1)
+            batch_count = size(A, 3)
+            C = similar(A, $elty, (m, k, batch_count))
+            gemm_batched!(transA, transB, alpha, A, B, zero($elty), C )
+        end
+        function gemm_batched(
+            transA::Char, transB::Char,
+            A::Array{ROCMatrix{$elty},1}, B::Array{ROCMatrix{$elty},1},
+        )
+            gemm_batched(transA, transB, one($elty), A, B)
+        end
+        function gemm_batched(
+            transA::Char, transB::Char,
+            A::ROCArray{$elty, 3}, B::ROCArray{$elty, 3},
+        )
             gemm_batched(transA, transB, one($elty), A, B)
         end
     end

--- a/src/blas/wrappers.jl
+++ b/src/blas/wrappers.jl
@@ -1029,13 +1029,17 @@ for (fname, elty) in
         ) where T <: Union{ROCArray{$elty, 3}, Vector{ROCMatrix{$elty}}}
             m, k, n, lda, ldb, ldc = check_gemm_batched_dims(
                 transA, transB, A, B, C)
-            wait!((A, B, C))
+            wait!(A)
+            wait!(B)
+            wait!(C)
             $(fname)(
                 handle(), rocblasop(transA), rocblasop(transB),
                 m, n, k, Ref(alpha),
                 device_batch(A), lda, device_batch(B), ldb, Ref(beta),
                 device_batch(C), ldc, size(A, 3))
-            mark!((A, B, C), rocblas_get_stream(handle()))
+            mark!(A, rocblas_get_stream(handle()))
+            mark!(B, rocblas_get_stream(handle()))
+            mark!(C, rocblas_get_stream(handle()))
             C
         end
         function gemm_batched(

--- a/src/blas/wrappers.jl
+++ b/src/blas/wrappers.jl
@@ -918,7 +918,6 @@ for (fname, elty) in
             ldb = max(1, stride(B, 2))
             ldc = max(1, stride(C, 2))
             wait!((A, B, C))
-
             $(fname)(
                 handle(), rocblasop(transA), rocblasop(transB),
                 m, n, k, Ref(alpha), A, lda, B, ldb, Ref(beta), C, ldc)

--- a/test/rocarray/blas.jl
+++ b/test/rocarray/blas.jl
@@ -125,8 +125,20 @@ end
 end
 
 @testset "Level 3 BLAS" begin
+    @testset "gemm()" begin
+        for T in (Float16, Float32, Float64, ComplexF32, ComplexF64)
+            A = rand(T, 8, 4)
+            B = rand(T, 8, 4)
+            RA = ROCArray(A)
+            RB = ROCArray(B)
+
+            RC = rocBLAS.gemm('T', 'N', RA, RB)
+            @test Array(RC) ≈ transpose(A) * B
+        end
+    end
+
     @testset "gemm_batched()" begin
-        for T in (Float16, Float32, Float64)
+        for T in (Float16, Float32, Float64, ComplexF32, ComplexF64)
             batch_count = 3
             A = rand(T, 8, 4, batch_count)
             B = rand(T, 8, 4, batch_count)
@@ -136,7 +148,7 @@ end
             RC = rocBLAS.gemm_batched('T', 'N', RA, RB)
             C = Array(RC)
             for i in 1:batch_count
-                c = A[:, :, i]' * B[:, :, i]
+                c = transpose(A[:, :, i]) * B[:, :, i]
                 @test C[:, :, i] ≈ c
             end
         end

--- a/test/rocarray/blas.jl
+++ b/test/rocarray/blas.jl
@@ -124,4 +124,23 @@ end
     end
 end
 
-end # testset BLAS
+@testset "Level 3 BLAS" begin
+    @testset "gemm_batched()" begin
+        for T in (Float16, Float32, Float64)
+            batch_count = 3
+            A = rand(T, 8, 4, batch_count)
+            B = rand(T, 8, 4, batch_count)
+            RA = ROCArray(A)
+            RB = ROCArray(B)
+
+            RC = rocBLAS.gemm_batched('T', 'N', RA, RB)
+            C = Array(RC)
+            for i in 1:batch_count
+                c = A[:, :, i]' * B[:, :, i]
+                @test C[:, :, i] ≈ c
+            end
+        end
+    end
+end
+
+end # testse BLAS

--- a/test/rocarray/blas.jl
+++ b/test/rocarray/blas.jl
@@ -127,29 +127,38 @@ end
 @testset "Level 3 BLAS" begin
     @testset "gemm()" begin
         for T in (Float16, Float32, Float64, ComplexF32, ComplexF64)
-            A = rand(T, 8, 4)
-            B = rand(T, 8, 4)
-            RA = ROCArray(A)
-            RB = ROCArray(B)
+            for at in ('N', 'T'), bt in ('N', 'T')
+                A = rand(T, 4, 4)
+                B = rand(T, 4, 4)
+                RA = ROCArray(A)
+                RB = ROCArray(B)
 
-            RC = rocBLAS.gemm('T', 'N', RA, RB)
-            @test Array(RC) ≈ transpose(A) * B
+                RC = rocBLAS.gemm(at, bt, RA, RB)
+                C =
+                    (at == 'T' ? transpose(A) : A) *
+                    (bt == 'T' ? transpose(B) : B)
+                @test Array(RC) ≈ C
+            end
         end
     end
 
     @testset "gemm_batched()" begin
         for T in (Float16, Float32, Float64, ComplexF32, ComplexF64)
-            batch_count = 3
-            A = rand(T, 8, 4, batch_count)
-            B = rand(T, 8, 4, batch_count)
-            RA = ROCArray(A)
-            RB = ROCArray(B)
+            for at in ('N', 'T'), bt in ('N', 'T')
+                batch_count = 3
+                A = rand(T, 4, 4, batch_count)
+                B = rand(T, 4, 4, batch_count)
+                RA = ROCArray(A)
+                RB = ROCArray(B)
 
-            RC = rocBLAS.gemm_batched('T', 'N', RA, RB)
-            C = Array(RC)
-            for i in 1:batch_count
-                c = transpose(A[:, :, i]) * B[:, :, i]
-                @test C[:, :, i] ≈ c
+                RC = rocBLAS.gemm_batched(at, bt, RA, RB)
+                C = Array(RC)
+                for i in 1:batch_count
+                    c =
+                        (at == 'T' ? transpose(A[:, :, i]) : A[:, :, i]) *
+                        (bt == 'T' ? transpose(B[:, :, i]) : B[:, :, i])
+                    @test C[:, :, i] ≈ c
+                end
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,49 +45,49 @@ AMDGPU.versioninfo()
 
 @info "Running tests with $(length(ws)) workers"
 
-# push!(tests, "Core" => ()->include("pointer.jl"))
-# push!(tests, "HSA" => ()->begin
-#     include("hsa/error.jl")
-#     include("hsa/utils.jl")
-#     include("hsa/device.jl")
-#     include("hsa/queue.jl")
-#     include("hsa/memory.jl")
-#     include("hsa/hashing.jl")
-# end)
-# push!(tests, "Codegen" => ()->begin
-#     include("codegen/synchronization.jl")
-#     include("codegen/trap.jl")
-# end)
+push!(tests, "Core" => ()->include("pointer.jl"))
+push!(tests, "HSA" => ()->begin
+    include("hsa/error.jl")
+    include("hsa/utils.jl")
+    include("hsa/device.jl")
+    include("hsa/queue.jl")
+    include("hsa/memory.jl")
+    include("hsa/hashing.jl")
+end)
+push!(tests, "Codegen" => ()->begin
+    include("codegen/synchronization.jl")
+    include("codegen/trap.jl")
+end)
 
-# push!(tests, "Device Functions" => ()->begin
-#     include("device/launch.jl")
-#     include("device/array.jl")
-#     include("device/vadd.jl")
-#     include("device/memory.jl")
-#     include("device/indexing.jl")
-#     include("device/hostcall.jl")
-#     include("device/output.jl")
-#     include("device/globals.jl")
-#     include("device/math.jl")
-#     include("device/wavefront.jl")
-#     include("device/execution_control.jl")
-#     include("device/exceptions.jl")
-#     # FIXME segfaults in a weird way (on check_ir)
-#     # include("device/deps.jl")
-#     include("device/queries.jl")
-# end)
-# push!(tests, "ROCArray - Base" => ()->include("rocarray/base.jl"))
-# push!(tests, "ROCArray - Broadcast" => ()->include("rocarray/broadcast.jl"))
-# if CI
-#     push!(tests, "ROCm libraries are functional" => ()->begin
-#         @test AMDGPU.functional(:rocblas)
-#         @test AMDGPU.functional(:rocrand)
-#         if !AMDGPU.use_artifacts
-#             # We don't have artifacts for these
-#             @test AMDGPU.functional(:rocfft)
-#         end
-#     end)
-# end
+push!(tests, "Device Functions" => ()->begin
+    include("device/launch.jl")
+    include("device/array.jl")
+    include("device/vadd.jl")
+    include("device/memory.jl")
+    include("device/indexing.jl")
+    include("device/hostcall.jl")
+    include("device/output.jl")
+    include("device/globals.jl")
+    include("device/math.jl")
+    include("device/wavefront.jl")
+    include("device/execution_control.jl")
+    include("device/exceptions.jl")
+    # FIXME segfaults in a weird way (on check_ir)
+    # include("device/deps.jl")
+    include("device/queries.jl")
+end)
+push!(tests, "ROCArray - Base" => ()->include("rocarray/base.jl"))
+push!(tests, "ROCArray - Broadcast" => ()->include("rocarray/broadcast.jl"))
+if CI
+    push!(tests, "ROCm libraries are functional" => ()->begin
+        @test AMDGPU.functional(:rocblas)
+        @test AMDGPU.functional(:rocrand)
+        if !AMDGPU.use_artifacts
+            # We don't have artifacts for these
+            @test AMDGPU.functional(:rocfft)
+        end
+    end)
+end
 push!(tests, "rocBLAS" => ()->begin
     if AMDGPU.functional(:rocblas)
         include("rocarray/blas.jl")
@@ -95,32 +95,32 @@ push!(tests, "rocBLAS" => ()->begin
         @test_skip "rocBLAS"
     end
 end)
-# push!(tests, "rocRAND" => ()->begin
-#     if AMDGPU.functional(:rocrand)
-#         include("rocarray/random.jl")
-#     else
-#         @test_skip "rocRAND"
-#     end
-# end)
-# push!(tests, "rocFFT" => ()->begin
-#     if AMDGPU.functional(:rocfft)
-#         include("rocarray/fft.jl")
-#     else
-#         @test_skip "rocFFT"
-#     end
-# end)
-# push!(tests, "NMF" => ()->begin
-#     if AMDGPU.functional(:rocblas)
-#         include("rocarray/nmf.jl")
-#     else
-#         @test_skip "NMF"
-#     end
-# end)
-# push!(tests, "External Packages" => ()->include("external/forwarddiff.jl"))
-# for name in keys(TestSuite.tests)
-#     push!(tests, "GPUArrays TestSuite - $name" =>
-#                  ()->TestSuite.tests[name](ROCArray))
-# end
+push!(tests, "rocRAND" => ()->begin
+    if AMDGPU.functional(:rocrand)
+        include("rocarray/random.jl")
+    else
+        @test_skip "rocRAND"
+    end
+end)
+push!(tests, "rocFFT" => ()->begin
+    if AMDGPU.functional(:rocfft)
+        include("rocarray/fft.jl")
+    else
+        @test_skip "rocFFT"
+    end
+end)
+push!(tests, "NMF" => ()->begin
+    if AMDGPU.functional(:rocblas)
+        include("rocarray/nmf.jl")
+    else
+        @test_skip "NMF"
+    end
+end)
+push!(tests, "External Packages" => ()->include("external/forwarddiff.jl"))
+for name in keys(TestSuite.tests)
+    push!(tests, "GPUArrays TestSuite - $name" =>
+                 ()->TestSuite.tests[name](ROCArray))
+end
 
 function run_worker(w)
     while !isempty(tests)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,49 +45,49 @@ AMDGPU.versioninfo()
 
 @info "Running tests with $(length(ws)) workers"
 
-push!(tests, "Core" => ()->include("pointer.jl"))
-push!(tests, "HSA" => ()->begin
-    include("hsa/error.jl")
-    include("hsa/utils.jl")
-    include("hsa/device.jl")
-    include("hsa/queue.jl")
-    include("hsa/memory.jl")
-    include("hsa/hashing.jl")
-end)
-push!(tests, "Codegen" => ()->begin
-    include("codegen/synchronization.jl")
-    include("codegen/trap.jl")
-end)
+# push!(tests, "Core" => ()->include("pointer.jl"))
+# push!(tests, "HSA" => ()->begin
+#     include("hsa/error.jl")
+#     include("hsa/utils.jl")
+#     include("hsa/device.jl")
+#     include("hsa/queue.jl")
+#     include("hsa/memory.jl")
+#     include("hsa/hashing.jl")
+# end)
+# push!(tests, "Codegen" => ()->begin
+#     include("codegen/synchronization.jl")
+#     include("codegen/trap.jl")
+# end)
 
-push!(tests, "Device Functions" => ()->begin
-    include("device/launch.jl")
-    include("device/array.jl")
-    include("device/vadd.jl")
-    include("device/memory.jl")
-    include("device/indexing.jl")
-    include("device/hostcall.jl")
-    include("device/output.jl")
-    include("device/globals.jl")
-    include("device/math.jl")
-    include("device/wavefront.jl")
-    include("device/execution_control.jl")
-    include("device/exceptions.jl")
-    # FIXME segfaults in a weird way (on check_ir)
-    # include("device/deps.jl")
-    include("device/queries.jl")
-end)
-push!(tests, "ROCArray - Base" => ()->include("rocarray/base.jl"))
-push!(tests, "ROCArray - Broadcast" => ()->include("rocarray/broadcast.jl"))
-if CI
-    push!(tests, "ROCm libraries are functional" => ()->begin
-        @test AMDGPU.functional(:rocblas)
-        @test AMDGPU.functional(:rocrand)
-        if !AMDGPU.use_artifacts
-            # We don't have artifacts for these
-            @test AMDGPU.functional(:rocfft)
-        end
-    end)
-end
+# push!(tests, "Device Functions" => ()->begin
+#     include("device/launch.jl")
+#     include("device/array.jl")
+#     include("device/vadd.jl")
+#     include("device/memory.jl")
+#     include("device/indexing.jl")
+#     include("device/hostcall.jl")
+#     include("device/output.jl")
+#     include("device/globals.jl")
+#     include("device/math.jl")
+#     include("device/wavefront.jl")
+#     include("device/execution_control.jl")
+#     include("device/exceptions.jl")
+#     # FIXME segfaults in a weird way (on check_ir)
+#     # include("device/deps.jl")
+#     include("device/queries.jl")
+# end)
+# push!(tests, "ROCArray - Base" => ()->include("rocarray/base.jl"))
+# push!(tests, "ROCArray - Broadcast" => ()->include("rocarray/broadcast.jl"))
+# if CI
+#     push!(tests, "ROCm libraries are functional" => ()->begin
+#         @test AMDGPU.functional(:rocblas)
+#         @test AMDGPU.functional(:rocrand)
+#         if !AMDGPU.use_artifacts
+#             # We don't have artifacts for these
+#             @test AMDGPU.functional(:rocfft)
+#         end
+#     end)
+# end
 push!(tests, "rocBLAS" => ()->begin
     if AMDGPU.functional(:rocblas)
         include("rocarray/blas.jl")
@@ -95,32 +95,32 @@ push!(tests, "rocBLAS" => ()->begin
         @test_skip "rocBLAS"
     end
 end)
-push!(tests, "rocRAND" => ()->begin
-    if AMDGPU.functional(:rocrand)
-        include("rocarray/random.jl")
-    else
-        @test_skip "rocRAND"
-    end
-end)
-push!(tests, "rocFFT" => ()->begin
-    if AMDGPU.functional(:rocfft)
-        include("rocarray/fft.jl")
-    else
-        @test_skip "rocFFT"
-    end
-end)
-push!(tests, "NMF" => ()->begin
-    if AMDGPU.functional(:rocblas)
-        include("rocarray/nmf.jl")
-    else
-        @test_skip "NMF"
-    end
-end)
-push!(tests, "External Packages" => ()->include("external/forwarddiff.jl"))
-for name in keys(TestSuite.tests)
-    push!(tests, "GPUArrays TestSuite - $name" =>
-                 ()->TestSuite.tests[name](ROCArray))
-end
+# push!(tests, "rocRAND" => ()->begin
+#     if AMDGPU.functional(:rocrand)
+#         include("rocarray/random.jl")
+#     else
+#         @test_skip "rocRAND"
+#     end
+# end)
+# push!(tests, "rocFFT" => ()->begin
+#     if AMDGPU.functional(:rocfft)
+#         include("rocarray/fft.jl")
+#     else
+#         @test_skip "rocFFT"
+#     end
+# end)
+# push!(tests, "NMF" => ()->begin
+#     if AMDGPU.functional(:rocblas)
+#         include("rocarray/nmf.jl")
+#     else
+#         @test_skip "NMF"
+#     end
+# end)
+# push!(tests, "External Packages" => ()->include("external/forwarddiff.jl"))
+# for name in keys(TestSuite.tests)
+#     push!(tests, "GPUArrays TestSuite - $name" =>
+#                  ()->TestSuite.tests[name](ROCArray))
+# end
 
 function run_worker(w)
     while !isempty(tests)


### PR DESCRIPTION
- Fix outdated `rocblas_dgemmBatched` function names.
- Use c-call wrappers generated by Clang.
- Support batched gemm that operates not only on Array-of-ROCArrays but on 3D ROCArrays as well.
So now we can do this:
```julia
julia> x = AMDGPU.rand(Float32, 4, 4, 3);
julia> AMDGPU.rocBLAS.gemm_batched('N', 'N', x, x);
```
- Add GEMM & batched GEMM tests for all supported types.
- Fix half-precision GEMM.
- Fix incorrect `rocblas_half` type alias.

---

Posting this here for the reference.
Clang generator for rocBLAS:

```julia
using Clang.Generators
using rocBLAS_jll

include_dir = normpath(rocBLAS_jll.artifact_dir, "include")
rocblas_dir = joinpath(include_dir, "rocblas")
options = load_options("blas-generator.toml")

args = get_default_args()
push!(args, "-I$include_dir")

headers = [
    joinpath(rocblas_dir, header)
    for header in readdir(rocblas_dir)
    if endswith(header, ".h")
]

ctx = create_context(headers, args, options)
build!(ctx)
```

```toml
[general]
module_name = "libROCBlas"
library_name = "librocblas"
output_file_path = "./librocblas.jl"
jll_pkg_name = "rocBLAS_jll"
export_symbol_prefixes = []
```