### PR TITLE
Add support for 2D * 3D batched GEMM

### DIFF
--- a/test/rocarray/blas.jl
+++ b/test/rocarray/blas.jl
@@ -162,6 +162,18 @@ end
             end
         end
     end
+
+    @testset "2D * 3D batched gemm" begin
+        A = ROCArray(rand(Float32, 4, 4))
+        B = ROCArray(rand(Float32, 4, 16, 5))
+        C = rocBLAS.gemm_batched('N', 'N', A, B)
+        @test size(C) == (4, 16, 5)
+
+        A = ROCArray(rand(Float32, 4, 4, 5))
+        B = ROCArray(rand(Float32, 4, 16))
+        C = rocBLAS.gemm_batched('N', 'N', A, B)
+        @test size(C) == (4, 16, 5)
+    end
 end
 
-end # testse BLAS
+end # testset BLAS

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,49 +45,49 @@ AMDGPU.versioninfo()
 
 @info "Running tests with $(length(ws)) workers"
 
-# push!(tests, "Core" => ()->include("pointer.jl"))
-# push!(tests, "HSA" => ()->begin
-#     include("hsa/error.jl")
-#     include("hsa/utils.jl")
-#     include("hsa/device.jl")
-#     include("hsa/queue.jl")
-#     include("hsa/memory.jl")
-#     include("hsa/hashing.jl")
-# end)
-# push!(tests, "Codegen" => ()->begin
-#     include("codegen/synchronization.jl")
-#     include("codegen/trap.jl")
-# end)
+push!(tests, "Core" => ()->include("pointer.jl"))
+push!(tests, "HSA" => ()->begin
+    include("hsa/error.jl")
+    include("hsa/utils.jl")
+    include("hsa/device.jl")
+    include("hsa/queue.jl")
+    include("hsa/memory.jl")
+    include("hsa/hashing.jl")
+end)
+push!(tests, "Codegen" => ()->begin
+    include("codegen/synchronization.jl")
+    include("codegen/trap.jl")
+end)
 
-# push!(tests, "Device Functions" => ()->begin
-#     include("device/launch.jl")
-#     include("device/array.jl")
-#     include("device/vadd.jl")
-#     include("device/memory.jl")
-#     include("device/indexing.jl")
-#     include("device/hostcall.jl")
-#     include("device/output.jl")
-#     include("device/globals.jl")
-#     include("device/math.jl")
-#     include("device/wavefront.jl")
-#     include("device/execution_control.jl")
-#     include("device/exceptions.jl")
-#     # FIXME segfaults in a weird way (on check_ir)
-#     # include("device/deps.jl")
-#     include("device/queries.jl")
-# end)
-# push!(tests, "ROCArray - Base" => ()->include("rocarray/base.jl"))
-# push!(tests, "ROCArray - Broadcast" => ()->include("rocarray/broadcast.jl"))
-# if CI
-#     push!(tests, "ROCm libraries are functional" => ()->begin
-#         @test AMDGPU.functional(:rocblas)
-#         @test AMDGPU.functional(:rocrand)
-#         if !AMDGPU.use_artifacts
-#             # We don't have artifacts for these
-#             @test AMDGPU.functional(:rocfft)
-#         end
-#     end)
-# end
+push!(tests, "Device Functions" => ()->begin
+    include("device/launch.jl")
+    include("device/array.jl")
+    include("device/vadd.jl")
+    include("device/memory.jl")
+    include("device/indexing.jl")
+    include("device/hostcall.jl")
+    include("device/output.jl")
+    include("device/globals.jl")
+    include("device/math.jl")
+    include("device/wavefront.jl")
+    include("device/execution_control.jl")
+    include("device/exceptions.jl")
+    # FIXME segfaults in a weird way (on check_ir)
+    # include("device/deps.jl")
+    include("device/queries.jl")
+end)
+push!(tests, "ROCArray - Base" => ()->include("rocarray/base.jl"))
+push!(tests, "ROCArray - Broadcast" => ()->include("rocarray/broadcast.jl"))
+if CI
+    push!(tests, "ROCm libraries are functional" => ()->begin
+        @test AMDGPU.functional(:rocblas)
+        @test AMDGPU.functional(:rocrand)
+        if !AMDGPU.use_artifacts
+            # We don't have artifacts for these
+            @test AMDGPU.functional(:rocfft)
+        end
+    end)
+end
 push!(tests, "rocBLAS" => ()->begin
     if AMDGPU.functional(:rocblas)
         include("rocarray/blas.jl")
@@ -95,32 +95,32 @@ push!(tests, "rocBLAS" => ()->begin
         @test_skip "rocBLAS"
     end
 end)
-# push!(tests, "rocRAND" => ()->begin
-#     if AMDGPU.functional(:rocrand)
-#         include("rocarray/random.jl")
-#     else
-#         @test_skip "rocRAND"
-#     end
-# end)
-# push!(tests, "rocFFT" => ()->begin
-#     if AMDGPU.functional(:rocfft)
-#         include("rocarray/fft.jl")
-#     else
-#         @test_skip "rocFFT"
-#     end
-# end)
-# push!(tests, "NMF" => ()->begin
-#     if AMDGPU.functional(:rocblas)
-#         include("rocarray/nmf.jl")
-#     else
-#         @test_skip "NMF"
-#     end
-# end)
-# push!(tests, "External Packages" => ()->include("external/forwarddiff.jl"))
-# for name in keys(TestSuite.tests)
-#     push!(tests, "GPUArrays TestSuite - $name" =>
-#                  ()->TestSuite.tests[name](ROCArray))
-# end
+push!(tests, "rocRAND" => ()->begin
+    if AMDGPU.functional(:rocrand)
+        include("rocarray/random.jl")
+    else
+        @test_skip "rocRAND"
+    end
+end)
+push!(tests, "rocFFT" => ()->begin
+    if AMDGPU.functional(:rocfft)
+        include("rocarray/fft.jl")
+    else
+        @test_skip "rocFFT"
+    end
+end)
+push!(tests, "NMF" => ()->begin
+    if AMDGPU.functional(:rocblas)
+        include("rocarray/nmf.jl")
+    else
+        @test_skip "NMF"
+    end
+end)
+push!(tests, "External Packages" => ()->include("external/forwarddiff.jl"))
+for name in keys(TestSuite.tests)
+    push!(tests, "GPUArrays TestSuite - $name" =>
+                 ()->TestSuite.tests[name](ROCArray))
+end
 
 function run_worker(w)
     while !isempty(tests)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,49 +45,49 @@ AMDGPU.versioninfo()
 
 @info "Running tests with $(length(ws)) workers"
 
-push!(tests, "Core" => ()->include("pointer.jl"))
-push!(tests, "HSA" => ()->begin
-    include("hsa/error.jl")
-    include("hsa/utils.jl")
-    include("hsa/device.jl")
-    include("hsa/queue.jl")
-    include("hsa/memory.jl")
-    include("hsa/hashing.jl")
-end)
-push!(tests, "Codegen" => ()->begin
-    include("codegen/synchronization.jl")
-    include("codegen/trap.jl")
-end)
+# push!(tests, "Core" => ()->include("pointer.jl"))
+# push!(tests, "HSA" => ()->begin
+#     include("hsa/error.jl")
+#     include("hsa/utils.jl")
+#     include("hsa/device.jl")
+#     include("hsa/queue.jl")
+#     include("hsa/memory.jl")
+#     include("hsa/hashing.jl")
+# end)
+# push!(tests, "Codegen" => ()->begin
+#     include("codegen/synchronization.jl")
+#     include("codegen/trap.jl")
+# end)
 
-push!(tests, "Device Functions" => ()->begin
-    include("device/launch.jl")
-    include("device/array.jl")
-    include("device/vadd.jl")
-    include("device/memory.jl")
-    include("device/indexing.jl")
-    include("device/hostcall.jl")
-    include("device/output.jl")
-    include("device/globals.jl")
-    include("device/math.jl")
-    include("device/wavefront.jl")
-    include("device/execution_control.jl")
-    include("device/exceptions.jl")
-    # FIXME segfaults in a weird way (on check_ir)
-    # include("device/deps.jl")
-    include("device/queries.jl")
-end)
-push!(tests, "ROCArray - Base" => ()->include("rocarray/base.jl"))
-push!(tests, "ROCArray - Broadcast" => ()->include("rocarray/broadcast.jl"))
-if CI
-    push!(tests, "ROCm libraries are functional" => ()->begin
-        @test AMDGPU.functional(:rocblas)
-        @test AMDGPU.functional(:rocrand)
-        if !AMDGPU.use_artifacts
-            # We don't have artifacts for these
-            @test AMDGPU.functional(:rocfft)
-        end
-    end)
-end
+# push!(tests, "Device Functions" => ()->begin
+#     include("device/launch.jl")
+#     include("device/array.jl")
+#     include("device/vadd.jl")
+#     include("device/memory.jl")
+#     include("device/indexing.jl")
+#     include("device/hostcall.jl")
+#     include("device/output.jl")
+#     include("device/globals.jl")
+#     include("device/math.jl")
+#     include("device/wavefront.jl")
+#     include("device/execution_control.jl")
+#     include("device/exceptions.jl")
+#     # FIXME segfaults in a weird way (on check_ir)
+#     # include("device/deps.jl")
+#     include("device/queries.jl")
+# end)
+# push!(tests, "ROCArray - Base" => ()->include("rocarray/base.jl"))
+# push!(tests, "ROCArray - Broadcast" => ()->include("rocarray/broadcast.jl"))
+# if CI
+#     push!(tests, "ROCm libraries are functional" => ()->begin
+#         @test AMDGPU.functional(:rocblas)
+#         @test AMDGPU.functional(:rocrand)
+#         if !AMDGPU.use_artifacts
+#             # We don't have artifacts for these
+#             @test AMDGPU.functional(:rocfft)
+#         end
+#     end)
+# end
 push!(tests, "rocBLAS" => ()->begin
     if AMDGPU.functional(:rocblas)
         include("rocarray/blas.jl")
@@ -95,32 +95,32 @@ push!(tests, "rocBLAS" => ()->begin
         @test_skip "rocBLAS"
     end
 end)
-push!(tests, "rocRAND" => ()->begin
-    if AMDGPU.functional(:rocrand)
-        include("rocarray/random.jl")
-    else
-        @test_skip "rocRAND"
-    end
-end)
-push!(tests, "rocFFT" => ()->begin
-    if AMDGPU.functional(:rocfft)
-        include("rocarray/fft.jl")
-    else
-        @test_skip "rocFFT"
-    end
-end)
-push!(tests, "NMF" => ()->begin
-    if AMDGPU.functional(:rocblas)
-        include("rocarray/nmf.jl")
-    else
-        @test_skip "NMF"
-    end
-end)
-push!(tests, "External Packages" => ()->include("external/forwarddiff.jl"))
-for name in keys(TestSuite.tests)
-    push!(tests, "GPUArrays TestSuite - $name" =>
-                 ()->TestSuite.tests[name](ROCArray))
-end
+# push!(tests, "rocRAND" => ()->begin
+#     if AMDGPU.functional(:rocrand)
+#         include("rocarray/random.jl")
+#     else
+#         @test_skip "rocRAND"
+#     end
+# end)
+# push!(tests, "rocFFT" => ()->begin
+#     if AMDGPU.functional(:rocfft)
+#         include("rocarray/fft.jl")
+#     else
+#         @test_skip "rocFFT"
+#     end
+# end)
+# push!(tests, "NMF" => ()->begin
+#     if AMDGPU.functional(:rocblas)
+#         include("rocarray/nmf.jl")
+#     else
+#         @test_skip "NMF"
+#     end
+# end)
+# push!(tests, "External Packages" => ()->include("external/forwarddiff.jl"))
+# for name in keys(TestSuite.tests)
+#     push!(tests, "GPUArrays TestSuite - $name" =>
+#                  ()->TestSuite.tests[name](ROCArray))
+# end
 
 function run_worker(w)
     while !isempty(tests)


### PR DESCRIPTION
This PR adds support for 2D * 3D batched GEMM.
One use-case is applying the same `4x4` intrinsics matrix `K` to different extrinsics `4x4xN` matrices `[R|t]`.