### PR TITLE
Add pointer() method for ROCArray and some library tests

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -85,8 +85,6 @@ function unsafe_free!(xs::ROCArray)
     return
 end
 
-Base.pointer(x::ROCArray) = x.buf.ptr + x.offset
-
 wait!(x::ROCArray) = wait!(x.syncstate)
 mark!(x::ROCArray, s) = mark!(x.syncstate, s)
 wait!(xs::Vector{<:ROCArray}) = foreach(wait!, xs)
@@ -389,7 +387,7 @@ roc(xs) = adapt(Float32Adaptor(), xs)
 
 
 Base.unsafe_convert(::Type{Ptr{T}}, x::ROCArray{T}) where T =
-    Base.unsafe_convert(Ptr{T}, x.buf)
+    Base.unsafe_convert(Ptr{T}, x.buf) + x.offset
 
 # some nice utilities
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -85,6 +85,8 @@ function unsafe_free!(xs::ROCArray)
     return
 end
 
+Base.pointer(x::ROCArray) = x.buf.ptr + x.offset
+
 wait!(x::ROCArray) = wait!(x.syncstate)
 mark!(x::ROCArray, s) = mark!(x.syncstate, s)
 wait!(xs::Vector{<:ROCArray}) = foreach(wait!, xs)

--- a/test/rocarray/blas.jl
+++ b/test/rocarray/blas.jl
@@ -13,6 +13,7 @@ end
 
 @testset "Highlevel" begin
     for T in (Float32, Float64)
+        # Regular array
         A = rand(T, 8, 8)
         x = rand(T, 8)
         RA = ROCArray(A)
@@ -20,6 +21,17 @@ end
         Rb = RA*Rx
         _b = Array(Rb)
         @test isapprox(A*x, _b)
+
+        # View into array
+        A = rand(T, 8, 8, 2)
+        x = rand(T, 8, 2)
+        A_d = ROCArray(A)
+        x_d = ROCArray(x)
+        # Perform multiplication with contiguous view with non-zero offsets
+        # This ensures that the offsets are properly being passed to rocBLAS
+        Ax = view(A, :, :, 2) * view(x, :, 2)
+        Ax_d = view(A_d, :, :, 2) * view(x_d, :, 2)
+        @test isapprox(Ax, Array(Ax_d))
     end
     @testset "norm" begin
         for T in (Float32, Float64, ComplexF32, ComplexF64)

--- a/test/rocarray/fft.jl
+++ b/test/rocarray/fft.jl
@@ -295,6 +295,20 @@ end
 
 end
 
+@testset "FFT with view" begin
+    for T in (ComplexF32, ComplexF64)
+        X = rand(T, 128, 128, 2)
+        X_d = ROCArray(X)
+
+        # Perform fft with contiguous view with non-zero offsets
+        # This ensures that the offsets are properly being passed to rocFFT
+        fft!(view(X, :, :, 2))
+        fft!(view(X_d, :, :, 2))
+
+        @test isapprox(X, Array(X_d))
+    end
+end
+
 @testset "Promoted types" begin
     @testset for T in (Float32, Float64)
         X = rand(T, 10, 10)


### PR DESCRIPTION
This PR mean to resolve [issue](https://github.com/JuliaGPU/AMDGPU.jl/issues/319) by providing a `Base.pointer(::ROCArray)` method that correctly handles non-zero offsets.

(Honestly, I don't understand how the calls to `pointer(::ROCArray)` were working at all before??!)

Currently, the FFT test now passes, however, the the BLAS test still fails. Still attempting to work out why `pointer()` is not being called when performing matrix multiplication.