### PR TITLE
Cast to Ptr before checking NULL pointer

### DIFF
--- a/src/runtime/executable.jl
+++ b/src/runtime/executable.jl
@@ -103,7 +103,7 @@ function get_exception(
         ex_ring_ptr = unsafe_load(ex_ring_ptr_ptr)
 
         while (ex_ring_value = unsafe_load(ex_ring_ptr)).kern != 1
-            if ex_ring_value.kern == signal_handle && ex_ring_value.ptr != C_NULL
+            if ex_ring_value.kern == signal_handle && reinterpret(Ptr{UInt8}, ex_ring_value.ptr) != C_NULL
                 ex_ring_value_str = unsafe_string(
                     reinterpret(Ptr{UInt8}, ex_ring_value.ptr))
                 push!(ex_strings, ex_ring_value_str)


### PR DESCRIPTION
The LLVM Ptr can't be directly compared to the C_NULL pointer - it needs to first be cast.

(Be warned, I have no idea what this code is doing, only that I encountered this bug during testing.)