### PR TITLE
Fix `unsafe_free!` not actually freeing

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -226,7 +226,7 @@ function Base.unsafe_wrap(::Type{<:ROCArray}, ptr::Ptr{T}, dims::NTuple{N,<:Inte
     @assert isbitstype(T) "Cannot wrap a non-bitstype pointer as a ROCArray"
     sz = prod(dims) * sizeof(T)
     device_ptr = lock ? Mem.lock(ptr, sz, device) : ptr
-    buf = Mem.Buffer(device_ptr, ptr, device_ptr, sz, device, false, false)
+    buf = Mem.Buffer(device_ptr, Ptr{Cvoid}(ptr), device_ptr, sz, device, false, false)
     return ROCArray{T, N}(buf, dims; own=false)
 end
 Base.unsafe_wrap(::Type{ROCArray{T}}, ptr::Ptr, dims; kwargs...) where T =
@@ -275,9 +275,7 @@ end
 end
 @inline function unsafe_contiguous_view(a::ROCArray{T}, I::NTuple{N,Base.ViewIndex}, dims::NTuple{M,Integer}) where {T,N,M}
     offset = Base.compute_offset1(a, 1, I) * sizeof(T)
-
-    b = ROCArray{T,M}(a.buf, dims, offset=a.offset+offset, own=false)
-    return b
+    ROCArray{T,M}(a.buf, dims, offset=a.offset+offset, own=false)
 end
 
 @inline function unsafe_view(A, I, ::NonContiguous)
@@ -299,8 +297,7 @@ function Base.reshape(a::ROCArray{T,M}, dims::NTuple{N,Int}) where {T,N,M}
         return a
     end
 
-    b = ROCArray{T,N}(a.buf, dims, offset=a.offset, own=false)
-    return b
+    ROCArray{T,N}(a.buf, dims, offset=a.offset, own=false)
 end
 
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -68,24 +68,19 @@ mutable struct ROCArray{T,N} <: AbstractGPUArray{T,N}
     function ROCArray{T,N}(buf::Mem.Buffer, dims::Dims{N}; offset::Integer=0, own::Bool=true) where {T,N}
         @assert isbitstype(T) "ROCArray only supports bits types"
         xs = new{T,N}(buf, own, dims, offset, Runtime.SyncState())
-        if own
-            hsaref!()
-        end
         Mem.retain(buf)
-        finalizer(unsafe_free!, xs)
+        finalizer(_safe_free!, xs)
         return xs
     end
 end
 
-function unsafe_free!(xs::ROCArray)
-    if Mem.release(xs.buf)
-        Mem.free(xs.buf)
-        if xs.own
-            hsaunref!()
-        end
-    end
+_safe_free!(xs::ROCArray) = _safe_free!(xs.buf)
+function _safe_free!(buf::Mem.Buffer)
+    Mem.release(buf)
     return
 end
+
+unsafe_free!(xs::ROCArray) = Mem.free_if_live(xs.buf)
 
 wait!(x::ROCArray) = wait!(x.syncstate)
 mark!(x::ROCArray, s) = mark!(x.syncstate, s)
@@ -281,9 +276,7 @@ end
 @inline function unsafe_contiguous_view(a::ROCArray{T}, I::NTuple{N,Base.ViewIndex}, dims::NTuple{M,Integer}) where {T,N,M}
     offset = Base.compute_offset1(a, 1, I) * sizeof(T)
 
-    Mem.retain(a.buf)
     b = ROCArray{T,M}(a.buf, dims, offset=a.offset+offset, own=false)
-    finalizer(unsafe_free!, b)
     return b
 end
 
@@ -306,9 +299,7 @@ function Base.reshape(a::ROCArray{T,M}, dims::NTuple{N,Int}) where {T,N,M}
         return a
     end
 
-    Mem.retain(a.buf)
     b = ROCArray{T,N}(a.buf, dims, offset=a.offset, own=false)
-    finalizer(unsafe_free!, b)
     return b
 end
 
@@ -401,10 +392,7 @@ zeros(T::Type, dims...) = fill!(ROCArray{T}(undef, dims...), zero(T))
 # create a derived array (reinterpreted or reshaped) that's still a ROCArray
 # TODO: Move this to GPUArrays?
 @inline function _derived_array(::Type{T}, N::Int, a::ROCArray, osize::Dims) where {T}
-    Mem.retain(a.buf)
-    b = ROCArray{T,N}(a.buf, osize, offset=a.offset, own=false)
-    finalizer(unsafe_free!, b)
-    return b
+    return ROCArray{T,N}(a.buf, osize, offset=a.offset, own=false)
 end
 
 ## reinterpret
@@ -523,14 +511,18 @@ end
 """
     resize!(a::ROCVector, n::Integer)
 
-Resize `a` to contain `n` elements. If `n` is smaller than the current collection length,
-the first `n` elements will be retained. If `n` is larger, the new elements are not
-guaranteed to be initialized.
+Resize `a` to contain `n` elements. If `n` is smaller than the current
+collection length, the first `n` elements will be retained. If `n` is larger,
+the new elements are not guaranteed to be initialized.
 
-Note that this operation is only supported on managed buffers, i.e., not on arrays that are
-created by `unsafe_wrap` with `own=false`.
+Note that this operation is only supported on managed buffers, i.e., not on
+arrays that are created by `unsafe_wrap` with `own=false`.
 """
 function Base.resize!(A::ROCVector{T}, n::Integer) where T
+    if !A.own
+        throw(ArgumentError("Cannot resize an unowned `ROCVector`"))
+    end
+
     # TODO: add additional space to allow for quicker resizing
     if n == length(A)
         return A
@@ -547,10 +539,12 @@ function Base.resize!(A::ROCVector{T}, n::Integer) where T
     if copy_size > 0
         Mem.transfer!(new_buf, A.buf, copy_size)
     end
+
+    # Release old buffer
+    _safe_free!(A.buf)
+    # N.B. Manually retain new buffer (this is normally done in ROCArray ctor)
     Mem.retain(new_buf)
-    if Mem.release(A.buf)
-        Mem.free(A.buf)
-    end
+
     A.buf = new_buf
     A.dims = (n,)
     A.offset = 0

--- a/src/runtime/error.jl
+++ b/src/runtime/error.jl
@@ -11,9 +11,10 @@ end
 
 Gets the string description of an error code.
 """
-function description(err::HSAError)
+description(err::HSAError) = description(err.code)
+function description(status::HSA.Status)
     str_ref = Ref{Ptr{Int8}}()
-    HSA.status_string(err.code, str_ref)
+    HSA.status_string(status, str_ref)
     unsafe_string(reinterpret(Cstring, str_ref[]))
 end
 

--- a/src/runtime/kernel-signal.jl
+++ b/src/runtime/kernel-signal.jl
@@ -83,7 +83,7 @@ end
 
 function Base.show(io::IO, kersig::ROCKernelSignal)
     ex = kersig.exception
-    print(io, "ROCKernelSignal(signal=$(kersig.signal), $(ex !== nothing ? ", exception=$ex" : ""))")
+    print(io, "ROCKernelSignal(signal=$(kersig.signal)$(ex !== nothing ? ", exception=$ex" : ""))")
 end
 
 Base.notify(kersig::ROCKernelSignal) = notify(kersig.signal)

--- a/src/runtime/memory.jl
+++ b/src/runtime/memory.jl
@@ -4,7 +4,7 @@
 import AMDGPU
 import AMDGPU: HSA
 if AMDGPU.hip_configured
-import AMDGPU: HIP
+    import AMDGPU: HIP
 end
 import AMDGPU: Runtime
 import .Runtime: ROCDevice, ROCSignal, ROCMemoryRegion, ROCMemoryPool, ROCDim, ROCDim3
@@ -21,6 +21,16 @@ struct Buffer
     device::ROCDevice
     coherent::Bool
     pool_alloc::Bool
+    # Unique ID used for refcounting.
+    _id::UInt64
+
+    function Buffer(
+        ptr::Ptr{Cvoid}, host_ptr::Ptr{Cvoid}, base_ptr::Ptr{Cvoid},
+        bytesize::Int, device::ROCDevice, coherent::Bool, pool_alloc::Bool,
+    )
+        _id = _buffer_id!()
+        new(ptr, host_ptr, base_ptr, bytesize, device, coherent, pool_alloc, _id)
+    end
 end
 
 Base.unsafe_convert(::Type{Ptr{T}}, buf::Buffer) where {T} = convert(Ptr{T}, buf.ptr)
@@ -35,13 +45,18 @@ end
 
 ## refcounting
 
-const refcounts = Dict{Ptr{Cvoid}, Int}()
-const liveness = Dict{Ptr{Cvoid}, Bool}()
+const _ID_COUNTER = Threads.Atomic{UInt64}(0)
+const refcounts = Dict{UInt64, Int}()
+const liveness = Dict{UInt64, Bool}()
 const refcounts_lock = Threads.ReentrantLock()
+
+function _buffer_id!()::UInt64
+    return Threads.atomic_add!(_ID_COUNTER, UInt64(1))
+end
 
 function refcount(buf::Buffer)
     Base.lock(refcounts_lock) do
-        get(refcounts, buf.base_ptr, 0)
+        get(refcounts, buf._id, 0)
     end
 end
 
@@ -52,9 +67,10 @@ Increase the refcount of a buffer.
 """
 function retain(buf::Buffer)
     Base.lock(refcounts_lock) do
-        get!(liveness, buf.base_ptr, true)
-        count = get!(refcounts, buf.base_ptr, 0)
-        refcounts[buf.base_ptr] = count + 1
+        live = get!(liveness, buf._id, true)
+        @assert live "Trying to retain dead buffer!"
+        count = get!(refcounts, buf._id, 0)
+        refcounts[buf._id] = count + 1
     end
     return
 end
@@ -68,12 +84,12 @@ to 0, and some action needs to be taken.
 function release(buf::Buffer)
     while !Base.trylock(refcounts_lock) end
     try
-        count = refcounts[buf.base_ptr]
+        count = refcounts[buf._id]
         @assert count >= 1 "Buffer refcount dropping below 0!"
-        refcounts[buf.base_ptr] = count - 1
+        refcounts[buf._id] = count - 1
         done = count == 1
 
-        live = liveness[buf.base_ptr]
+        live = liveness[buf._id]
 
         if done
             if live
@@ -95,8 +111,8 @@ update refcounts.
 """
 function free_if_live(buf::Buffer)
     Base.lock(refcounts_lock) do
-        if liveness[buf.base_ptr]
-            liveness[buf.base_ptr] = false
+        if liveness[buf._id]
+            liveness[buf._id] = false
             free(buf)
         end
     end
@@ -110,8 +126,8 @@ Removes refcount tracking information for a buffer.
 function untrack(buf::Buffer)
     while !Base.trylock(refcounts_lock) end
     try
-        delete!(liveness, buf.base_ptr)
-        delete!(refcounts, buf.base_ptr)
+        delete!(liveness, buf._id)
+        delete!(refcounts, buf._id)
     finally
         Base.unlock(refcounts_lock)
     end
@@ -366,7 +382,8 @@ function alloc(device::ROCDevice, pool::ROCMemoryPool, bytesize::Integer)
         HSA.amd_memory_pool_allocate(pool.pool, bytesize, 0, ptr_ref)
     end
     AMDGPU.hsaref!()
-    return Buffer(ptr_ref[], C_NULL, ptr_ref[], bytesize, device, Runtime.pool_accessible_by_all(pool), true)
+    ptr = ptr_ref[]
+    return Buffer(ptr, C_NULL, ptr, bytesize, device, Runtime.pool_accessible_by_all(pool), true)
 end
 function alloc(device::ROCDevice, region::ROCMemoryRegion, bytesize::Integer)
     ptr_ref = Ref{Ptr{Cvoid}}()
@@ -374,7 +391,8 @@ function alloc(device::ROCDevice, region::ROCMemoryRegion, bytesize::Integer)
         HSA.memory_allocate(region.region, bytesize, ptr_ref)
     end
     AMDGPU.hsaref!()
-    return Buffer(ptr_ref[], C_NULL, ptr_ref[], bytesize, device, Runtime.region_host_accessible(region), false)
+    ptr = ptr_ref[]
+    return Buffer(ptr, C_NULL, ptr, bytesize, device, Runtime.region_host_accessible(region), false)
 end
 alloc(bytesize; kwargs...) =
     alloc(Runtime.get_default_device(), bytesize; kwargs...)
@@ -392,31 +410,32 @@ function alloc_hip(bytesize::Integer)
         end
     end
     AMDGPU.hsaref!()
-    return Buffer(ptr_ref[], C_NULL, ptr_ref[], bytesize, Runtime.get_default_device(), false, true)
+    ptr = ptr_ref[]
+    return Buffer(ptr, C_NULL, ptr, bytesize, Runtime.get_default_device(), false, true)
 end
 end # if AMDGPU.hip_configured
 
 function free(buf::Buffer)
-    if buf.ptr != C_NULL
-        if buf.host_ptr == C_NULL
-            # HSA-backed
-            if buf.pool_alloc
-                if USE_HIP_MALLOC_OVERRIDE
-                    @static if AMDGPU.hip_configured
-                        # Actually HIP-backed
-                        HIP.@check HIP.hipFree(buf.base_ptr)
-                    end
-                else
-                    memory_check(HSA.amd_memory_pool_free(buf.base_ptr), buf.base_ptr)
+    buf.ptr == C_NULL && return
+
+    if buf.host_ptr == C_NULL
+        # HSA-backed
+        if buf.pool_alloc
+            if USE_HIP_MALLOC_OVERRIDE
+                @static if AMDGPU.hip_configured
+                    # Actually HIP-backed
+                    HIP.@check HIP.hipFree(buf.base_ptr)
                 end
             else
-                memory_check(HSA.memory_free(buf.base_ptr), buf.base_ptr)
+                memory_check(HSA.amd_memory_pool_free(buf.base_ptr), buf.base_ptr)
             end
-            AMDGPU.hsaunref!()
         else
-            # Wrapped
-            unlock(buf.ptr)
+            memory_check(HSA.memory_free(buf.base_ptr), buf.base_ptr)
         end
+        AMDGPU.hsaunref!()
+    else
+        # Wrapped
+        unlock(buf.ptr)
     end
     return
 end

--- a/src/runtime/signal.jl
+++ b/src/runtime/signal.jl
@@ -64,6 +64,7 @@ function Base.wait(
     finished = false
 
     while !finished
+        @assert AMDGPU.HSA_REFCOUNT[] > 0
         v = HSA.signal_wait_scacquire(
             signal.signal[], HSA.SIGNAL_CONDITION_LT, 1,
             min_latency, HSA.WAIT_STATE_BLOCKED)

--- a/test/rocarray/base.jl
+++ b/test/rocarray/base.jl
@@ -96,4 +96,88 @@ end
     finalize(A)
 end
 
+@testset "Refcounting" begin
+    refcount_live(A) = (get(AMDGPU.Mem.refcounts, A.buf.base_ptr, 0),
+                        get(AMDGPU.Mem.liveness, A.buf.base_ptr, false))
+
+    for (f, switch) in [(A->view(A, 2:4), false),
+                        (A->resize!(A, 8), true),
+                        (A->reinterpret(UInt8, A), false),
+                        (A->reshape(A, 4, 4), false)]
+
+        # Safe free
+        A = AMDGPU.ones(16)
+        @test refcount_live(A) == (1, true)
+        B = f(A)
+        @test A.buf.base_ptr == B.buf.base_ptr
+        @test refcount_live(A) == refcount_live(B)
+        @test refcount_live(B) == (2-switch, true)
+        finalize(B)
+        @test refcount_live(B) == (1-switch, !switch)
+        finalize(A)
+        @test refcount_live(B) == (0, false)
+
+        # Unsafe free original
+        A = AMDGPU.ones(16)
+        B = f(A)
+        AMDGPU.unsafe_free!(A)
+        @test refcount_live(B) == (2-switch, false)
+        finalize(B)
+        @test refcount_live(B) == (1-switch, false)
+        finalize(A)
+        @test refcount_live(B) == (0, false)
+
+        # Unsafe free derived
+        A = AMDGPU.ones(16)
+        B = f(A)
+        AMDGPU.unsafe_free!(B)
+        @test refcount_live(B) == (2-switch, false)
+        finalize(A)
+        @test refcount_live(B) == (1-switch, false)
+        finalize(B)
+        @test refcount_live(B) == (0, false)
+
+        # Unsafe free original and derived
+        A = AMDGPU.ones(16)
+        B = f(A)
+        AMDGPU.unsafe_free!(A)
+        AMDGPU.unsafe_free!(B)
+        @test refcount_live(B) == (2-switch, false)
+        finalize(A)
+        @test refcount_live(B) == (1-switch, false)
+        finalize(B)
+        @test refcount_live(B) == (0, false)
+    end
+
+    # Chained Safe free
+    A = AMDGPU.ones(16)
+    @test refcount_live(A) == (1, true)
+    B = reshape(A, 4, 4)
+    @test refcount_live(A) == (2, true)
+    C = reshape(B, 2, 8)
+    @test refcount_live(A) == (3, true)
+    finalize(B)
+    @test refcount_live(A) == (2, true)
+    finalize(A)
+    @test refcount_live(A) == (1, true)
+    finalize(C)
+    @test refcount_live(A) == (0, false)
+
+    # Chained Unsafe free
+    A = AMDGPU.ones(16)
+    @test refcount_live(A) == (1, true)
+    B = reshape(A, 4, 4)
+    @test refcount_live(A) == (2, true)
+    C = reshape(B, 2, 8)
+    @test refcount_live(A) == (3, true)
+    AMDGPU.unsafe_free!(A)
+    @test refcount_live(A) == (3, false)
+    finalize(B)
+    @test refcount_live(A) == (2, false)
+    finalize(A)
+    @test refcount_live(A) == (1, false)
+    finalize(C)
+    @test refcount_live(A) == (0, false)
+end
+
 end

--- a/test/rocarray/base.jl
+++ b/test/rocarray/base.jl
@@ -97,8 +97,8 @@ end
 end
 
 @testset "Refcounting" begin
-    refcount_live(A) = (get(AMDGPU.Mem.refcounts, A.buf.base_ptr, 0),
-                        get(AMDGPU.Mem.liveness, A.buf.base_ptr, false))
+    refcount_live(A) = (get(AMDGPU.Mem.refcounts, A.buf._id, 0),
+                        get(AMDGPU.Mem.liveness, A.buf._id, false))
 
     for (f, switch) in [(A->view(A, 2:4), false),
                         (A->resize!(A, 8), true),


### PR DESCRIPTION
Adds liveness tracking for each HSA/HIP pointer, and allows `unsafe_free!` to mark a pointer as dead; standard buffer refcounting will use this liveness marker to determine if the pointer should be freed.

Also fixes a refcounting off-by-one bug, excessive retains in derived array construction, and moves HSA refcount increment/decrement into memory allocation/free methods.

@pxl-th 