### PR TITLE
Reduce signal wait allocations

### DIFF
--- a/src/runtime/signal.jl
+++ b/src/runtime/signal.jl
@@ -55,7 +55,7 @@ load_acquire(signal::ROCSignal) = HSA.signal_load_scacquire(signal.signal[])
 Base.isdone(signal::ROCSignal) = load_acquire(signal) < 1
 
 Base.show(io::IO, signal::ROCSignal) =
-    print(io, "ROCSignal($(signal.signal[]))")
+    print(io, "ROCSignal($(repr(get_handle(signal))))")
 
 function Base.wait(
     signal::ROCSignal; timeout::Union{Real, Nothing} = DEFAULT_SIGNAL_TIMEOUT[],


### PR DESCRIPTION
This removes excess allocations within the signal wait loop that would build up over time and slow down waiting.