### PR TITLE
Implement unified getinfo interface

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -51,7 +51,6 @@ steps:
       rocmgpu: "*"
     if: build.message !~ /\[skip tests\]/
     command: "julia --project -e 'using Pkg; Pkg.update()'"
-    soft_fail: true
     timeout_in_minutes: 180
     env:
       JULIA_AMDGPU_CORE_MUST_LOAD: "1"
@@ -70,7 +69,6 @@ steps:
       rocmgpu: "*"
     if: build.message !~ /\[skip tests\]/
     command: "julia --project -e 'using Pkg; Pkg.update()'"
-    soft_fail: true
     timeout_in_minutes: 180
     env:
       JULIA_AMDGPU_CORE_MUST_LOAD: "1"
@@ -90,7 +88,6 @@ steps:
       rocmgpu: "*"
     if: build.message !~ /\[skip tests\]/
     command: "julia --project -e 'using Pkg; Pkg.update()'"
-    soft_fail: true
     timeout_in_minutes: 180
     env:
       JULIA_AMDGPU_CORE_MUST_LOAD: "1"

--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -64,6 +64,7 @@ module Runtime
     import TimespanLogging: timespan_start, timespan_finish
 
     import ..AMDGPU
+    import ..AMDGPU: getinfo, getinfo_map
 
     struct Adaptor end
 

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -3,7 +3,7 @@
 import AMDGPU: Runtime, Compiler
 import .Runtime: ROCDevice, ROCQueue, ROCExecutable, ROCKernel, ROCSignal, ROCKernelSignal, HSAError
 import .Runtime: ROCDim, ROCDim3
-import .Runtime: getinfo, wait!, mark!
+import .Runtime: wait!, mark!
 import .Compiler: rocfunction
 
 export @roc, rocconvert, rocfunction
@@ -65,6 +65,8 @@ function device_type(device::ROCDevice)
         return :unknown
     end
 end
+
+wavefrontsize(device::ROCDevice) = Runtime.device_wavefront_size(device)
 
 # Queues
 

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -137,7 +137,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyROCArray{T},
         pool = first(pools)
         max_lmem_elements = Runtime.pool_size(pool) ÷ sizeof(T)
         isa = first(Runtime.isas(device))
-        Base.min(Runtime.max_group_size(isa), compute_items(max_lmem_elements ÷ 2))
+        Base.min(Runtime.isa_workgroup_max_size(isa), compute_items(max_lmem_elements ÷ 2))
     else
         @warn "No group segment detected for device $device; assuming 64 elements\nThis message will not be shown again" maxlog=1
         64

--- a/src/random.jl
+++ b/src/random.jl
@@ -6,12 +6,8 @@ const GPUARRAY_RNG = Ref{Union{Nothing,GPUArrays.RNG}}(nothing)
 
 function GPUArrays.default_rng(::Type{<:ROCArray})
     if GPUARRAY_RNG[] == nothing
-        device = AMDGPU.default_device().agent
-        p = Ref{UInt32}()
-        GC.@preserve p begin
-            AMDGPU.getinfo(device, HSA.AGENT_INFO_WORKGROUP_MAX_SIZE, p) |> Runtime.check
-            N = Int(p[])
-        end
+        device = AMDGPU.default_device()
+        N = Int(Runtime.device_workgroup_max_size(device))
         state = ROCArray{NTuple{4, UInt32}}(undef, N)
         GPUARRAY_RNG[] = GPUArrays.RNG(state)
         Random.seed!(GPUARRAY_RNG[])

--- a/src/runtime/kernel.jl
+++ b/src/runtime/kernel.jl
@@ -70,56 +70,61 @@ mutable struct ROCKernel{F,T<:Tuple}
     kernarg_address::Ptr{Nothing}
 end
 
+function executable_symbol_any(exe::ROCExecutable, device::ROCDevice)
+    agent_func = @cfunction(iterate_exec_agent_syms_cb, HSA.Status,
+                            (HSA.Executable, HSA.Agent, HSA.ExecutableSymbol, Ptr{HSA.ExecutableSymbol}))
+    exec_symbol_ref = Ref{HSA.ExecutableSymbol}()
+    ret = HSA.executable_iterate_agent_symbols(exe.executable[], device.agent,
+                                               agent_func, exec_symbol_ref)
+    @assert ret == HSA.STATUS_SUCCESS || ret == HSA.STATUS_INFO_BREAK
+    if isassigned(exec_symbol_ref)
+        return exec_symbol_ref[]
+    end
+    return nothing
+end
+function executable_symbol_by_name(exe::ROCExecutable, device::ROCDevice, name::Symbol)
+    agent_ref = Ref(device.agent)
+    exec_symbol_ref = Ref{HSA.ExecutableSymbol}()
+    GC.@preserve agent_ref begin
+        HSA.executable_get_symbol_by_name(exe.executable[], symbol,
+                                          agent_ref, exec_symbol_ref) |> check
+    end
+    if isassigned(exec_symbol_ref)
+        return exec_symbol_ref[]
+    end
+    return nothing
+end
+
 function ROCKernel(kernel #= ::HostKernel =#, f::Core.Function, args::Tuple; localmem::Int=0)
     exe = kernel.mod.exe
     device = exe.device
     symbol = kernel.fun.entry
-    agent_func = @cfunction(iterate_exec_agent_syms_cb, HSA.Status,
-                           (HSA.Executable, HSA.Agent, HSA.ExecutableSymbol, Ptr{Cvoid}))
-    exec_symbol = Ref{HSA.ExecutableSymbol}()
-    exec_ptr = Base.unsafe_convert(Ref{Cvoid}, exec_symbol)
-    HSA.executable_iterate_agent_symbols(exe.executable[], device.agent,
-                                         agent_func, exec_ptr) |> check
 
+    exec_symbol = executable_symbol_any(exe, device)
     # TODO: Conditionally disable once ROCR is fixed
-    if !isassigned(exec_symbol)
-        agent_ref = Ref(device.agent)
-        GC.@preserve agent_ref begin
-            HSA.executable_get_symbol_by_name(exe.executable[], symbol,
-                                              agent_ref, exec_symbol) |> check
-        end
+    if exec_symbol === nothing
+        exec_symbol = something(executable_symbol_by_name(exe, device, symbol))
     end
 
-    kernel_object = Ref{UInt64}(0)
-    getinfo(exec_symbol[], HSA.EXECUTABLE_SYMBOL_INFO_KERNEL_OBJECT,
-            kernel_object) |> check
-
-    kernarg_segment_size = Ref{UInt32}(0)
-    getinfo(exec_symbol[], HSA.EXECUTABLE_SYMBOL_INFO_KERNEL_KERNARG_SEGMENT_SIZE,
-            kernarg_segment_size) |> check
-
-    if kernarg_segment_size[] == 0
+    kernel_object = executable_symbol_kernel_object(exec_symbol)
+    kernarg_segment_size = executable_symbol_kernel_kernarg_segment_size(exec_symbol)
+    if kernarg_segment_size == 0
         # FIXME: Hidden arguments!
         if length(args) > 0
-            kernarg_segment_size[] = sum(sizeof(typeof(arg)) for arg in args)
+            kernarg_segment_size = UInt32(sum(sizeof(typeof(arg)) for arg in args))
         else
             # Allocate some memory anyway, #10
-            kernarg_segment_size[] = max(kernarg_segment_size[], 8)
+            kernarg_segment_size = UInt32(max(kernarg_segment_size, 8))
         end
     end
 
-    group_segment_size = Ref{UInt32}(0)
-    getinfo(exec_symbol[], HSA.EXECUTABLE_SYMBOL_INFO_KERNEL_GROUP_SEGMENT_SIZE,
-            group_segment_size) |> check
-    group_segment_size[] = max(group_segment_size[], localmem)
-
-    private_segment_size = Ref{UInt32}(0)
-    getinfo(exec_symbol[], HSA.EXECUTABLE_SYMBOL_INFO_KERNEL_PRIVATE_SEGMENT_SIZE,
-            private_segment_size) |> check
+    group_segment_size = executable_symbol_kernel_group_segment_size(exec_symbol)
+    group_segment_size = UInt32(max(group_segment_size, localmem))
+    private_segment_size = executable_symbol_kernel_private_segment_size(exec_symbol)
 
     # Allocate the kernel argument buffer
     key = khash(f, khash(args))
-    kernarg_address, do_write = Mem.alloc_pooled(device, key, :kernarg, kernarg_segment_size[])
+    kernarg_address, do_write = Mem.alloc_pooled(device, key, :kernarg, kernarg_segment_size)
 
     if do_write
         # Fill kernel argument buffer
@@ -140,9 +145,9 @@ function ROCKernel(kernel #= ::HostKernel =#, f::Core.Function, args::Tuple; loc
         end
     end
 
-    kernel = ROCKernel(device, exe, symbol, f, args, kernel_object[],
-                       kernarg_segment_size[], group_segment_size[],
-                               private_segment_size[], kernarg_address)
+    kernel = ROCKernel(device, exe, symbol, f, args, kernel_object,
+                       kernarg_segment_size, group_segment_size,
+                       private_segment_size, kernarg_address)
     AMDGPU.hsaref!()
     finalizer(kernel) do k
         Mem.free_pooled(device, key, :kernarg, k.kernarg_address)

--- a/src/runtime/queue.jl
+++ b/src/runtime/queue.jl
@@ -30,17 +30,21 @@ function queue_error_handler(
     nothing
 end
 
+device_queue_max_size(device::AnyROCDevice) =
+    getinfo(device, HSA.AGENT_INFO_QUEUE_MAX_SIZE)
+
+device_queue_type(device::AnyROCDevice) =
+    getinfo(device, HSA.AGENT_INFO_QUEUE_TYPE)
+
 function ROCQueue(device::ROCDevice; priority::Symbol = :normal)
     alloc_id = rand(UInt64)
     @log_start(:alloc_queue, (;alloc_id), (;device=get_handle(device), priority))
 
-    queue_size = Ref{UInt32}(0)
-    getinfo(device.agent, HSA.AGENT_INFO_QUEUE_MAX_SIZE, queue_size) |> check
-    @assert queue_size[] > 0
+    queue_size = device_queue_max_size(device)
+    @assert queue_size > 0
 
-    queue_type = Ref{HSA.QueueType}()
-    getinfo(device.agent, HSA.AGENT_INFO_QUEUE_TYPE, queue_type) |> check
-    @assert queue_type[] == HSA.QUEUE_TYPE_MULTI
+    queue_type = device_queue_type(device)
+    @assert queue_type == HSA.QUEUE_TYPE_MULTI
 
     r_queue = Ref{Ptr{HSA.Queue}}()
     queue = ROCQueue(device, Ptr{HSA.Queue}(0), HSA.STATUS_SUCCESS, true)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -171,3 +171,22 @@ function print_build_diagnostics()
     end
     run(`id`)
 end
+
+function getinfo(object, query)
+    map = getinfo_map(object)
+    @assert haskey(map, query)
+    info_type = map[query]
+    value = if info_type === Vector{UInt8}
+        Base.zeros(UInt8, 64)
+    else
+        Ref{info_type}()
+    end
+    getinfo(object, query, value) |> Runtime.check
+    if value isa Vector{UInt8}
+        return rstrip(String(value), '\0')
+    else
+        return value[]
+    end
+end
+getinfo_map(::T) where T =
+    throw(ArgumentError("No getinfo mappings defined for $T"))

--- a/test/device/output.jl
+++ b/test/device/output.jl
@@ -112,7 +112,7 @@ end
 
 @testset "Per-wavefront" begin
     kernel() = @rocprintf :wave "[%d] " workitemIdx().x
-    wsize::Int64 = AMDGPU.Runtime.wavefrontsize(ROCDevice())
+    wsize::Int64 = AMDGPU.wavefrontsize(ROCDevice())
 
     # One group, one wavefront
     exp = "[1] "

--- a/test/device/wavefront.jl
+++ b/test/device/wavefront.jl
@@ -1,5 +1,5 @@
 @testset "Wavefront Operations" begin
-    wavefrontsize = AMDGPU.Runtime.wavefrontsize(AMDGPU.default_device())
+    wavefrontsize = AMDGPU.wavefrontsize(AMDGPU.default_device())
 
     function reduce_kernel(op,X,Y)
         idx = workitemIdx().x
@@ -57,7 +57,7 @@
 end
 
 @testset "Wavefront Information" begin
-    wavefrontsize = AMDGPU.Runtime.wavefrontsize(AMDGPU.default_device())
+    wavefrontsize = AMDGPU.wavefrontsize(AMDGPU.default_device())
 
     @test wavefrontsize == 32 || wavefrontsize == 64
 

--- a/test/hsa/getinfo.jl
+++ b/test/hsa/getinfo.jl
@@ -1,0 +1,84 @@
+@testset "getinfo queries" begin
+    @testset "ROCDevice" begin
+        device = AMDGPU.default_device()
+        for (kind, T) in AMDGPU.Runtime.AGENT_INFO_MAP
+            result = AMDGPU.getinfo(device, kind)
+            result_raw = AMDGPU.getinfo(device.agent, kind)
+            if T === Vector{UInt8}
+                @test result isa AbstractString
+                @test result_raw isa AbstractString
+            else
+                @test result isa T
+                @test result_raw isa T
+            end
+            @test result == result_raw
+        end
+    end
+    @testset "HSA.ISA" begin
+        device = AMDGPU.default_device()
+        device_isa = first(AMDGPU.Runtime.isas(device))
+        for (kind, T) in AMDGPU.Runtime.ISA_INFO_MAP
+            result = AMDGPU.getinfo(device_isa, kind)
+            if T === Vector{UInt8}
+                @test result isa AbstractString
+            else
+                @test result isa T
+            end
+        end
+    end
+    @testset "ROCMemoryRegion" begin
+        device = AMDGPU.default_device()
+        region = first(AMDGPU.Runtime.regions(device))
+        for (kind, T) in AMDGPU.Runtime.REGION_INFO_MAP
+            if kind == AMDGPU.HSA.REGION_INFO_ALLOC_MAX_PRIVATE_WORKGROUP_SIZE &&
+               (AMDGPU.Runtime.region_segment(region) & AMDGPU.HSA.REGION_SEGMENT_PRIVATE == 0)
+                # TODO: Test this too
+                continue
+            end
+            result = AMDGPU.getinfo(region, kind)
+            result_raw = AMDGPU.getinfo(region.region, kind)
+            if T === Vector{UInt8}
+                @test result isa AbstractString
+                @test result_raw isa AbstractString
+            else
+                @test result isa T
+                @test result_raw isa T
+            end
+            @test result == result_raw
+        end
+    end
+    @testset "ROCMemoryPool" begin
+        device = AMDGPU.default_device()
+        pool = first(AMDGPU.Runtime.memory_pools(device))
+        for (kind, T) in AMDGPU.Runtime.POOL_INFO_MAP
+            result = AMDGPU.getinfo(pool, kind)
+            result_raw = AMDGPU.getinfo(pool.pool, kind)
+            if T === Vector{UInt8}
+                @test result isa AbstractString
+                @test result_raw isa AbstractString
+            else
+                @test result isa T
+                @test result_raw isa T
+            end
+            @test result == result_raw
+        end
+    end
+    @testset "HSA.ExecutableSymbol" begin
+        device = AMDGPU.default_device()
+        kernel = @roc launch=false identity(nothing)
+        exe = kernel.mod.exe
+        sym_name = kernel.fun.entry
+        exec_sym = AMDGPU.Runtime.executable_symbol_any(exe, device)
+        if exec_sym === nothing
+            exec_sym = AMDGPU.Runtime.executable_symbol_by_name(exe, device, sym_name)
+        end
+        for (kind, T) in AMDGPU.Runtime.EXECUTABLE_SYMBOL_INFO_MAP
+            result = AMDGPU.getinfo(exec_sym, kind)
+            if T === Vector{UInt8}
+                @test result isa AbstractString
+            else
+                @test result isa T
+            end
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,6 +49,7 @@ push!(tests, "Core" => ()->include("pointer.jl"))
 push!(tests, "HSA" => ()->begin
     include("hsa/error.jl")
     include("hsa/utils.jl")
+    include("hsa/getinfo.jl")
     include("hsa/device.jl")
     include("hsa/queue.jl")
     include("hsa/memory.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ np = Threads.nthreads()
 ws = Int[]
 ws_pids = Int[]
 if np == 1
+    include("setup.jl")
     push!(ws, 1)
     push!(ws_pids, getpid())
 else


### PR DESCRIPTION
Makes `getinfo` more powerful by keeping track of the appropriate `Ref` eltype for all implemented info queries, and provides a generic interface which doesn't require passing a `Ref` object of the appropriate type.