### PR TITLE
Assorted fixes

### DIFF
--- a/deps/bindeps.jl
+++ b/deps/bindeps.jl
@@ -21,26 +21,18 @@ function find_roc_paths()
     if haskey(ENV, "ROCM_PATH")
         push!(paths, joinpath(ENV["ROCM_PATH"], "lib"))
     end
-    paths = filter(isdir, paths)
-    @debug "bindeps: ROCm library search paths:"
-    for path in paths
-        @debug "bindeps: - " * path
-    end
-    return paths
+    return filter(isdir, paths)
 end
 
 function find_rocm_library(lib, dirs, ext=dlext)
-    @debug "bindeps: Searching for $lib.$ext"
     path = Libdl.find_library(lib)
     if path != ""
-        @debug "bindeps: - $path: true"
         return Libdl.dlpath(path)
     end
     for dir in dirs
         files = readdir(dir)
         for file in files
             matched = startswith(basename(file), lib*".$ext")
-            @debug "bindeps: - $file: $matched"
             if matched
                 return joinpath(dir, file)
             end
@@ -80,7 +72,6 @@ function find_ld_lld()
                 vstr = replace(vstr, "AMD " => "")
                 vstr_splits = split(vstr, ' ')
                 if VersionNumber(vstr_splits[2]) >= v"6.0.0"
-                    @debug "bindeps: Found useable ld.lld at $exp_ld_path"
                     return exp_ld_path
                 end
             catch

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -146,8 +146,8 @@ Constructs a `ROCKernel` object from a compiled kernel described by `kernel`.
 
 See [`@roc`](@ref) for the list of available keyword arguments.
 """
-create_kernel(kernel::Runtime.HostKernel, f, args; kwargs...) =
-    ROCKernel(kernel, f, args; kwargs...)
+create_kernel(kernel::Runtime.HostKernel; kwargs...) =
+    ROCKernel(kernel; kwargs...)
 
 ## Kernel launch and barriers
 
@@ -437,8 +437,7 @@ macro roc(ex...)
                         if $wait
                             foreach($wait!, ($(var_exprs...),))
                         end
-                        local $kernel_instance = $create_kernel(
-                            $kernel, $kernel_f, $kernel_args; $(kernel_kwargs...))
+                        local $kernel_instance = $create_kernel($kernel; $(kernel_kwargs...))
                         local $signal = $create_event(
                             $kernel_instance; $(device_kwargs...), $(signal_kwargs...))
                         $kernel($kernel_args...; signal=$signal, $(call_kwargs...))

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -433,10 +433,10 @@ macro roc(ex...)
                         $kernel_f, $kernel_tt;
                         $(device_kwargs...), $(compiler_kwargs...))
 
-                    if $wait
-                        foreach($wait!, ($(var_exprs...),))
-                    end
                     if $launch
+                        if $wait
+                            foreach($wait!, ($(var_exprs...),))
+                        end
                         local $kernel_instance = $create_kernel(
                             $kernel, $kernel_f, $kernel_args; $(kernel_kwargs...))
                         local $signal = $create_event(

--- a/src/runtime/device.jl
+++ b/src/runtime/device.jl
@@ -126,6 +126,7 @@ const AGENT_INFO_MAP = Dict(
     HSA.AGENT_INFO_QUEUE_MAX_SIZE => UInt32,
     HSA.AGENT_INFO_QUEUE_TYPE => HSA.QueueType,
 
+    HSA.AGENT_INFO_WAVEFRONT_SIZE => UInt32, # TODO: Deprecated
     HSA.AGENT_INFO_WORKGROUP_MAX_SIZE => UInt32,
     HSA.AMD_AGENT_INFO_COMPUTE_UNIT_COUNT => UInt32,
     HSA.AMD_AGENT_INFO_NUM_SIMDS_PER_CU => UInt32,
@@ -150,6 +151,9 @@ profile(device::AnyROCDevice) =
 
 device_type(device::AnyROCDevice) =
     getinfo(device, HSA.AGENT_INFO_DEVICE)
+
+device_wavefront_size(device::AnyROCDevice) =
+    getinfo(device, HSA.AGENT_INFO_WAVEFRONT_SIZE)
 
 device_workgroup_max_size(device::AnyROCDevice) =
     getinfo(device, HSA.AGENT_INFO_WORKGROUP_MAX_SIZE)

--- a/src/runtime/execution.jl
+++ b/src/runtime/execution.jl
@@ -133,12 +133,50 @@ roccall
     end
 
     append!(ex.args, (quote
+        write_args!(signal.kernel, $(arg_ptrs...))
         #GC.@preserve $(converted_args...) begin
             launch_kernel!(signal, groupsize, gridsize, ($(arg_ptrs...),))
         #end
     end).args)
 
     return ex
+end
+
+function write_args!(kernel::ROCKernel, args...)
+    # Allocate the kernel argument buffer
+    key = khash(args)
+    kernarg_address, do_write = Mem.alloc_pooled(kernel.device, key, :kernarg,
+                                                 kernel.kernarg_segment_size)
+
+    if do_write
+        # Fill kernel argument buffer
+        # FIXME: Query kernarg segment alignment
+        ctr = 0
+        for arg in args
+            sz = sizeof(typeof(arg))
+            if sz == 0
+                continue
+            end
+            rarg = Ref(arg)
+            align = Base.datatype_alignment(typeof(arg))
+            rem = mod(ctr, align)
+            if rem > 0
+                ctr += align-rem
+            end
+            ccall(:memcpy, Cvoid,
+                  (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t),
+                  kernarg_address+ctr, rarg, sz)
+            ctr += sz
+        end
+    end
+
+    # Register kernarg buffer
+    kernel.kernarg_address = kernarg_address
+    AMDGPU.hsaref!()
+    finalizer(kernel) do k
+        Mem.free_pooled(kernel.device, key, :kernarg, kernarg_address)
+        AMDGPU.hsaunref!()
+    end
 end
 
 ## device-side kernels

--- a/src/runtime/kernel-signal.jl
+++ b/src/runtime/kernel-signal.jl
@@ -36,7 +36,7 @@ function Base.wait(
 )
     @log_start(:wait, (;f=typeof(kersig.kernel.f), tt=typeof(kersig.kernel.args), signal=get_handle(kersig.signal)), nothing)
     finished = try
-        wait(kersig.signal; signal_kwargs...)
+        wait(kersig.signal; queue=kersig.queue, signal_kwargs...)
         true
     catch err
         if isa(err, SignalTimeoutException) && SIGNAL_TIMEOUT_KILL_QUEUE[]

--- a/src/runtime/queue.jl
+++ b/src/runtime/queue.jl
@@ -1,13 +1,3 @@
-struct QueueError <: Exception
-    queue::Ptr{HSA.Queue}
-    err::HSAError
-end
-
-function Base.showerror(io::IO, err::QueueError)
-    println(io, "QueueError(Queue at $(err.queue)) due to:")
-    Base.showerror(io, err.err)
-end
-
 mutable struct ROCQueue
     device::ROCDevice
     @atomic queue::Ptr{HSA.Queue}
@@ -28,6 +18,17 @@ function queue_error_handler(
         queue.status = status
     end
     nothing
+end
+
+struct QueueError <: Exception
+    queue::Ptr{HSA.Queue}
+    err::HSAError
+end
+QueueError(queue::ROCQueue) = QueueError(queue.queue, HSAError(queue.status))
+
+function Base.showerror(io::IO, err::QueueError)
+    println(io, "QueueError(Queue at $(err.queue)) due to:")
+    Base.showerror(io, err.err)
 end
 
 device_queue_max_size(device::AnyROCDevice) =

--- a/src/runtime/signal.jl
+++ b/src/runtime/signal.jl
@@ -60,6 +60,7 @@ Base.show(io::IO, signal::ROCSignal) =
 function Base.wait(
     signal::ROCSignal; timeout::Union{Real, Nothing} = DEFAULT_SIGNAL_TIMEOUT[],
     min_latency::Int64 = 1_000, # 1 micro-second
+    queue = nothing,
 )
     has_timeout = !isnothing(timeout)
     has_timeout && (timeout < 0) && error(
@@ -84,6 +85,10 @@ function Base.wait(
             if has_timeout && !finished
                 diff_time = (time_ns() - start_time) / 1e9
                 (diff_time > timeout) && throw(SignalTimeoutException(signal))
+            end
+
+            if queue !== nothing && queue.status !== HSA.STATUS_SUCCESS
+                throw(QueueError(queue))
             end
 
             # Allow another scheduled task to run.


### PR DESCRIPTION
Fixes various issues:
- `@roc` no longer synchronizes on kernel arguments when `launch=false`
- `wait` on the result of `@roc` now checks for and propagates queue errors
- Kernarg buffer writing happens just before launch, where ghost arguments have been eliminated
- Adds the missing `Runtime.device_wavefront_size` query for the generic `AMDGPU.wavefrontsize` call