### PR TITLE
Add memory allocation limiters

### DIFF
--- a/src/runtime/kernel.jl
+++ b/src/runtime/kernel.jl
@@ -115,9 +115,33 @@ function ROCKernel(kernel #= ::HostKernel =#; localmem::Int=0)
     group_segment_size = executable_symbol_kernel_group_segment_size(exec_symbol)
     group_segment_size = UInt32(max(group_segment_size, localmem))
     private_segment_size = executable_symbol_kernel_private_segment_size(exec_symbol)
+    if private_segment_size > MAXIMUM_SCRATCH_ALLOCATION
+        @debug "Excessive scratch allocation requested\nReducing per-lane scratch to $(Int(MAXIMUM_SCRATCH_ALLOCATION)) bytes"
+        private_segment_size = MAXIMUM_SCRATCH_ALLOCATION
+    end
 
     kernel = ROCKernel(device, exe, symbol, kernel_object,
                        kernarg_segment_size, group_segment_size,
                        private_segment_size, Ptr{Cvoid}(0))
     return kernel
 end
+
+"Sets the maximum amount of per-lane scratch memory that can be allocated for a
+kernel. Consider setting this to a value below 2^14 if encountering
+`QueueError`s with the `HSA.STATUS_ERROR_OUT_OF_RESOURCES` code."
+set_max_scratch!(scratch::Integer) =
+    @set_preferences!("max_scratch"=>scratch)
+const MAXIMUM_SCRATCH_ALLOCATION = let
+    if haskey(ENV, "JULIA_AMDGPU_MAX_SCRATCH")
+        scratch = ENV["JULIA_AMDGPU_MAX_SCRATCH"]
+        scratch = if uppercase(scratch) == "MAX"
+            typemax(UInt32)
+        else
+            parse(UInt32, scratch)
+        end
+        set_max_scratch!(scratch)
+        scratch
+    else
+        UInt32(@load_preference("max_scratch", 8192))
+    end
+end::UInt32


### PR DESCRIPTION
Adds limiters for HSA memory allocations, and also for dynamic scratch memory allocations. The former is useful to detect where excessive allocations might be happening, and the latter is useful to ensure that we don't over-allocate scratch memory when it won't actually be used.

We also set a default scratch limit of 8192 bytes, down from the 16384 that the compiler chooses when including error paths.