### PR TITLE
Store `HSA.Signal` instead of `Ref{HSA.Signal}` in `ROCSignal`

### DIFF
--- a/src/runtime/launch.jl
+++ b/src/runtime/launch.jl
@@ -121,7 +121,7 @@ function launch_kernel!(
         @set! _packet.grid_size_x = gridsize.x
         @set! _packet.grid_size_y = gridsize.y
         @set! _packet.grid_size_z = gridsize.z
-        @set! _packet.completion_signal = signal.signal[]
+        @set! _packet.completion_signal = signal.signal
         @set! _packet.kernel_object = kernel.kernel_object
         @set! _packet.kernarg_address = kernel.kernarg_address
         @set! _packet.private_segment_size = kernel.private_segment_size
@@ -138,7 +138,7 @@ function launch_barrier!(T, queue::ROCQueue, signals::Vector{ROCSignal})
         for signal_set in Iterators.partition(signals, 5)
             comp_signal = ROCSignal()
             enqueue_packet!(T, queue) do _packet
-                @set! _packet.dep_signal = ntuple(i->length(signal_set)>=i ? signal_set[i].signal[] : HSA.Signal(0), 5)
+                @set! _packet.dep_signal = ntuple(i->length(signal_set)>=i ? signal_set[i].signal : HSA.Signal(0), 5)
                 _packet
             end
             push!(outset.signals, comp_signal)

--- a/src/runtime/memory.jl
+++ b/src/runtime/memory.jl
@@ -712,14 +712,13 @@ function unsafe_copy3d!(dst::Ptr{T}, src::Ptr{T}, width, height=1, depth=1;
     dstOffsetRef = Ref(HSA.Dim3(dstOffset...))
     srcOffsetRef = Ref(HSA.Dim3(srcOffset...))
     rangeRef = Ref(HSA.Dim3(sizeof(T)*width, height, depth))
-    sig = signal.signal[]
 
     AMDGPU.HSA.amd_memory_async_copy_rect(Base.unsafe_convert(Ptr{HSA.PitchedPtr}, dstRef),
                                           Base.unsafe_convert(Ptr{HSA.Dim3},       dstOffsetRef),
                                           Base.unsafe_convert(Ptr{HSA.PitchedPtr}, srcRef),
                                           Base.unsafe_convert(Ptr{HSA.Dim3},       srcOffsetRef),
                                           Base.unsafe_convert(Ptr{HSA.Dim3},       rangeRef),
-                                          Runtime.get_default_device().agent,hsaCopyDir,UInt32(0),C_NULL,sig) |> check
+                                          Runtime.get_default_device().agent,hsaCopyDir,UInt32(0),C_NULL, signal.signal) |> check
 
     async || wait(signal)
     return nothing

--- a/test/device/deps.jl
+++ b/test/device/deps.jl
@@ -26,11 +26,11 @@
                 if i > 0
                     sleep(0.5)
                     @test Array(RA)[1] == 0.0
-                    HSA.signal_store_screlease(sig.signal[], 3)
+                    HSA.signal_store_screlease(sig.signal, 3)
                     wait.(ret1)
                     @test Array(RA)[1] == 1.0
                 end
-                HSA.signal_store_screlease(sig.signal[], 0)
+                HSA.signal_store_screlease(sig.signal, 0)
                 # FIXME: wait(retb)
                 wait(ret2)
                 @test Array(RA)[1] == 2.0
@@ -54,18 +54,18 @@
                 if i > 0
                     sleep(0.5)
                     @test Array(RA)[1] == 0.0
-                    HSA.signal_store_release(sig.signal[], 3)
+                    HSA.signal_store_release(sig.signal], 3)
 
                     wait(ret1[1])
                     @test Array(RA)[1] == 1.0
                 end
-                HSA.signal_store_screlease(sig.signal[], 0)
+                HSA.signal_store_screlease(sig.signal, 0)
                 sleep(0.5)
                 @test Array(RA)[1] == 2.0
                 wait(ret2)
                 # FIXME: wait(retb)
                 # clear waiting kernels
-                HSA.signal_store_screlease(sig.signal[], 7)
+                HSA.signal_store_screlease(sig.signal, 7)
             end
         end
     end

--- a/test/device/execution_control.jl
+++ b/test/device/execution_control.jl
@@ -10,7 +10,7 @@
 
     ev = @roc completion_signal_kernel(RA)
     wait(ev)
-    @test Array(RA)[1] == ev.signal.signal[].handle
+    @test Array(RA)[1] == ev.signal.signal.handle
 end
 
 @testset "sendmsg/sendmsghalt/endpgm" begin

--- a/test/device/launch.jl
+++ b/test/device/launch.jl
@@ -102,7 +102,7 @@ end
     sig = @roc identity(nothing)
     wait(sig)
     wait(sig.signal)
-    wait(sig.signal.signal[])
+    wait(sig.signal.signal)
     @test sig.queue === AMDGPU.default_queue()
 end
 


### PR DESCRIPTION
We always unref `Ref{HSA.Signal}` before using it anywhere, so instead we can unref it right after the creation, which will save us from unnecessary allocations later on.