### PR TITLE
devices: Switch device_local_memory_size to use pools

### DIFF
--- a/src/runtime/device.jl
+++ b/src/runtime/device.jl
@@ -151,13 +151,13 @@ device_num_simds_per_compute_unit(device::AnyROCDevice) =
     getinfo(UInt32, device, HSA.AMD_AGENT_INFO_NUM_SIMDS_PER_CU)
 
 function device_local_memory_size(device::AnyROCDevice)
-    _regions = regions(device)
-    for region in _regions
-        if region_segment(region) == HSA.REGION_SEGMENT_GROUP
-            return region_size(region)
+    _pools = memory_pools(device)
+    for pool in _pools
+        if pool_segment(pool) == HSA.AMD_SEGMENT_GROUP
+            return pool_size(pool)
         end
     end
-    error("Failed to find local memory region for $device")
+    error("Failed to find local memory pool for $device")
 end
 
 ### ISAs


### PR DESCRIPTION
Since the regions API is broken on the non-primary device.