### PR TITLE
Use broadcast instead of copies to initialize mapreduce buffers.

### DIFF
--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -176,12 +176,7 @@ function GPUArrays.mapreducedim!(f::F, op::OP, R::AnyROCArray{T},
         partial = similar(R, (size(R)..., reduce_groups))
         if init === nothing
             # without an explicit initializer we need to copy from the output container
-            sz = prod(size(R))
-            for i in 1:reduce_groups
-                # TODO: async copies (or async fill!, but then we'd need to load first)
-                #       or maybe just broadcast since that extends singleton dimensions
-                copyto!(partial, (i-1)*sz+1, R, 1, sz)
-            end
+            partial .= R
         end
         wait(@roc gridsize=gridsize groupsize=items partial_mapreduce_device(
             f, op, init, Val(items), Rreduce, Rother, partial, A))


### PR DESCRIPTION
That only requires a single kernel vs. N copies for every block.

ref https://github.com/JuliaGPU/CUDA.jl/pull/1223