### PR TITLE
Add blas wrappers for triangular matrix mul / div

### DIFF
--- a/test/rocarray/blas.jl
+++ b/test/rocarray/blas.jl
@@ -206,6 +206,55 @@ end
             end
         end
     end
+
+    @testset "triangular lmul!, rmul!, ldiv!, rdiv!" begin
+        for T in (Float32, Float64)
+            A = triu(rand(T, 20, 20))
+            B = rand(T, 20, 20)
+            b = rand(T, 20)
+            dA, dB, db = ROCArray(A), ROCArray(B), ROCArray(b)
+
+            for t in (identity, transpose, adjoint),
+                TR in (UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular)
+
+                # Left division.
+                dC = copy(dB)
+                ldiv!(t(TR(dA)), dC)
+                C = t(TR(A)) \ B
+                @test C ≈ Array(dC)
+
+                # Right division.
+                dC = copy(dB)
+                rdiv!(dC, t(TR(dA)))
+                C = B / t(TR(A))
+                @test C ≈ Array(dC)
+
+                # Left division vector.
+                dc = copy(db)
+                ldiv!(t(TR(dA)), dc)
+                c = t(TR(A)) \ b
+                @test c ≈ Array(dc)
+
+                # Left multiplication.
+                dC = copy(dB)
+                lmul!(t(TR(dA)), dC)
+                C = t(TR(A)) * B
+                @test C ≈ Array(dC)
+
+                # Right multiplication.
+                dC = copy(dB)
+                rmul!(dC, t(TR(dA)))
+                C = B * t(TR(A))
+                @test C ≈ Array(dC)
+
+                # Left multiplication by vector.
+                dc = copy(db)
+                lmul!(t(TR(dA)), dc)
+                c = t(TR(A)) * b
+                @test c ≈ Array(dc)
+            end
+        end
+    end
 end
 
 end # testset BLAS


### PR DESCRIPTION
We had method definitions for:
`Transpose{T,UpperTriangular{T,ROCMatrix{T}}}`
But not for:
`LowerTriangular{T, Transpose{T, ROCMatrix{T}}}`

Which is what you get from:
```julia
julia> x = ROCArray(triu(rand(Float32, 4, 4)));

julia> x = transpose(UpperTriangular(x))
4×4 LowerTriangular{Float32, Transpose{Float32, ROCMatrix{Float32}}}:
 0.939737    ⋅         ⋅         ⋅ 
 0.0391901  0.184103   ⋅         ⋅ 
 0.578203   0.059085  0.419264   ⋅ 
 0.245061   0.34397   0.923544  0.710086
```

This PR adds those definitions for BLAS 2 & 3 as well as tests.