### PR TITLE
Simplify signal pooling

### DIFF
--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -64,7 +64,7 @@ module Runtime
     import TimespanLogging: timespan_start, timespan_finish
 
     import ..AMDGPU
-    import ..AMDGPU: getinfo
+    import ..AMDGPU: getinfo, LockedObject
 
     struct Adaptor end
 

--- a/src/runtime/signal.jl
+++ b/src/runtime/signal.jl
@@ -56,6 +56,7 @@ the host and device.
     signals; if `false`, or if the pool is empty, the signal is allocated from HSA.
 - `ipc::Bool`: If `true`, signal may be used for interprocess communication.
     IPC signals can be read, written, and waited on from any process.
+    Disables signal pooling when `true`.
 """
 function ROCSignal(init::Int64 = 1; pooled::Bool = true, ipc::Bool = false)
     pooled = ipc ? false : pooled
@@ -68,7 +69,7 @@ function ROCSignal(init::Int64 = 1; pooled::Bool = true, ipc::Bool = false)
             HSA.signal_create(init, 0, C_NULL, signal_ref))
         raw_signal = signal_ref[]
     else
-        HSA.signal_store_relaxed(raw_signal, init)
+        HSA.signal_store_relaxed(raw_signal, init) |> check
     end
 
     AMDGPU.hsaref!()


### PR DESCRIPTION
- Use `LockedObject` instead of `ALLOC_SIGNAL_LOCK` global lock.
- Handle fetching from pool and pushing to pool in its own functions.
- Remove outer while loop in signal wait function.
Was the outer while loop to check `@assert AMDGPU.HSA_REFCOUNT[] > 0`?
Was there a situation where we had this issue?
- Rename `alloc_signal_pool_max` to `signal_pool_max_size` (IMO, but looks more descriptive).