### PR TITLE
rocBLAS: define highlevel dot, gemm, axpy functions for FP16

### DIFF
--- a/src/blas/wrappers.jl
+++ b/src/blas/wrappers.jl
@@ -9,9 +9,10 @@
 # License: MIT
 #
 
-const ROCBLASReal = Union{Float32,Float64}
-const ROCBLASComplex = Union{ComplexF32,ComplexF64}
+const ROCBLASReal = Union{Float32, Float64}
+const ROCBLASComplex = Union{ComplexF32, ComplexF64}
 const ROCBLASFloat = Union{ROCBLASReal, ROCBLASComplex}
+const ROCBLASFloatWithHalf = Union{Float16, ROCBLASFloat}
 
 # Utility functions
 
@@ -102,6 +103,7 @@ end
 
 for (jname, fname, elty) in ((:dot,:rocblas_ddot,:Float64),
                              (:dot,:rocblas_sdot,:Float32),
+                             (:dot,:rocblas_hdot,:Float16),
                              (:dotc,:rocblas_zdotc,:ComplexF64),
                              (:dotc,:rocblas_cdotc,:ComplexF32),
                              (:dotu,:rocblas_zdotu,:ComplexF64),
@@ -159,6 +161,7 @@ end
 ## axpy
 for (fname, elty) in ((:rocblas_daxpy,:Float64),
                       (:rocblas_saxpy,:Float32),
+                      (:rocblas_haxpy,:Float16),
                       (:rocblas_zaxpy,:ComplexF64),
                       (:rocblas_caxpy,:ComplexF32))
     @eval begin
@@ -177,11 +180,10 @@ for (fname, elty) in ((:rocblas_daxpy,:Float64),
     end
 end
 
-function axpy!(alpha::Ta,
-               x::ROCArray{T},
-               rx::Union{UnitRange{Ti},AbstractRange{Ti}},
-               y::ROCArray{T},
-               ry::Union{UnitRange{Ti},AbstractRange{Ti}}) where {T<:ROCBLASFloat,Ta<:Number,Ti<:Integer}
+function axpy!(
+    alpha::Ta, x::ROCArray{T}, rx::Union{UnitRange{Ti},AbstractRange{Ti}},
+    y::ROCArray{T}, ry::Union{UnitRange{Ti}, AbstractRange{Ti}},
+) where {T <: ROCBLASFloat, Ta <: Number, Ti <: Integer}
     length(rx)==length(ry) || throw(DimensionMismatch(""))
     if minimum(rx) < 1 || maximum(rx) > length(x) || minimum(ry) < 1 || maximum(ry) > length(y)
         throw(BoundsError())


### PR DESCRIPTION
Previously, they were defined for `<:ROCBlasFloat` eltype which did not cover `Float16`, leading to generic mul pass for FP16 matrices.

- Before:
```julia
julia> using AMDGPU, BenchmarkTools, LinearAlgebra

julia> xf = AMDGPU.rand(Float16, 128, 128);

julia> @benchmark xf * xf
BenchmarkTools.Trial: 4885 samples with 1 evaluation.
 Range (min … max):  254.892 μs … 16.584 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     424.914 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):     1.022 ms ±  2.802 ms  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▃                                                            
  ██▇▃▃▅▃▁▁▁▃▁▃▁▄▄▁▁▁▁▁▁▃▁▁▁▁▁▃▃▁▁▃▁▁▁▄▃▄▄▅▄▅▆█▄▄▄▁▄▄▅▄▄▁▅▅▅▇█ █
  255 μs        Histogram: log(frequency) by time        16 ms <

 Memory estimate: 4.66 KiB, allocs estimate: 121.
```
- This PR:
```julia
julia> using AMDGPU, BenchmarkTools, LinearAlgebra

julia> xf = AMDGPU.rand(Float16, 128, 128);

julia> @benchmark xf * xf
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  24.311 μs …  1.791 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     27.831 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   39.520 μs ± 32.425 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

   ▂█▄▁    ▄▃         ▂▁▃▄     ▄▅                             ▂
  ▇██████████▅▇▄▅▄▄▄▅█████▇▆▇▆████▇▆▆▆▅▃▃▃▃▁▄▁▄▄▁▄▁▄▇█▇▇▅▆▅▅▅ █
  24.3 μs      Histogram: log(frequency) by time      97.6 μs <

 Memory estimate: 832 bytes, allocs estimate: 17.
```

For comparison, here's FP32 matmul:
```julia
julia> x = AMDGPU.rand(Float32, 128, 128);

julia> @benchmark x * x
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  24.660 μs …  1.133 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     57.645 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   56.269 μs ± 31.189 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

   ▂▇▂▁  ▄       ▃▃▇▄ ▁▃█▆▂▁                  ▁    ▁          ▂
  ▇████████▆▄▆▅▅▆████████████▇▆▅▅▅▄▄▄▂▄▄▆▆▅▅▆▇█▆▅▆▇█▇▄▆▆▅▅▄▄▄ █
  24.7 μs      Histogram: log(frequency) by time       122 μs <

 Memory estimate: 832 bytes, allocs estimate: 17.
```