### PR TITLE
Fix huge MIOpen workspace allocations

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -63,8 +63,8 @@ mutable struct ROCArray{T,N} <: AbstractGPUArray{T,N}
     syncstate::Runtime.SyncState
 
     function ROCArray{T,N}(
-        buf::Mem.Buffer, dims::Dims{N};
-        offset::Integer = 0, syncstate = Runtime.SyncState(),
+        buf::Mem.Buffer, dims::Dims{N}; offset::Integer = 0,
+        syncstate::Runtime.SyncState = Runtime.SyncState(),
     ) where {T,N}
         @assert isbitstype(T) "ROCArray only supports bits types"
         xs = new{T,N}(buf, dims, offset, syncstate)

--- a/src/dnn/convolution.jl
+++ b/src/dnn/convolution.jl
@@ -98,16 +98,11 @@ function find_algorithm(
     cache = get_benchmark_cache(conv_type, conv_args, dev)
     isnothing(cache) || return cache
 
-    is_fwd = conv_type == Type{miopenConvFwdAlgorithm_t}
-    workspace_size = get_workspace_size(conv_type;
-        handle,
-        a_desc=(is_fwd ? b_desc : a_desc),
-        b_desc=(is_fwd ? a_desc : b_desc), conv_desc, c_desc)
-
-    workspace = Workspace(dev, workspace_size)
+    workspace = Workspace(dev, 0)
     perf_results = find_conv_algo(conv_type;
         handle, workspace, a, a_desc, b, b_desc, conv_desc, c, c_desc)
     set_benchmark_cache!(conv_type, conv_args, perf_results)
+    workspace = Workspace(dev, perf_results.memory)
 
     perf_results, workspace
 end

--- a/src/runtime/kernel.jl
+++ b/src/runtime/kernel.jl
@@ -37,7 +37,8 @@ end
 function ROCModule(exe::ROCExecutable)
     device = exe.device
     metadata = KernelMetadata[]
-    exceptions = Mem.alloc(device, sizeof(AMDGPU.Device.ExceptionEntry)*MAX_EXCEPTIONS; coherent=true)
+    bytesize = sizeof(AMDGPU.Device.ExceptionEntry) * MAX_EXCEPTIONS
+    exceptions = Mem.alloc(device, bytesize; coherent=true)
 
     mod = ROCModule(exe, metadata, exceptions)
     EXE_TO_MODULE_MAP[exe] = WeakRef(mod)


### PR DESCRIPTION
- Use workspace size suggested from `find_conv_algo` function.
Using `get_workspace_size` function for initial workspace allocation can lead to unncessary huge memory allocations (up to 2.5 GiB). Here's an example of convolution that led to 2.5 GiB workspace allocation.
```julia
c = Conv((3, 3), 1280=>1280) |> f16 |> gpu
x = rand(Float32, 32, 32, 1280, 1) |> f16 |> gpu
y = c(x)
```

Workspace size from `find_conv_algo` takes only ~15 MiB.

- Refactor allocation code a bit