### PR TITLE
Use accurate softmax

### DIFF
--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -51,7 +51,6 @@ import .HIP: HIPContext, HIPDevice, HIPStream
 export HIPContext, HIPDevice, HIPStream
 
 module Runtime
-
     using ..CEnum
     using Setfield
     import ..HSA

--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -51,6 +51,7 @@ import .HIP: HIPContext, HIPDevice, HIPStream
 export HIPContext, HIPDevice, HIPStream
 
 module Runtime
+
     using ..CEnum
     using Setfield
     import ..HSA

--- a/src/array.jl
+++ b/src/array.jl
@@ -8,9 +8,8 @@ struct ROCArrayBackend <: AbstractGPUBackend end
 
 struct ROCKernelContext <: AbstractKernelContext end
 
-function GPUArrays.gpu_call(::ROCArrayBackend, f, args, threads::Int, blocks::Int;
-                            name::Union{String,Nothing})
-    groupsize, gridsize = threads, blocks*threads
+function GPUArrays.gpu_call(::ROCArrayBackend, f, args, threads::Int, blocks::Int; name::Union{String,Nothing})
+    groupsize, gridsize = threads, blocks * threads
     wait(@roc groupsize=groupsize gridsize=gridsize f(ROCKernelContext(), args...))
 end
 function GPUArrays.gpu_call(::ROCArrayBackend, f, args; elements::Int, name::Union{String,Nothing}=nothing)


### PR DESCRIPTION
Fast softmax produces `NaN` values in FP16 mode on big arrays (e.g. 4096x4096)...