### PR TITLE
Add device selection in current task by ID

### DIFF
--- a/docs/src/devices.md
+++ b/docs/src/devices.md
@@ -40,6 +40,8 @@ The default device ID can be queried with [`AMDGPU.default_device_id`](@ref),
 which returns an `Int`.
 This value is bounded between `1` and `length(AMDGPU.devices())`,
 and device `1` is the default device when AMDGPU is first loaded.
+The ID of the device associated with the current task can be queried
+with [`AMDGPU.device_id`](@ref) and changed with [`AMDGPU.device_id!`](@ref).
 
 ```@docs
 AMDGPU.devices
@@ -47,6 +49,8 @@ AMDGPU.device
 AMDGPU.device!
 AMDGPU.default_device
 AMDGPU.default_device!
+AMDGPU.device_id
+AMDGPU.device_id!
 AMDGPU.default_device_id
 AMDGPU.default_device_id!
 ```

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -102,7 +102,7 @@ Sets the current device to `AMDGPU.devices(kind)[idx]`. See
 [`device_id`](@ref) for details on the numbering semantics.
 """
 device_id!(idx::Integer, kind::Symbol=:gpu) =
-    default_device!(devices(kind)[idx])
+    device!(devices(kind)[idx])
 
 """
     device_type(device::ROCDevice) -> Symbol

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -96,6 +96,15 @@ device_id(device::ROCDevice, kind::Symbol=:gpu) =
     something(findfirst(dev->dev === device, devices(kind)))
 
 """
+    device_id!(idx::Integer, kind::Symbol=:gpu)
+
+Sets the current device to `AMDGPU.devices(kind)[idx]`. See
+[`device_id`](@ref) for details on the numbering semantics.
+"""
+device_id!(idx::Integer, kind::Symbol=:gpu) =
+    default_device!(devices(kind)[idx])
+
+"""
     device_type(device::ROCDevice) -> Symbol
 
 Return the kind of `device` as a `Symbol`. CPU devices return `:cpu`, GPU


### PR DESCRIPTION
This PR adds `AMDGPU.device_id!` to allow switching device in the current task. It also extends the doc.