### PR TITLE
Remove buggy uses of default_device

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -221,7 +221,7 @@ function Base.copy(X::ROCArray{T}) where T
     Xnew
 end
 
-function Base.unsafe_wrap(::Type{<:ROCArray}, ptr::Ptr{T}, dims::NTuple{N,<:Integer}; device=default_device(), lock::Bool=true) where {T,N}
+function Base.unsafe_wrap(::Type{<:ROCArray}, ptr::Ptr{T}, dims::NTuple{N,<:Integer}; device=device(), lock::Bool=true) where {T,N}
     @assert isbitstype(T) "Cannot wrap a non-bitstype pointer as a ROCArray"
     sz = prod(dims) * sizeof(T)
     device_ptr = lock ? Mem.lock(ptr, sz, device) : ptr

--- a/src/compiler/codegen.jl
+++ b/src/compiler/codegen.jl
@@ -99,7 +99,7 @@ generated automatically, when function definitions change, or when different
 types or keyword arguments are provided.
 """
 function rocfunction(
-    f::F, tt::Type = Tuple{}; device::ROCDevice = AMDGPU.default_device(),
+    f::F, tt::Type = Tuple{}; device::ROCDevice = AMDGPU.device(),
     global_hooks = NamedTuple(), kwargs...,
 ) where {F <: Core.Function}
     Base.@lock rocfunction_lock begin

--- a/src/device/gcn/hostcall.jl
+++ b/src/device/gcn/hostcall.jl
@@ -42,7 +42,7 @@ struct HostCall{RT,AT}
 end
 
 function HostCall(RT::Type, AT::Type{<:Tuple}, signal_handle::UInt64;
-                  device=AMDGPU.default_device(), buf_len=nothing)
+                  device=AMDGPU.device(), buf_len=nothing)
     if isnothing(buf_len)
         buf_len = 0
         for T in AT.parameters
@@ -264,7 +264,7 @@ hostcall will fail with undefined behavior.
 Note: This API is currently experimental and is subject to change at any time.
 """
 function HostCall(func::Base.Callable, rettype::Type, argtypes::Type{<:Tuple}; return_task::Bool = false,
-                  device=AMDGPU.default_device(), maxlat=DEFAULT_HOSTCALL_LATENCY[],
+                  device=AMDGPU.device(), maxlat=DEFAULT_HOSTCALL_LATENCY[],
                   timeout=nothing, continuous=false, buf_len=nothing)
     # Create raw HSA signal to avoid ROCSignal finalizer
     # being called too early in the HostCall task.

--- a/src/device/gcn/output.jl
+++ b/src/device/gcn/output.jl
@@ -8,7 +8,7 @@ Base.unsafe_store!(ptr::LLVMPtr{<:DeviceStaticString,AS.Global}, x) = nothing
 struct OutputContext{HC}
     hostcall::HC
 end
-function OutputContext(io::IO=stdout; device=AMDGPU.default_device(), continuous=true, buf_len=2^16, name=nothing, kwargs...)
+function OutputContext(io::IO=stdout; device=AMDGPU.device(), continuous=true, buf_len=2^16, name=nothing, kwargs...)
     hc = if name !== nothing
         named_perdevice_hostcall(device, name) do
             create_output_context_hostcall(io; device, continuous, buf_len, kwargs...)


### PR DESCRIPTION
These were leftovers from before the TLS transition.

Fixes #425 