### PR TITLE
Fix `unsafe_wrap` for device arrays

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -224,7 +224,7 @@ end
 function Base.unsafe_wrap(::Type{<:ROCArray}, ptr::Ptr{T}, dims::NTuple{N,<:Integer}; device=device(), lock::Bool=true) where {T,N}
     @assert isbitstype(T) "Cannot wrap a non-bitstype pointer as a ROCArray"
     sz = prod(dims) * sizeof(T)
-    device_ptr = lock ? Mem.lock(ptr, sz, device) : ptr
+    device_ptr = lock ? Mem.lock(ptr, sz, device) : Ptr{Cvoid}(ptr)
     buf = Mem.Buffer(device_ptr, Ptr{Cvoid}(ptr), device_ptr, sz, device, false, false)
     return ROCArray{T, N}(buf, dims)
 end

--- a/test/rocarray/base.jl
+++ b/test/rocarray/base.jl
@@ -90,6 +90,10 @@ end
     RD = Base.unsafe_wrap(ROCArray, pointer(D), size(D))
     copyto!(RD, RA)
     @test Array(RD) ≈ Array(RA) ≈ C
+
+    # Wrapping a GPU array without a copy
+    wRD = Base.unsafe_wrap(ROCArray, pointer(RD), size(D); lock=false)
+    @test pointer(wRD) == pointer(RD)
 end
 
 @testset "unsafe_free" begin


### PR DESCRIPTION
Here is my draft of a fix for #436.

What I thought would be a simple task left me quite confused about some things.

My initial understanding of the kwarg `lock` of `unsafe_wrap` was:

- `true` (default): copy a CPU array to the GPU and wrap it to a ROCArray, while keeping a reference to the CPU array
- `false`: wrap a GPU array into a ROCArray

But if we set `host_ptr` of the `Mem.Buffer` to the `ptr` given to `unsafe_wrap` (which is wrong if `ptr` is a GPU pointer), then we would have a segfault e.g. in `Mem.transfer!`:
https://github.com/JuliaGPU/AMDGPU.jl/blob/767adb15fbfd691204e6ea969ebb9e1506912132/src/runtime/memory.jl#L647-L650

Therefore, I thought I should add another kwarg `is_device_ptr`, and if `true`, no `host_ptr` should remain `0`.
Something like:
```julia
function Base.unsafe_wrap(
    ::Type{<:ROCArray}, ptr::Ptr{T}, dims::NTuple{N,<:Integer};
    device=device(), lock::Bool=true, is_device_ptr::Bool=false
) where {T,N}
    @assert isbitstype(T) "Cannot wrap a non-bitstype pointer as a ROCArray"
    sz = prod(dims) * sizeof(T)

    if !is_device_ptr
        host_ptr = Ptr{Cvoid}(ptr)
        device_ptr = lock ? Mem.lock(ptr, sz, device) : Ptr{Cvoid}(ptr)
    else
        host_ptr = C_NULL
        device_ptr = Ptr{Cvoid}(ptr)
    end

    buf = Mem.Buffer(device_ptr, host_ptr, device_ptr, sz, device, false, false)
    return ROCArray{T, N}(buf, dims)
end
```

But then the case `lock=true` and `is_device_ptr=false` produces a ROCArray with a buffer with no pointers to the memory of the `device`, and I don't think this makes sense either.

Should we get rid of the `lock` kwarg then?

There is also issues about memory management: the retuned array will gain ownership of the device pointer it is given.
With the test I added, the buffer will be freed twice.
Is there any way to make `Mem.release` or `Mem.free` detect that the array was built with `unsafe_wrap` from an externally allocated array and skip deallocation?
