### PR TITLE
Fix docs for HIP

### DIFF
--- a/docs/src/profiling.md
+++ b/docs/src/profiling.md
@@ -17,11 +17,11 @@ end
 function main(N)
     src = ROCArray{Float64}(undef, N)
     dst = ROCArray{Float64}(undef, N)
-    nthreads = 256
-    nblocks = cld(N, nthreads)
+    groupsize = 256               # nthreads
+    gridsize = cld(N, groupsize)  # nblocks
 
     for i in 1:10
-        @roc groupsize=nthreads gridsize=nblocks mycopy!(dst, src)
+        @roc groupsize=groupsize gridsize=gridsize mycopy!(dst, src)
         AMDGPU.synchronize()
     end
 
@@ -52,7 +52,7 @@ We can fix this by moving synchronization outside the loop so that it happens on
 ```julia
     ...
     for i in 1:10
-        @roc groupsize=nthreads gridsize=nblocks mycopy!(dst, src)
+        @roc groupsize=groupsize gridsize=gridsize mycopy!(dst, src)
     end
     AMDGPU.synchronize()
     ...

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -163,8 +163,8 @@ As a quick summary, here is a mapping of the most common terms:
 | [`gridItemDim`](@ref) | No equivalent |
 | [`gridGroupDim`](@ref) | `gridDim` |
 | `groupsize` | `threads` |
-| `gridsize` | `blocks * threads` |
+| `gridsize` | `blocks` |
 | `queue` | `stream` |
 
-For compatibilty reasons, the symbols in the CUDA column
-(except for `gridItemDim`) are also supported by AMDGPU.
+!!! warning
+    Since AMDGPU v0.5.0 `gridsize` represents the number of "workgroups" (or `blocks` in CUDA) and no longer "workitems * workgroups" (or `threads * blocks` in CUDA) as HIP is used for kernel launches instead of HSA.

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -19,7 +19,8 @@ Pkg.test("AMDGPU")
 ```
 
 !!! warning
-    If you get an error message along the lines of `GLIB_CXX_... not found`, it's possible that the C++ runtime used to build the ROCm stack and the one used by Julia are different.
+    If you get an error message along the lines of `GLIB_CXX_... not found`,
+    it's possible that the C++ runtime used to build the ROCm stack and the one used by Julia are different.
     If you built the ROCm stack yourself this is very likely the case since Julia normally ships with its own C++ runtime.
     For more information, check out this [GitHub issue](https://github.com/JuliaLang/julia/issues/34276).
 
@@ -164,7 +165,9 @@ As a quick summary, here is a mapping of the most common terms:
 | [`gridGroupDim`](@ref) | `gridDim` |
 | `groupsize` | `threads` |
 | `gridsize` | `blocks` |
-| `queue` | `stream` |
+| `stream` | `stream` |
 
 !!! warning
-    Since AMDGPU v0.5.0 `gridsize` represents the number of "workgroups" (or `blocks` in CUDA) and no longer "workitems * workgroups" (or `threads * blocks` in CUDA) as HIP is used for kernel launches instead of HSA.
+    Since AMDGPU v0.5.0 `gridsize` represents the number of "workgroups"
+    (or `blocks` in CUDA) and no longer "workitems * workgroups"
+    (or `threads * blocks` in CUDA) as HIP is used for kernel launches instead of HSA.


### PR DESCRIPTION
Fix and homogenise naming convention for using AMDGPU with HIP backend for kernel launch. Remove the statement about combat with CUDA naming which is not working.