### PR TITLE
Check pointer is still pinned before unregistering it

### DIFF
--- a/src/hip/libhip.jl
+++ b/src/hip/libhip.jl
@@ -136,6 +136,11 @@ function hipHostGetDevicePointer(devPtr, hstPtr, flags)
         (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cuint), devPtr, hstPtr, flags)
 end
 
+function hipPointerGetAttributes(attribute, ptr)
+    ccall((:hipPointerGetAttributes, libhip), hipError_t,
+        (Ptr{hipPointerAttribute_t}, Ptr{Cvoid}), attribute, ptr)
+end
+
 function hipMallocAsync(ptr, sz, stream)
     ccall((:hipMallocAsync, libhip), hipError_t,
         (Ptr{Ptr{Cvoid}}, Csize_t, hipStream_t),

--- a/src/hip/libhip_common.jl
+++ b/src/hip/libhip_common.jl
@@ -2,6 +2,23 @@ const HIP_LAUNCH_PARAM_BUFFER_POINTER = Ptr{Cvoid}(1)
 const HIP_LAUNCH_PARAM_BUFFER_SIZE = Ptr{Cvoid}(2)
 const HIP_LAUNCH_PARAM_END = Ptr{Cvoid}(3)
 
+@cenum hipMemoryType begin
+    hipMemoryTypeHost
+    hipMemoryTypeDevice
+    hipMemoryTypeArray
+    hipMemoryTypeUnified
+    hipMemoryTypeManaged
+end
+
+struct hipPointerAttribute_t
+    memoryType::hipMemoryType
+    device::Cint
+    devicePointer::Ptr{Cvoid}
+    hostPointer::Ptr{Cvoid}
+    isManaged::Cint
+    allocationFlags::Cuint
+end
+
 @cenum hipMemcpyKind begin
     hipMemcpyHostToHost
     hipMemcpyHostToDevice

--- a/test/rocarray/base.jl
+++ b/test/rocarray/base.jl
@@ -109,6 +109,27 @@ end
         # Can use in HIP libraries.
         @test Array(xd * xd) ≈ Array(x * x)
     end
+
+    @testset "Multiple wraps of the same array" begin
+        x = zeros(Float32, 16)
+        @test AMDGPU.Mem.is_pinned(Ptr{Cvoid}(pointer(x))) == false
+
+        xd1 = unsafe_wrap(ROCArray, pointer(x), size(x))
+        xd2 = unsafe_wrap(ROCArray, pointer(x), size(x))
+
+        @test AMDGPU.Mem.is_pinned(Ptr{Cvoid}(pointer(xd1))) == true
+        @test AMDGPU.Mem.is_pinned(Ptr{Cvoid}(pointer(xd2))) == true
+
+        AMDGPU.unsafe_free!(xd1)
+
+        @test AMDGPU.Mem.is_pinned(Ptr{Cvoid}(pointer(xd1))) == false
+        @test AMDGPU.Mem.is_pinned(Ptr{Cvoid}(pointer(xd2))) == false
+
+        AMDGPU.unsafe_free!(xd2)
+
+        @test AMDGPU.Mem.is_pinned(Ptr{Cvoid}(pointer(xd1))) == false
+        @test AMDGPU.Mem.is_pinned(Ptr{Cvoid}(pointer(xd2))) == false
+    end
 end
 
 @testset "unsafe_free" begin


### PR DESCRIPTION
Check if host memory pointer is still pinned before unregistering it in finalizer.

Fixes situation where two or more arrays wrap the same host buffer:
```julia
julia> using AMDGPU

julia> x = rand(Float32, 16);

julia> xd1 = unsafe_wrap(ROCArray, pointer(x), size(x));
[register] Ptr{Nothing} @0x00007f47bfedab40

julia> xd2 = unsafe_wrap(ROCArray, pointer(x), size(x));
[register] Ptr{Nothing} @0x00007f47bfedab40

julia> 
[unregister] Ptr{Nothing} @0x00007f47bfedab40
[unregister] Ptr{Nothing} @0x00007f47bfedab40
error in running finalizer: UndefVarError(var=:hipErrorInvalidResourceHandle)
ijl_undefined_var_error at /cache/build/default-amdci5-2/julialang/julia-release-1-dot-9/src/rtutils.c:132
ijl_get_binding_or_error at /cache/build/default-amdci5-2/julialang/julia-release-1-dot-9/src/module.c:421
status_message at /home/pxl-th/.julia/dev/AMDGPU/src/hip/error.jl:118
HIPError at /home/pxl-th/.julia/dev/AMDGPU/src/hip/error.jl:12 [inlined]
check at /home/pxl-th/.julia/dev/AMDGPU/src/hip/error.jl:149 [inlined]
|> at ./operators.jl:907 [inlined]
#free#19 at /home/pxl-th/.julia/dev/AMDGPU/src/runtime/memory/hip.jl:222
```