### PR TITLE
Add `AMDGPU.@sync` macro

### DIFF
--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -196,8 +196,9 @@ macro sync(ex...)
     #     (key != :blocking) && error("Unknown keyword argument $kwarg")
     # end
 
-    @show quote
+    quote
         local ret = $(esc(code))
+        @show "hi"
         synchronize()
         ret
     end

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -3,7 +3,6 @@
 import AMDGPU: Runtime, Compiler
 import .Runtime: ROCDim, ROCDim3
 import .Compiler: hipfunction
-import Base: @sync
 
 export @roc, rocconvert
 
@@ -187,19 +186,19 @@ See also: [`synchronize`](@ref).
 macro sync(ex...)
     # destructure the `@sync` expression
     code = ex[end]
-    kwargs = ex[1:end-1]
+    # kwargs = ex[1:end-1]
 
     # decode keyword arguments
-    for kwarg in kwargs
-        Meta.isexpr(kwarg, :(=)) || error("Invalid keyword argument $kwarg")
-        key, _ = kwarg.args
-        (key != :blocking) && error("Unknown keyword argument $kwarg")
-    end
+    # for kwarg in kwargs
+    #     Meta.isexpr(kwarg, :(=)) || error("Invalid keyword argument $kwarg")
+    #     key, _ = kwarg.args
+    #     (key != :blocking) && error("Unknown keyword argument $kwarg")
+    # end
 
-    quote
+    @show quote
         local ret = $(esc(code))
+        synchronize()
         ret
-        AMDGPU.synchronize()
     end
 end
 

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -198,8 +198,8 @@ macro sync(ex...)
 
     quote
         local ret = $(esc(code))
-        AMDGPU.synchronize()
         ret
+        AMDGPU.synchronize()
     end
 end
 

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -3,6 +3,7 @@
 import AMDGPU: Runtime, Compiler
 import .Runtime: ROCDim, ROCDim3
 import .Compiler: hipfunction
+import Base: @sync
 
 export @roc, rocconvert
 

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -187,18 +187,17 @@ See also: [`synchronize`](@ref).
 macro sync(ex...)
     # destructure the `@sync` expression
     code = ex[end]
-    # kwargs = ex[1:end-1]
+    kwargs = ex[1:end-1]
 
     # decode keyword arguments
-    # for kwarg in kwargs
-    #     Meta.isexpr(kwarg, :(=)) || error("Invalid keyword argument $kwarg")
-    #     key, _ = kwarg.args
-    #     (key != :blocking) && error("Unknown keyword argument $kwarg")
-    # end
+    for kwarg in kwargs
+        Meta.isexpr(kwarg, :(=)) || error("Invalid keyword argument $kwarg")
+        key, _ = kwarg.args
+        (key != :blocking) && error("Unknown keyword argument $kwarg")
+    end
 
     quote
         local ret = $(esc(code))
-        @show "hi"
         synchronize()
         ret
     end


### PR DESCRIPTION
I am trying to add similar macro to AMDGPU as it exists in CUDA.jl, [CUDA.@sync](https://github.com/JuliaGPU/CUDA.jl/blob/d79adbfd090b0e51ccaf4c74710eaa610e0bf998/src/utilities.jl#L1C1-L29).

One reason is that AMDGPU currently returns following for `AMDGPU.@sync`:
```julia
help?> AMDGPU.@sync
  @sync


  Wait until all lexically-enclosed uses of @async, @spawn,
  @spawnat and @distributed are complete. All exceptions thrown
  by enclosed async operations are collected and thrown as a
  CompositeException.

  Examples
  ≡≡≡≡≡≡≡≡≡≡

  julia> Threads.nthreads()
  4
  
  julia> @sync begin
             Threads.@spawn println("Thread-id $(Threads.threadid()), task 1")
             Threads.@spawn println("Thread-id $(Threads.threadid()), task 2")
         end;
  Thread-id 3, task 1
  Thread-id 1, task 2


julia> 
```
which seems to be a different then expected behaviour.

Trying to implement the macro, getting inspiration from CUDA.jl, I am facing some issues, namely:
- The implementation does not sync the current stream (see perf output from MWE below)
- One needs to `import Base: @sync` which does not seems to be needed in CUDA.jl
- I am wondering if the `quote` should not rather be in following order such that one syncs after `ret`:
```julia
    quote
        local ret = $(esc(code))
        ret
        synchronize()
    end
```

The MWE I am trying the syncing on is following
```julia
using Printf
using AMDGPU

macro inn(A) esc(:( $A[ix+1, iy+1, iz+1] )) end
macro d2_xi(A) esc(:( $A[ix+2, iy+1, iz+1] - $A[ix+1, iy+1, iz+1] - $A[ix+1, iy+1, iz+1] - $A[ix, iy+1, iz+1] )) end
macro d2_yi(A) esc(:( $A[ix+1, iy+2, iz+1] - $A[ix+1, iy+1, iz+1] - $A[ix+1, iy+1, iz+1] - $A[ix+1, iy, iz+1] )) end
macro d2_zi(A) esc(:( $A[ix+1, iy+1, iz+2] - $A[ix+1, iy+1, iz+1] - $A[ix+1, iy+1, iz+1] - $A[ix+1, iy+1, iz] )) end

function lapl!(A2, A, D, dt_dx, dt_dy, dt_dz)
    ix = (workgroupIdx().x - UInt32(1)) * workgroupDim().x + workitemIdx().x
    iy = (workgroupIdx().y - UInt32(1)) * workgroupDim().y + workitemIdx().y
    iz = (workgroupIdx().z - UInt32(1)) * workgroupDim().z + workitemIdx().z
    if (ix < size(A, 1) - 2 && iy < size(A, 2) - 2 && iz < size(A, 3) - 2)
        @inbounds @inn(A2) = @inn(A) + @inn(D) * (dt_dx * @d2_xi(A) + dt_dy * @d2_yi(A) + dt_dz * @d2_zi(A))
    end
    return
end

function compute_roc(A2, A, D, dt_dx, dt_dy, dt_dz, iters, nblocks, nthreads, stream)
    print("Starting the time loop 🚀...")
    tic = time_ns()
    for it = 1:iters
        AMDGPU.@sync @roc gridsize=nblocks groupsize=nthreads #= stream=stream =# lapl!(A2, A, D, dt_dx, dt_dy, dt_dz)
        # AMDGPU.synchronize(stream)
        # AMDGPU.synchronize()
        A, A2 = A2, A
    end
    wtime = (time_ns() - tic) * 1e-9
    println("done")
    return wtime
end

function main(; resol=128)
    # physics
    lx = ly = lz = 10.0
    d0 = 1.0
    # numerics
    nx = ny = nz = resol
    nthreads = (128, 2, 1)
    iters, warmup = 33, 3
    println("Process selecting device $(AMDGPU.device_id(AMDGPU.device()))")
    # preprocessing
    nblocks = cld.((nx, ny, nz), nthreads)
    dx, dy, dz = 1.0 / nx, 1.0 / ny, 1.0 / nz
    dt = min(dx*dx, dy*dy, dz*dz)*d0 / 6.1
    dt_dx, dt_dy, dt_dz = dt / dx, dt / dy, dt / dz
    # init
    A = AMDGPU.rand(Float64, nx, ny, nz)
    D = d0 .* AMDGPU.ones(Float64, nx, ny, nz)
    A2 = copy(A)
    stream = nothing #AMDGPU.HIPStream(:high)
    # action
    # warmup
    compute_roc(A2, A, D, dt_dx, dt_dy, dt_dz, warmup, nblocks, nthreads, stream)
    # time
    wtime = compute_roc(A2, A, D, dt_dx, dt_dy, dt_dz, (iters - warmup), nblocks, nthreads, stream)
    # perf
    A_eff = 3 / 2^30 * nx * ny * nz * sizeof(Float64)
    wtime_it = wtime / (iters - warmup)
    T_eff = A_eff / wtime_it
    @printf("Executed %d steps in = %1.3e sec (@ T_eff = %1.2f GB/s) \n", (iters - warmup), wtime, round(T_eff, sigdigits=3))
    return
end

main(resol=512)
```
Note that the correct behaviour can be obtained by commenting the `AMDGPU.@sync` macro and syncing after the kernel with `AMDGPU.synchronize` (or syncing the specific stream), The expected performance on MI250x is:
```
Executed 30 steps in = 1.435e-01 sec (@ T_eff = 627.00 GB/s) 
```
while erroneous perf would return e.g.
```
Executed 30 steps in = 2.051e-04 sec (@ T_eff = 439000.00 GB/s) 
```

