### PR TITLE
blas: Improve error on missing rocBLAS

### DIFF
--- a/src/blas/rocBLAS.jl
+++ b/src/blas/rocBLAS.jl
@@ -36,10 +36,15 @@ end
 # cache for created, but unused handles
 const IDLE_HANDLES = HandleCache{HIPContext, rocblas_handle}()
 
-lib_state() = library_state(
-    :rocBLAS, rocblas_handle, IDLE_HANDLES,
-    create_handle, destroy_handle!,
-    (nh, s) -> check(rocblas_set_stream(nh, s)))
+function lib_state()
+    if !AMDGPU.functional(:rocblas)
+        throw(ArgumentError("rocBLAS is not available"))
+    end
+    return library_state(
+        :rocBLAS, rocblas_handle, IDLE_HANDLES,
+        create_handle, destroy_handle!,
+        (nh, s) -> check(rocblas_set_stream(nh, s)))
+end
 
 handle() = lib_state().handle
 stream() = lib_state().stream

--- a/src/fft/rocFFT.jl
+++ b/src/fft/rocFFT.jl
@@ -35,7 +35,7 @@ if AMDGPU.functional(:rocfft)
     end
 else
     @eval rocfft_setup_once() =
-        throw(ArgumentError("rocFFT is not functional"))
+        throw(ArgumentError("rocFFT is not available"))
 end
 
 end


### PR DESCRIPTION
Now:
```julia
julia> qr(A)
ERROR: ArgumentError: rocBLAS is not available
Stacktrace:
 [1] lib_state()
   @ AMDGPU.rocBLAS ~/.julia/dev/AMDGPU/src/blas/rocBLAS.jl:41
 [2] handle()
   @ AMDGPU.rocBLAS ~/.julia/dev/AMDGPU/src/blas/rocBLAS.jl:49
 [3] geqrf!(A::ROCMatrix{ComplexF64, AMDGPU.Runtime.Mem.HIPBuffer})
   @ AMDGPU.rocSOLVER ~/.julia/dev/AMDGPU/src/solver/highlevel.jl:13
 [4] qr!(A::ROCMatrix{ComplexF64, AMDGPU.Runtime.Mem.HIPBuffer})
   @ AMDGPU.rocSOLVER ~/.julia/dev/AMDGPU/src/solver/highlevel.jl:206
 [5] qr(::ROCMatrix{ComplexF64, AMDGPU.Runtime.Mem.HIPBuffer}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ LinearAlgebra ~/.julia/juliaup/julia-1.9.2+0.x64.linux.gnu/share/julia/stdlib/v1.9/LinearAlgebra/src/qr.jl:428
 [6] qr(::ROCMatrix{ComplexF64, AMDGPU.Runtime.Mem.HIPBuffer})
   @ LinearAlgebra ~/.julia/juliaup/julia-1.9.2+0.x64.linux.gnu/share/julia/stdlib/v1.9/LinearAlgebra/src/qr.jl:425
 [7] top-level scope
   @ REPL[6]:1
```

Fixes https://github.com/JuliaGPU/AMDGPU.jl/issues/461