### PR TITLE
Fix tests

### DIFF
--- a/test/rocsparse/broadcast.jl
+++ b/test/rocsparse/broadcast.jl
@@ -1,8 +1,8 @@
-const m, n = 2, 3
-const p = 0.5
+m, n = 2, 3
+p = 0.5
 
-for elty in [Int32,]# Int64, Float32, Float64]
-    @testset "$typ($elty)" for typ in [ROCSparseMatrixCSR,]# ROCSparseMatrixCSC]
+for elty in [Int32, Int64, Float32, Float64]
+    @testset "$typ($elty)" for typ in [ROCSparseMatrixCSR, ROCSparseMatrixCSC]
         x = sprand(elty, m, n, p)
         dx = typ(x)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ function parse_flags!(args, flag; default = nothing, typ = typeof(default))
 
         if f != flag
             val = split(f, '=')[2]
-            if typ ≢ nothing && typ <: AbstractString
+            if !(typ ≡ nothing && typ <: AbstractString)
                 val = parse(typ, val)
             end
         else
@@ -89,9 +89,11 @@ end
 
 @test length(AMDGPU.devices()) > 0
 
-# Run tests in parallel
-
+# Run tests in parallel.
 np = set_jobs ? jobs : (Sys.CPU_THREADS ÷ 2)
+# Limit to 4 workers, otherwise unfortunate things happen (fences timeout).
+np = clamp(np, 1, 4)
+
 ws = Int[]
 ws_pids = Int[]
 if np == 1


### PR DESCRIPTION
- Fix test option parsing.
- Uncomment tests :/
- Limit number of workers to 4. Otherwise we get fences timeout (might be fixed with 6.2 Linux kernel though).