### PR TITLE
`AMDGPU.@elapsed`

### DIFF
--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -62,7 +62,7 @@ populate_globals!(bindeps_setup())
 include("utils.jl")
 
 include(joinpath("hip", "HIP.jl"))
-import .HIP: HIPContext, HIPDevice, HIPStream, @elapsed
+import .HIP: HIPContext, HIPDevice, HIPStream
 export HIPContext, HIPDevice, HIPStream
 
 include("cache.jl")

--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -62,7 +62,7 @@ populate_globals!(bindeps_setup())
 include("utils.jl")
 
 include(joinpath("hip", "HIP.jl"))
-import .HIP: HIPContext, HIPDevice, HIPStream
+import .HIP: HIPContext, HIPDevice, HIPStream, @elapsed
 export HIPContext, HIPDevice, HIPStream
 
 include("cache.jl")

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -307,3 +307,22 @@ function launch_configuration(
 )
     HIP.launch_configuration(kern.fun; shmem, max_block_size)
 end
+
+"""
+    @elapsed ex
+
+A macro to evaluate an expression, discarding the resulting value, instead returning the
+number of seconds it took to execute on the GPU, as a floating-point number.
+"""
+macro elapsed(ex)
+    quote
+        current_stream = stream()
+        t0 = HIP.HIPEvent(current_stream; do_record=false, disable_timing=false)
+        t1 = HIP.HIPEvent(current_stream; do_record=false, disable_timing=false)
+        HIP.record(t0)
+        $(esc(ex))
+        HIP.record(t1)
+        HIP.synchronize(t1)
+        HIP.elapsed(t0, t1)
+    end
+end

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -317,8 +317,8 @@ number of seconds it took to execute on the GPU, as a floating-point number.
 macro elapsed(ex)
     quote
         current_stream = stream()
-        t0 = HIP.HIPEvent(current_stream; do_record=false, disable_timing=false)
-        t1 = HIP.HIPEvent(current_stream; do_record=false, disable_timing=false)
+        t0 = HIP.HIPEvent(current_stream; do_record=false, timing=true)
+        t1 = HIP.HIPEvent(current_stream; do_record=false, timing=true)
         HIP.record(t0)
         $(esc(ex))
         HIP.record(t1)

--- a/src/hip/event.jl
+++ b/src/hip/event.jl
@@ -62,3 +62,31 @@ function HIPEvent(stream::hipStream_t; do_record::Bool = true)
     event
 end
 HIPEvent(stream::HIPStream; do_record::Bool = true) = HIPEvent(stream.stream; do_record)
+
+"""
+    elapsed(start::HIPEvent, stop::HIPEvent)
+
+Computes the elapsed time between two events (in seconds).
+"""
+function elapsed(start::HIPEvent, stop::HIPEvent)
+    time_ref = Ref{Cfloat}()
+    hipEventElapsedTime(time_ref, start, stop)
+    return time_ref[]/1000
+end
+
+"""
+    @elapsed ex
+
+A macro to evaluate an expression, discarding the resulting value, instead returning the
+number of seconds it took to execute on the GPU, as a floating-point number.
+"""
+macro elapsed(ex)
+    quote
+        t0, t1 = HIPEvent(C_NULL), HIPEvent(C_NULL)
+        record(t0)
+        $(esc(ex))
+        record(t1)
+        synchronize(t1)
+        elapsed(t0, t1)
+    end
+end

--- a/src/hip/libhip.jl
+++ b/src/hip/libhip.jl
@@ -86,6 +86,11 @@ function hipEventSynchronize(event)
     ccall((:hipEventSynchronize, libhip), hipError_t, (hipEvent_t,), event)
 end
 
+function hipEventElapsedTime(ms_ref, start_event, stop_event)
+    ccall((:hipEventElapsedTime, libhip), hipError_t,
+        (Ptr{Cfloat}, hipEvent_t, hipEvent_t), ms_ref, start_event, stop_event)
+end
+
 function hipStreamCreateWithPriority(stream_ref, flags, priority)
     ccall((:hipStreamCreateWithPriority, libhip), hipError_t,
         (Ptr{hipStream_t}, Cuint, Cint), stream_ref, flags, priority)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -204,6 +204,20 @@ if "hip" in TARGET_TESTS
             @test_skip "MIOpen"
         end
     end)
+    push!(tests, "AMDGPU.@elapsed" => () -> begin
+        xgpu = AMDGPU.rand(Float32, 100)
+        t = AMDGPU.@elapsed xgpu .+= 1
+        @test t isa AbstractFloat
+        @test t >= 0
+
+        x = rand(Float32, 100)
+        t = AMDGPU.@elapsed begin
+            copyto!(xgpu, x)
+            copyto!(x, xgpu)
+        end
+        @test t isa AbstractFloat
+        @test t >= 0
+    end)
 end
 
 "ext" in TARGET_TESTS && push!(tests,


### PR DESCRIPTION
This PR adds the functionality to measure the elapsed time between two hip events. Inspired by CUDA.jl, it exposes a macro `AMDGPU.@elapsed` for end users.

I tested the new macro in a simple memory bandwidth benchmark (just copying/transferring memory) and it seems to work. That is, the resulting memory bandwidth is reasonable. ~However, what I'm unsure about is the line:~

```julia
t0, t1 = HIPEvent(C_NULL), HIPEvent(C_NULL)
```

~I chose `C_NULL` for the stream here (which according to [this](https://rocm-developer-tools.github.io/HIP/group__Event.html#gad4128b815cb475c8e13c7e66ff6250b7) waits for all commands on all streams to finish). But maybe that should be `AMDGPU.stream()` or something else?~

UPDATE: We use the task-local `stream()` instead of `C_NULL` now.

(cc @jpsamaroo, @luraess)