### PR TITLE
Expose `hipDeviceCanAccessPeer`

### DIFF
--- a/src/hip/device.jl
+++ b/src/hip/device.jl
@@ -97,3 +97,9 @@ function device!(f::Base.Callable, device::HIPDevice)
         device!(old_device_id_ref[] + 1)
     end
 end
+
+function can_access_peer(dev::HIPDevice, peer::HIPDevice)
+    result = Ref{Cint}(0)
+    hipDeviceCanAccessPeer(result, device_id(dev), device_id(peer)) |> check
+    return result[] == 1
+end

--- a/src/hip/libhip.jl
+++ b/src/hip/libhip.jl
@@ -306,3 +306,8 @@ function hipModuleOccupancyMaxPotentialBlockSize(
         (Ptr{Cint}, Ptr{Cint}, hipFunction_t, Csize_t, Cint),
         gridSize, blockSize, f, dynSharedMemPerBlk, blockSizeLimit)
 end
+
+function hipDeviceCanAccessPeer(can_access_peer_ref, deviceid, peer_deviceid)
+    ccall((:hipDeviceCanAccessPeer, libhip), hipError_t, (Ptr{Cint}, Cint, Cint),
+        can_access_peer_ref, deviceid, peer_deviceid)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -218,6 +218,12 @@ if "hip" in TARGET_TESTS
         @test t isa AbstractFloat
         @test t >= 0
     end)
+    if length(AMDGPU.devices()) > 1
+        push!(tests, "HIP Peer Access" => () -> begin
+            dev1, dev2, _ = AMDGPU.devices()
+            @test AMDGPU.HIP.can_access_peer(dev1, dev2) isa Bool
+        end)
+    end
 end
 
 "ext" in TARGET_TESTS && push!(tests,


### PR DESCRIPTION
Similar to `CUDA.can_access_peer`, this PR introduces `AMDGPU.HIP.can_access_peer(device, peer)` to query whether one device can access another device.