### PR TITLE
Remove default device stuff

### DIFF
--- a/docs/src/devices.md
+++ b/docs/src/devices.md
@@ -8,11 +8,6 @@ If one is not specified via `@roc` or an equivalent interface,
 then the default device is used for those operations,
 which affects compilation and kernel launch.
 
-!!! note "Task-Local Storage"
-    AMDGPU.jl relies on Task-Local Storage, this means that
-    default devices are default only within a given task.
-    Other tasks migh have different default devices if user switched them.
-
 The device bound to a current Julia task is accessible via [`AMDGPU.device()`](@ref).
 The list of available devices can be queried with [`AMDGPU.devices`](@ref).
 
@@ -27,20 +22,7 @@ AMDGPU.device!(AMDGPU.devices()[2]) # Switch to second device.
 xd2 = AMDPGU.ones(Float32, 16) # On second device.
 ```
 
-To select a default device for newly created tasks,
-use [`AMDGPU.default_device!`](@ref).
-
-```julia
-AMDGPU.default_device!(AMDGPU.devices()[3]) # New tasks will use 3rd device by default.
-Threads.@spawn begin
-    x = AMDGPU.ones(Float32, 16) # On third device.
-    return
-end
-```
-
 Additionally, devices have an associated numeric ID.
-The default device ID can be queried with [`AMDGPU.default_device_id`](@ref),
-which returns an `Int`.
 This value is bounded between `1` and `length(AMDGPU.devices())`,
 and device `1` is the default device when AMDGPU is first loaded.
 The ID of the device associated with the current task can be queried
@@ -50,10 +32,6 @@ with [`AMDGPU.device_id`](@ref) and changed with [`AMDGPU.device_id!`](@ref).
 AMDGPU.devices
 AMDGPU.device
 AMDGPU.device!
-AMDGPU.default_device
-AMDGPU.default_device!
 AMDGPU.device_id
 AMDGPU.device_id!
-AMDGPU.default_device_id
-AMDGPU.default_device_id!
 ```

--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -217,9 +217,7 @@ function __init__()
 
     # Check whether HIP is available
     if functional(:hip)
-        # Fetch HIP devices and select default one.
-        devs = Runtime.fetch_devices()
-        Runtime.set_default_device!(first(devs))
+        Runtime.fetch_devices()
     else
         @warn """
         HIP library is unavailable, HIP integration will be disabled.

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -6,48 +6,6 @@ import .Compiler: hipfunction
 
 export @roc, rocconvert
 
-## Devices
-
-"""
-    default_device()::HIPDevice
-
-Default device which will be used by default in tasks.
-Meaning when a task is created, it selects this device as default.
-
-All subsequent uses rely on [`device()`](@ref) for device selection.
-"""
-default_device() = Runtime.get_default_device()
-
-"""
-    default_device!(device::HIPDevice)
-
-Set default device that will be used when creating new tasks.
-
-!!! note
-    This does not change current device being used.
-    Refer to [`device!`](@ref) for that.
-"""
-default_device!(device::HIPDevice) = Runtime.set_default_device!(device)
-
-"""
-    default_device_id() -> Int
-
-Returns the numeric ID of the current default device,
-which is in the range of `1:length(AMDGPU.devices())`.
-This number should be stable for all processes on the same node,
-The [`default_device_id!`](@ref) function accepts the same
-numeric ID that is produced by this function.
-"""
-default_device_id() = default_device().device_id
-
-"""
-    default_device_id!(idx::Integer)
-
-Sets the default device to `AMDGPU.devices()[idx]`. See
-[`default_device_id`](@ref) for details on the numbering semantics.
-"""
-default_device_id!(idx::Integer) = default_device!(devices()[idx])
-
 """
     device()::HIPDevice
 
@@ -61,10 +19,6 @@ device() = task_local_state().device
 
 Switch current device being used.
 This switches only for a task inside which it is called.
-
-!!! note
-    To select default device that will be used when creating new tasks,
-    refer to [`default_device!`](@ref) for that.
 """
 function device!(device::HIPDevice)
     task_local_state!(; device)
@@ -82,8 +36,7 @@ devices() = Runtime.fetch_devices()
 """
     device_id(device::HIPDevice) -> Int
 
-Returns the numerical device ID for `device`. See [`default_device_id`](@ref)
-for details on the numbering semantics.
+Returns the numerical device ID for `device`.
 """
 device_id(device::HIPDevice) = device.device_id
 

--- a/src/runtime/device.jl
+++ b/src/runtime/device.jl
@@ -1,4 +1,4 @@
-const DEFAULT_DEVICE = Ref{HIPDevice}()
+const DEFAULT_DEVICE = Ref{Union{Nothing, HIPDevice}}(nothing)
 const ALL_DEVICES = Vector{HIPDevice}()
 const HSA_DEVICES = Vector{ROCDevice}()
 
@@ -27,32 +27,6 @@ function fetch_hsa_devices()
 end
 
 hsa_device(device::HIPDevice) = HSA_DEVICES[device.device_id]
-
-"""
-    get_default_device() -> HIPDevice
-
-TODO update docs
-
-# Returns the default device, which is used for all kernel and array operations
-# when one is not explicitly specified. May be changed with
-# [`set_default_device!`](@ref).
-"""
-function get_default_device()
-    if !isassigned(DEFAULT_DEVICE)
-        error("No GPU devices detected!")
-    end
-    DEFAULT_DEVICE[]
-end
-
-"""
-    set_default_device!(device::ROCDevice) -> ROCDevice
-
-Sets the default device to `device`. See [`get_default_device`](@ref) for more
-details.
-"""
-function set_default_device!(device::HIPDevice)
-    DEFAULT_DEVICE[] = device
-end
 
 "Return all devices available to the runtime."
 devices() = copy(ALL_DEVICES)

--- a/test/hsa/device.jl
+++ b/test/hsa/device.jl
@@ -7,9 +7,8 @@
     end
 
     @testset "Default selection" begin
-        device = AMDGPU.default_device()
+        device = AMDGPU.device()
         @test device !== nothing
-        @test device == AMDGPU.device()
 
         device_name = HIP.name(device)
         @test length(device_name) > 0
@@ -17,20 +16,20 @@
 
         if length(AMDGPU.devices()) > 1
             @testset "Multi-GPU" begin
-                init_device = AMDGPU.default_device()
-                init_device_id = AMDGPU.default_device_id()
+                init_device = AMDGPU.device()
+                init_device_id = AMDGPU.device_id()
                 @test init_device_id == 1
 
-                AMDGPU.default_device_id!(2)
-                @test AMDGPU.default_device_id() == 2
-                @test AMDGPU.default_device() != init_device
+                AMDGPU.device_id!(2)
+                @test AMDGPU.device_id() == 2
+                @test AMDGPU.device() != init_device
 
-                AMDGPU.default_device_id!(1)
-                @test AMDGPU.default_device_id() == 1
-                @test AMDGPU.default_device() == init_device
+                AMDGPU.device_id!(1)
+                @test AMDGPU.device_id() == 1
+                @test AMDGPU.device() == init_device
 
-                @test_throws BoundsError AMDGPU.default_device_id!(0)
-                @test_throws BoundsError AMDGPU.default_device_id!(length(AMDGPU.devices())+1)
+                @test_throws BoundsError AMDGPU.device_id!(0)
+                @test_throws BoundsError AMDGPU.device_id!(length(AMDGPU.devices()) + 1)
             end
         else
             @test_skip "Multi-GPU"
@@ -38,7 +37,7 @@
     end
 
     @testset "ISAs" begin
-        device = AMDGPU.default_device()
+        device = AMDGPU.device()
         device_isa, features = AMDGPU.default_isa(device).arch_features
         @test length(device_isa) > 0
         @test occursin("gfx", device_isa)

--- a/test/hsa/getinfo.jl
+++ b/test/hsa/getinfo.jl
@@ -1,6 +1,6 @@
 @testset "getinfo queries" begin
     @testset "ROCDevice" begin
-        device = AMDGPU.default_device()
+        device = AMDGPU.device()
         hsa_dev = AMDGPU.Runtime.hsa_device(device)
         @test AMDGPU.Runtime.name(hsa_dev) isa String
         @test AMDGPU.Runtime.device_type(hsa_dev) isa AMDGPU.HSA.DeviceType
@@ -8,7 +8,7 @@
     end
 
     @testset "HSA.ISA" begin
-        device = AMDGPU.default_device()
+        device = AMDGPU.device()
         device_isa = AMDGPU.default_isa(device).hsa_isa
         @test AMDGPU.Runtime.isa_workgroup_max_size(device_isa) isa UInt32
     end

--- a/test/logging.jl
+++ b/test/logging.jl
@@ -38,7 +38,7 @@
     @testset "Buffer" begin
         local buf_ptr
         logs = AMDGPU.Runtime.log_and_fetch!() do
-            buf = AMDGPU.Runtime.Mem.alloc(AMDGPU.default_device(), 64)
+            buf = AMDGPU.Runtime.Mem.alloc(AMDGPU.device(), 64)
             buf_ptr = buf.ptr
             AMDGPU.Runtime.Mem.free(buf)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,7 +64,7 @@ const TARGET_TESTS = isempty(ARGS) ? TEST_NAMES : ARGS
 include("setup.jl")
 
 @info "Running following tests: $TARGET_TESTS."
-@info "Testing using device $(AMDGPU.default_device())."
+@info "Testing using device $(AMDGPU.device())."
 AMDGPU.versioninfo()
 
 if "core" in TARGET_TESTS

--- a/test/tls.jl
+++ b/test/tls.jl
@@ -18,7 +18,6 @@ end
 @testset "Basics" begin
     device = @inferred AMDGPU.device()
     @test device isa HIPDevice
-    @test device === AMDGPU.Runtime.get_default_device()
 
     context = @inferred AMDGPU.context()
     @test context isa HIPContext


### PR DESCRIPTION
Remove default device to simplify things.
Now the default device is the first device in the list returned by `AMDGPU.devices()`.
And when changing the device with `AMDGPU.device!` or `AMDGPU.device_id!`, IT becomes the default device for TLS.

CC @luraess.