### PR TITLE
Fix REPL display

### DIFF
--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -247,6 +247,12 @@ function __init__()
             """
         end
     end
+
+    # Ensure that operations executed by the REPL backend finish before returning.
+    # Displaying values happens on a different task.
+    if isdefined(Base, :active_repl_backend)
+        push!(Base.active_repl_backend.ast_transforms, synchronize_rocm_tasks)
+    end
 end
 
 end

--- a/src/gpuarrays.jl
+++ b/src/gpuarrays.jl
@@ -3,8 +3,7 @@ struct ROCArrayBackend <: AbstractGPUBackend end
 struct ROCKernelContext <: AbstractKernelContext end
 
 @inline function GPUArrays.gpu_call(
-    ::ROCArrayBackend, f, args, threads::Int, blocks::Int;
-    name::Union{String, Nothing},
+    ::ROCArrayBackend, f, args, threads::Int, blocks::Int; name::Maybe{String},
 )
     @roc gridsize=blocks groupsize=threads name=name f(ROCKernelContext(), args...)
 end

--- a/src/tls.jl
+++ b/src/tls.jl
@@ -189,3 +189,13 @@ end
     state.context != HIP.HIPContext() && HIP.context!(state.context)
     return
 end
+
+function synchronize_rocm_tasks(ex)
+    quote
+        try
+            $(ex)
+        finally
+            $task_local_state() ≢ nothing && $device_synchronize()
+        end
+    end
+end


### PR DESCRIPTION
REPL displays values in a separate task which creates different TLS storage thus creating different HIP stream.
Perform device synchronization when displaying values in REPL mode.

Closes #500.