### PR TITLE
Use refs instead of pointers to get a slightly friendlier abi

### DIFF
--- a/src/device/gcn/math.jl
+++ b/src/device/gcn/math.jl
@@ -77,12 +77,12 @@ for jltype in (Float64, Float32, Float16)
 
     @eval @device_override function Base.sincos(x::$jltype)
         ref = Ref{$jltype}()
-        ret = ccall($("extern __ocml_sincos_$(fntypes[jltype])"), llvmcall, $jltype, ($jltype, Ptr{$jltype}), x, ref)
+        ret = ccall($("extern __ocml_sincos_$(fntypes[jltype])"), llvmcall, $jltype, ($jltype, Ref{$jltype}), x, ref)
         return (ret, ref[])
     end
     @eval @device_override function Base.sincospi(x::$jltype)
         ref = Ref{$jltype}()
-        ret = ccall($("extern __ocml_sincospi_$(fntypes[jltype])"), llvmcall, $jltype, ($jltype, Ptr{$jltype}), x, ref)
+        ret = ccall($("extern __ocml_sincospi_$(fntypes[jltype])"), llvmcall, $jltype, ($jltype, Ref{$jltype}), x, ref)
         return (ret, ref[])
     end
 end


### PR DESCRIPTION
This seems to make the optimization pipeline happier, though it's still the wrong ABI because it says it's an `i8*` instead of a `addresspace(5) float *` this also might need a change upstream to the allocopt pass