### PR TITLE
Add ROCm mixed mode

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -73,10 +73,11 @@ For example Julia 1.10 uses LLVM 15, but ROCm 5.5+ uses LLVM 16 which are incomp
 However, there is a way to run system ROCm 5.5+ with Julia:
 
 1. Add respective version of artifact device libraries in your project:
-`]add ROCmDeviceLibs_jll@5.5` (for ROCm 5.5).
+    - ROCm 5.5: `]add ROCmDeviceLibs_jll@5.5`;
+    - ROCm 5.6: `]add ROCmDeviceLibs_jll@5.6`.
 2. Call [`AMDGPU.use_devlibs_jll!`](@ref) in your Julia session to switch
-to artifact device libraries (and the rest of the libraries
-will be used from system-wide installation).
+    to artifact device libraries (and the rest of the libraries
+    will be used from system-wide installation).
 
 ```@docs
 AMDGPU.use_devlibs_jll!

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -29,7 +29,13 @@ using Pkg
 Pkg.test("AMDGPU")
 ```
 
-## Required Software
+## Requirements
+
+Julia **1.9 or higher**.
+
+Minimal supported ROCm version is **5.3**.
+However, if you have ROCm 5.5+ installed, refer to
+[LLVM compatibility & mixed ROCm mode](@ref) section for additional instructions.
 
 For optimal experience, you should have full ROCm stack installed.
 Refer to official ROCm stack installation instructions: <https://rocm.docs.amd.com/en/latest/deploy/linux/index.html>
@@ -47,19 +53,34 @@ Currently, AMDGPU.jl utilizes following libraries:
 [rocRAND](https://github.com/ROCmSoftwarePlatform/rocRAND),
 [MIOpen](https://github.com/ROCmSoftwarePlatform/MIOpen).
 
-Other ROCm packages are currently unused by AMDGPU.
-
 ### ROCm artifacts
 
-Currently AMDGPU.jl does not provide ROCm artifacts.
-One needs to build a newer version of them.
-See #440 issue: <https://github.com/JuliaGPU/AMDGPU.jl/issues/440>.
+There is limited support for ROCm 5.4+ artifacts which can be enabled with
+[`AMDGPU.enable_artifacts!`](@ref).
 
-### LLVM compatibility
+Limited means not all libraries are available and some of the functionality
+may be disabled.
 
-As a rule of thumb, Julia's LLVM version should match ROCm LLVM's version.
-For example, Julia 1.9 relies on LLVM 14, so the matching ROCm version is `5.2.x`
-(although `5.4` is confirmed to work as well).
+```@docs
+AMDGPU.enable_artifacts!
+```
+
+### LLVM compatibility & mixed ROCm mode
+
+As a rule of thumb, Julia LLVM version should match ROCm LLVM version.
+For example Julia 1.10 uses LLVM 15, but ROCm 5.5+ uses LLVM 16 which are incompatible.
+
+However, there is a way to run system ROCm 5.5+ with Julia:
+
+1. Add respective version of artifact device libraries in your project:
+`]add ROCmDeviceLibs_jll@5.5` (for ROCm 5.5).
+2. Call [`AMDGPU.use_devlibs_jll!`](@ref) in your Julia session to switch
+to artifact device libraries (and the rest of the libraries
+will be used from system-wide installation).
+
+```@docs
+AMDGPU.use_devlibs_jll!
+```
 
 ### Extra Setup Details
 

--- a/src/rocm_discovery.jl
+++ b/src/rocm_discovery.jl
@@ -13,15 +13,17 @@ const rocm_ext_libs = [
 Pass `true` to switch from system-wide ROCm installtion to artifacts.
 When using artifacts, system-wide installation is not needed at all.
 """
-function enable_artifacts!(flag::Bool = true)
+function enable_artifacts!(flag::Bool = true; show_message::Bool = true)
     if flag && Base.libllvm_version >= v"16"
         error("No supported artifacts for LLVM 16+. See: https://github.com/JuliaGPU/AMDGPU.jl/issues/440.")
     end
     @set_preferences!("use_artifacts" => flag)
-    @info """
-    Switched `use_artifacts` to `$flag`.
-    Restart Julia session for the changes to take effect.
-    """
+    if show_message
+        @info """
+        Switched `use_artifacts` to `$flag`.
+        Restart Julia session for the changes to take effect.
+        """
+    end
 end
 
 use_artifacts()::Bool = @load_preference("use_artifacts", false)

--- a/src/rocm_discovery.jl
+++ b/src/rocm_discovery.jl
@@ -23,6 +23,18 @@ end
 # TODO need updated ROCm artifacts to enable them again (5.4+).
 use_artifacts()::Bool = @load_preference("use_artifacts", false)
 
+# TODO docs for why
+function use_devlibs_jll!(flag::Bool = true)
+    @set_preferences!("use_devlibs_jll" => flag)
+
+    @info """
+    Switched `use_devlibs_jll` to `$flag`.
+    Restart Julia session for the changes to take effect.
+    """
+end
+
+use_devlibs_jll()::Bool = @load_preference("use_devlibs_jll", false)
+
 if haskey(ENV, "JULIA_AMDGPU_DISABLE_ARTIFACTS")
     disable_artifacts = parse(Bool, get(ENV, "JULIA_AMDGPU_DISABLE_ARTIFACTS", "true"))
     if !disable_artifacts && Base.libllvm_version >= v"16"
@@ -140,7 +152,7 @@ function find_ld_lld!(config)
 end
 
 function find_device_libs!(config)
-    if use_artifacts()
+    if use_artifacts() || use_devlibs_jll()
         find_artifact_library!(
             config, :ROCmDeviceLibs_jll;
             name=:device_libs, lib=:bitcode_path)

--- a/src/rocm_discovery.jl
+++ b/src/rocm_discovery.jl
@@ -7,26 +7,37 @@ const rocm_ext_libs = [
     (:rocfft, nothing),
     (:MIOpen, :MIOpen_jll)]
 
-function enable_artifacts!(flag::Bool = true; show_message::Bool = true)
+"""
+    enable_artifacts!(flag::Bool = true)
+
+Pass `true` to switch from system-wide ROCm installtion to artifacts.
+When using artifacts, system-wide installation is not needed at all.
+"""
+function enable_artifacts!(flag::Bool = true)
     if flag && Base.libllvm_version >= v"16"
         error("No supported artifacts for LLVM 16+. See: https://github.com/JuliaGPU/AMDGPU.jl/issues/440.")
     end
     @set_preferences!("use_artifacts" => flag)
-    if show_message
-        @info """
-        Switched `use_artifacts` to `$flag`.
-        Restart Julia session for the changes to take effect.
-        """
-    end
+    @info """
+    Switched `use_artifacts` to `$flag`.
+    Restart Julia session for the changes to take effect.
+    """
 end
 
-# TODO need updated ROCm artifacts to enable them again (5.4+).
 use_artifacts()::Bool = @load_preference("use_artifacts", false)
 
-# TODO docs for why
+"""
+    use_devlibs_jll!(flag::Bool = true)
+
+Pass `true` to use device libraries from artifacts and
+the rest of the libraries from system-wide ROCm installation (mixed-mode).
+
+This allows using ROCm 5.5+ which internally use LLVM 16+, but
+device libraries from artifacts are built with LLVM 15 which makes them
+compatible with Julia.
+"""
 function use_devlibs_jll!(flag::Bool = true)
     @set_preferences!("use_devlibs_jll" => flag)
-
     @info """
     Switched `use_devlibs_jll` to `$flag`.
     Restart Julia session for the changes to take effect.


### PR DESCRIPTION
Mixed mode allows using ROCmDevice libraries from artifacts, but the rest of the libraries from system-wide installation.

Artifact device libraries were patched to be compatible with Julia LLVM.
This way you can run ROCm 5.6 (which uses LLVM 16) with Julia 1.10 (which uses LLVM 15).

Refer to `Requirements` section of the documentation for more instructions, but in short:
1. Add respective version of artifact device libraries in your project:
    - ROCm 5.5: `]add ROCmDeviceLibs_jll@5.5`;
    - ROCm 5.6: `]add ROCmDeviceLibs_jll@5.6`.
2. Call `AMDGPU.use_devlibs_jll!` in your Julia session to switch
    to artifact device libraries (and the rest of the libraries
    will be used from system-wide installation).

This should enable Navi 3 support (but I haven't tested it yet).

Thanks to @jpsamaroo for providing a patch to 'downgrade' device libraries to a compatible LLVM version 🎉🎉🎉!

Respective PRs for artifact device libraries:
- ROCm 5.5: https://github.com/JuliaPackaging/Yggdrasil/pull/7476
- ROCm 5.6: https://github.com/JuliaPackaging/Yggdrasil/pull/7485.

Should hopefully address #401 & #371.