### PR TITLE
Default to non-blocking synchronize

### DIFF
--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -42,16 +42,15 @@ device(idx::Integer) = devices()[idx]
 default_isa(device::HIPDevice) = Runtime.default_isa(Runtime.hsa_device(device))
 
 """
-    synchronize(stream::HIPStream = stream(); blocking::Bool = true)
+    synchronize(stream::HIPStream = stream(); blocking::Bool = false)
 
 Blocks until all kernels currently executing on `stream` have completed.
 
-If there are running HostCalls, then it non-blocking synchronization is required
-which can be done with `blocking=false` keyword.
-Additionally, it stops any running global hostcall afterwards.
-Note, that non-blocking synchronization is slower than blocking.
+If there are running HostCalls, then non-blocking synchronization is required.
+Note, that non-blocking synchronization is slower than blocking, which can be enabled
+with the `blocking=true` keyword.
 """
-function synchronize(stm::HIPStream = stream(); blocking::Bool = true)
+function synchronize(stm::HIPStream = stream(); blocking::Bool = false)
     throw_if_exception(stm.device)
     HIP.synchronize(stm; blocking)
     throw_if_exception(stm.device)


### PR DESCRIPTION
Transition to non-blocking synchronize behaviour by default in order to enable similar behaviour as in CUDA.jl and to comply with KerneAbstractions approach to perform tasks in a cooperative fashion.