### PR TITLE
Use non-blocking synchronization by default

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,13 +1,5 @@
 # AMDGPU API Reference
 
-## Synchronization
-
-```@docs
-AMDGPU.synchronize
-AMDGPU.@sync
-AMDGPU.device_synchronize
-```
-
 ## Device code API
 
 ### Thread indexing

--- a/docs/src/hostcall.md
+++ b/docs/src/hostcall.md
@@ -12,11 +12,11 @@ Hostcalls require careful usage, since they each spawn their own Tasks.
 There should be no blocking operations during this time.
 
 For example, using non-blocking synchronization instead of blocking with
-`AMDGPU.synchronize(; blocking=false)`.
+`AMDGPU.synchronize(; blocking=false)` (which is also the default).
 
-Non-blocking synchronization is also responsible for stopping global hostcalls,
-otherwise the performance might degarde because of constant pooling
-of HSA signals in a loop.
+To stop hostcalls after synchronization, provide `stop_hostcalls=true`
+keyword argument, otherwise the performance might degarde
+because of constant pooling of HSA signals in a loop.
 
 ## Example
 
@@ -32,7 +32,7 @@ end
 
 y = ROCArray(Float32[0f0])
 @roc kernel!(y, hc)
-AMDGPU.synchronize(; blocking=false) # Non-blocking sync to prevent hanging.
+AMDGPU.synchronize(; stop_hostcalls=true) # Stop hostcall.
 
 @assert Array(y)[1] ≈ 42f0
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -135,3 +135,28 @@ Once all of this is setup properly, you should be able to do `using AMDGPU`
 successfully.
 
 See the [Quick Start](@ref) documentation for an introduction to using AMDGPU.jl.
+
+## Preferences
+
+AMDGPU.jl supports setting
+[preferences](https://github.com/JuliaPackaging/Preferences.jl).
+Template of `LocalPreferences.toml` with all options:
+
+```toml
+[AMDGPU]
+# If `true` then use ROCm libraries provided by artifacts.
+# However, not all ROCm libraries are available as artifacts.
+use_artifacts = false
+# Use mixed-mode ROCm. This will use device libraries from artifacts,
+# but the rest of the ROCm libraries from system-wide installation.
+# See `LLVM compatibility & mixed ROCm mode` section in the documentation.
+use_devlibs_jll = false
+# Use non-blocking synchronization for all `AMDGPU.synchronize()` calls.
+nonblocking_synchronization = true
+# Memory limit specifies maximum amount of memory in percentages
+# a current Julia process can use.
+# Default is "none", which does not apply any limitation.
+hard_memory_limit = "none"
+# Notice a space between the value and percentage sign.
+# hard_memory_limit = "80 %"
+```

--- a/docs/src/streams.md
+++ b/docs/src/streams.md
@@ -53,3 +53,33 @@ AMDGPU.stream!
 AMDGPU.priority!
 AMDGPU.HIPStream
 ```
+
+## Synchronization
+
+AMDGPU.jl by default uses non-blocking stream synchronization with
+[`AMDGPU.synchronize`](@ref) to work correctly with TLS and [Hostcall](@ref).
+
+Users, however, can switch to a blocking synchronization globally
+with `nonblocking_synchronization`
+[preference](https://github.com/JuliaPackaging/Preferences.jl)
+or with fine-grained `AMDGPU.synchronize(; blocking=true)`.
+Blocking synchronization might offer slightly lower latency.
+
+You can also perform synchroization of the expression with
+[`AMDGPU.@sync`](@ref) macro, which will execute given expression and
+synchronize afterwards (using [`AMDGPU.synchronize`](@ref) under the hood).
+
+```julia
+AMDGPU.@sync begin
+    @roc ...
+end
+```
+
+Finally, you can perform full device synchronization with
+[`AMDGPU.device_synchronize`](@ref).
+
+```@docs
+AMDGPU.synchronize
+AMDGPU.@sync
+AMDGPU.device_synchronize
+```

--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -32,6 +32,7 @@ function Base.lock(f, x::LockedObject)
     end
 end
 
+# TODO simplify
 struct KernelState
     # Exception reporting buffers.
     exception_flag::Ptr{Int32}

--- a/src/compiler/codegen.jl
+++ b/src/compiler/codegen.jl
@@ -134,8 +134,8 @@ function hipcompile(@nospecialize(job::CompilerJob))
     end
     if !isempty(global_hostcalls)
         @warn """Global hostcalls detected: $global_hostcalls.
-        Use `AMDGPU.synchronize(; blocking=false)` to synchronize and stop them.
-        Otherwise, performance might degrade.
+        Use `AMDGPU.synchronize(; stop_hostcalls=false)` to synchronize and stop them.
+        Otherwise, performance might degrade if they keep running in the background.
         """ maxlog=1
     end
 

--- a/src/hip/HIP.jl
+++ b/src/hip/HIP.jl
@@ -90,7 +90,11 @@ function memcpy(dst, src, sz, kind, stream::HIPStream)
 end
 
 function __init__()
-    global old_nonblock_sync = runtime_version() < v"5.4"
+    global old_nonblock_sync = if AMDGPU.functional(:hip)
+        runtime_version() < v"5.4"
+    else
+        false
+    end
 end
 
 end

--- a/src/hip/HIP.jl
+++ b/src/hip/HIP.jl
@@ -12,10 +12,13 @@ include("libhip.jl")
 include("device.jl")
 
 function runtime_version()
-    rt_ref = Ref{Cint}()
-    hipRuntimeGetVersion(rt_ref) |> check
-    rt = rt_ref[]
-    VersionNumber(rt ÷ Int(1e7), rt ÷ Int(1e5), rt % Int(1e5))
+    v_ref = Ref{Cint}()
+    hipRuntimeGetVersion(v_ref) |> check
+    v = v_ref[]
+    major = v ÷ 10_000_000
+    minor = (v ÷ 100_000) % 100
+    patch = v % 100000
+    VersionNumber(major, minor, patch)
 end
 
 mutable struct HIPContext
@@ -84,6 +87,10 @@ function memcpy(dst, src, sz, kind, stream::HIPStream)
     sz == 0 && return
     HIP.hipMemcpyWithStream(dst, src, sz, kind, stream) |> HIP.check
     return
+end
+
+function __init__()
+    global old_nonblock_sync = runtime_version() < v"5.4"
 end
 
 end

--- a/src/hip/HIP.jl
+++ b/src/hip/HIP.jl
@@ -1,6 +1,7 @@
 module HIP
 
 using CEnum
+import Preferences
 
 import ..AMDGPU
 import ..AMDGPU.libhip

--- a/src/hip/libhip.jl
+++ b/src/hip/libhip.jl
@@ -306,3 +306,8 @@ function hipDeviceCanAccessPeer(can_access_peer_ref, deviceid, peer_deviceid)
     AMDGPU.prepare_state()
     ccall((:hipDeviceCanAccessPeer, libhip), hipError_t, (Ptr{Cint}, Cint, Cint), can_access_peer_ref, deviceid, peer_deviceid)
 end
+
+function hipLaunchHostFunc(stream, fn, userData)
+    AMDGPU.prepare_state()
+    ccall((:hipLaunchHostFunc, libhip), hipError_t, (hipStream_t, hipHostFn, Ptr{Cvoid}), stream, fn, userData)
+end

--- a/src/hip/libhip_common.jl
+++ b/src/hip/libhip_common.jl
@@ -252,6 +252,8 @@ hipModule_t = Ptr{Cvoid}
 
 hipFunction_t = Ptr{Cvoid}
 
+hipHostFn = Ptr{Cvoid}
+
 hiprtcLinkState = Ptr{Cvoid}
 
 struct hipMemLocation

--- a/src/hip/stream.jl
+++ b/src/hip/stream.jl
@@ -114,7 +114,7 @@ function nonblocking_synchronize(stream::HIPStream)
     return
 end
 
-function non_blocking_synchronize_old(stream::HIPStream)
+function nonblocking_synchronize_old(stream::HIPStream)
     while true
         yield()
         isdone(stream) && return

--- a/src/hip/stream.jl
+++ b/src/hip/stream.jl
@@ -1,3 +1,6 @@
+const use_nonblocking_synchronize = Preferences.@load_preference(
+    "nonblocking_synchronization", true)
+
 mutable struct HIPStream
     stream::hipStream_t
     priority::Symbol
@@ -114,10 +117,10 @@ end
 wait(stream::HIPStream) = hipStreamSynchronize(stream) |> check
 
 function synchronize(stream::HIPStream; blocking::Bool = false)
-    if !_low_latency_synchronize(stream) && !blocking
-        nonblocking_synchronize(stream)
+    if use_nonblocking_synchronize && !blocking
+        _low_latency_synchronize(stream) || nonblocking_synchronize(stream)
     end
-    # Perform an actual API call after non-blocking synchronization.
+    # Perform an actual API call even after non-blocking synchronization.
     wait(stream)
     return
 end

--- a/src/hip/stream.jl
+++ b/src/hip/stream.jl
@@ -66,22 +66,59 @@ function _low_latency_synchronize(stream::HIPStream)
     return false
 end
 
-function non_blocking_synchronize(stream::HIPStream)
-    while true
-        yield()
-        isdone(stream) && return true
+function launch(f::Base.Callable; stream::HIPStream)
+    # Condition object is embedded in a task, Julia scheduler keeps it alive.
+    cond = Base.AsyncCondition() do async_cond
+        f()
+        close(async_cond)
     end
-    return false
+    callback = cglobal(:uv_async_send)
+    hipLaunchHostFunc(stream, callback, cond) |> check
+end
+
+function nonblocking_synchronize(stream::HIPStream)
+    # Wait for an event signalled by HIP.
+    event = Base.Event()
+    launch(() -> notify(event); stream)
+
+    # If an error occurs, the callback may never fire.
+    # Create a timer to detect such cases.
+    dev = device()
+    timer = Timer(0; interval=1)
+
+    Base.@sync begin
+        # Launch timer.
+        Threads.@spawn try
+            device!(dev)
+            while true
+                try
+                    Base.wait(timer)
+                catch err
+                    err isa EOFError && break
+                    rethrow()
+                end
+                hipStreamQuery(stream) != hipErrorNotReady && break
+            end
+        finally
+            notify(event)
+        end
+        # Wait for `event`.
+        Threads.@spawn begin
+            Base.wait(event)
+            close(timer)
+        end
+    end
+    return
 end
 
 wait(stream::HIPStream) = hipStreamSynchronize(stream) |> check
 
-function synchronize(stream::HIPStream; blocking::Bool = true)
-    if blocking
-        _low_latency_synchronize(stream) || wait(stream)
-    else
-        non_blocking_synchronize(stream)
+function synchronize(stream::HIPStream; blocking::Bool = false)
+    if !_low_latency_synchronize(stream) && !blocking
+        nonblocking_synchronize(stream)
     end
+    # Perform an actual API call after non-blocking synchronization.
+    wait(stream)
     return
 end
 

--- a/test/device/hostcall.jl
+++ b/test/device/hostcall.jl
@@ -17,7 +17,7 @@
     end
 
     @roc kernel(RA, RB, hc)
-    AMDGPU.synchronize(; blocking=false)
+    AMDGPU.synchronize(; stop_hostcalls=true)
     @test Array(RB)[1] == 1f0
     @test dref[] == true
 end
@@ -41,7 +41,7 @@ end
         end
 
         @roc kernel(RA, RB, hc)
-        @test_throws ErrorException AMDGPU.synchronize(; blocking=false)
+        @test_throws ErrorException AMDGPU.synchronize(; stop_hostcalls=true)
         AMDGPU.reset_exception_holder!(AMDGPU.device())
 
         @test Array(RB)[1] == 0f0
@@ -65,7 +65,7 @@ end
     end
 
     @roc kernel(RA, RB, hc)
-    AMDGPU.synchronize(; blocking=false)
+    AMDGPU.synchronize(; stop_hostcalls=true)
     @test Array(RB)[1] == 2f0
 end
 
@@ -83,7 +83,7 @@ end
     end
 
     @roc kernel(RA, RB, hc)
-    AMDGPU.synchronize(; blocking=false)
+    AMDGPU.synchronize(; stop_hostcalls=true)
     @test Array(RB)[1] == 44f0
 end
 
@@ -101,7 +101,7 @@ end
     end
 
     @roc kernel(RA, RB, hc)
-    AMDGPU.synchronize(; blocking=false)
+    AMDGPU.synchronize(; stop_hostcalls=true)
     @test Array(RB)[1] == 47f0
 end
 
@@ -119,7 +119,7 @@ end
     end
 
     @roc kernel(RA, RB, hc)
-    AMDGPU.synchronize(; blocking=false)
+    AMDGPU.synchronize(; stop_hostcalls=true)
     @test Array(RB)[1] == 47f0
 end
 
@@ -137,7 +137,7 @@ end
     end
 
     @roc kernel(RA, RB, hc)
-    AMDGPU.synchronize(; blocking=false)
+    AMDGPU.synchronize(; stop_hostcalls=true)
     @test Array(RB)[1] == 48f0
 end
 
@@ -155,7 +155,7 @@ end
     end
 
     @roc kernel(RA, RB, hc)
-    AMDGPU.synchronize(; blocking=false)
+    AMDGPU.synchronize(; stop_hostcalls=true)
     @test Array(RB)[1] == 48f0
 end
 
@@ -177,7 +177,7 @@ end
     end
 
     @roc kernel(RA, RB, hc1, hc2)
-    AMDGPU.synchronize(; blocking=false)
+    AMDGPU.synchronize(; stop_hostcalls=true)
     @test Array(RB)[1] == 11f0
 end
 
@@ -195,10 +195,10 @@ end
     end
 
     @roc kernel(RA, RB, hc)
-    AMDGPU.synchronize(; blocking=false)
+    AMDGPU.synchronize(; stop_hostcalls=true)
 
     @roc kernel(RA, RB, hc)
-    AMDGPU.synchronize(; blocking=false)
+    AMDGPU.synchronize(; stop_hostcalls=true)
 
     # Next time HC will be called from the kernel is its last time.
     # So that it shutdowns correctly and does not stick to the end.

--- a/test/device/output.jl
+++ b/test/device/output.jl
@@ -4,7 +4,7 @@
 
         _, msg = @grab_output begin
             @roc kernel()
-            AMDGPU.synchronize(; blocking=false)
+            AMDGPU.synchronize(; stop_hostcalls=true)
         end
         @test msg == "Hello World!"
     end
@@ -14,7 +14,7 @@
 
         _, msg = @grab_output begin
             @roc kernel()
-            AMDGPU.synchronize(; blocking=false)
+            AMDGPU.synchronize(; stop_hostcalls=true)
         end
         @test msg == "Hello World!\n"
     end
@@ -27,7 +27,7 @@
 
         _, msg = @grab_output begin
             @roc kernel()
-            AMDGPU.synchronize(; blocking=false)
+            AMDGPU.synchronize(; stop_hostcalls=true)
         end
         @test msg == "Hello World!Goodbye World!\n"
     end
@@ -55,7 +55,7 @@ end
 
         _, msg = @grab_output begin
             @roc kernel()
-            AMDGPU.synchronize(; blocking=false)
+            AMDGPU.synchronize(; stop_hostcalls=true)
         end
         @test msg == "Hello World!\n"
     end
@@ -65,7 +65,7 @@ end
 
         _, msg = @grab_output begin
             @roc kernel(42)
-            AMDGPU.synchronize(; blocking=false)
+            AMDGPU.synchronize(; stop_hostcalls=true)
         end
         @test msg == "Value: 42\n"
     end
@@ -78,7 +78,7 @@ end
 
         _, msg = @grab_output begin
             @roc kernel(42)
-            AMDGPU.synchronize(; blocking=false)
+            AMDGPU.synchronize(; stop_hostcalls=true)
         end
         @test msg == "Value: 42 | 0.1234\n"
     end
@@ -90,7 +90,7 @@ end
         exp = reduce(*, ["[$i] " for i in 1:8])
         _, msg = @grab_output begin
             @roc groupsize=8 kernel()
-            AMDGPU.synchronize(; blocking=false)
+            AMDGPU.synchronize(; stop_hostcalls=true)
         end
         @test msg == exp
 
@@ -98,7 +98,7 @@ end
         exp = reduce(*, ["[$i] " for i in 1:128])
         _, msg = @grab_output begin
             @roc groupsize=128 kernel()
-            AMDGPU.synchronize(; blocking=false)
+            AMDGPU.synchronize(; stop_hostcalls=true)
         end
         @test msg == exp
 
@@ -106,7 +106,7 @@ end
         exp = reduce(*, ["[$i] " for i in vcat(1:64, 1:64, 1:64, 1:64)])
         _, msg = @grab_output begin
             @roc groupsize=64 gridsize=4 kernel()
-            AMDGPU.synchronize(; blocking=false)
+            AMDGPU.synchronize(; stop_hostcalls=true)
         end
         @test msg == exp
 
@@ -114,7 +114,7 @@ end
         exp = reduce(*, ["[$i] " for i in vcat(1:128, 1:128)])
         _, msg = @grab_output begin
             @roc groupsize=128 gridsize=2 kernel()
-            AMDGPU.synchronize(; blocking=false)
+            AMDGPU.synchronize(; stop_hostcalls=true)
         end
         @test msg == exp
     end
@@ -128,7 +128,7 @@ end
         exp = "[1] "
         _, msg = @grab_output begin
             @roc groupsize=1 kernel()
-            AMDGPU.synchronize(; blocking=false)
+            AMDGPU.synchronize(; stop_hostcalls=true)
         end
         @test msg == exp
 
@@ -137,7 +137,7 @@ end
         exp = reduce(*, ["[$i] " for i in collect(1:wsize:groupsize)])
         _, msg = @grab_output begin
             @roc groupsize=groupsize kernel()
-            AMDGPU.synchronize(; blocking=false)
+            AMDGPU.synchronize(; stop_hostcalls=true)
         end
         @test msg == exp
 
@@ -146,7 +146,7 @@ end
         exp = repeat("[1] ", 256 ÷ wsize)
         _, msg = @grab_output begin
             @roc groupsize=wsize gridsize=gridsize kernel()
-            AMDGPU.synchronize(; blocking=false)
+            AMDGPU.synchronize(; stop_hostcalls=true)
         end
         @test msg == exp
 
@@ -158,7 +158,7 @@ end
             n_groups)
         _, msg = @grab_output begin
             @roc groupsize=128 gridsize=2 kernel()
-            AMDGPU.synchronize(; blocking=false)
+            AMDGPU.synchronize(; stop_hostcalls=true)
         end
         @test msg == exp
     end
@@ -170,7 +170,7 @@ end
         exp = "[1] "
         _, msg = @grab_output begin
             @roc groupsize=8 kernel()
-            AMDGPU.synchronize(; blocking=false)
+            AMDGPU.synchronize(; stop_hostcalls=true)
         end
         @test msg == exp
 
@@ -178,7 +178,7 @@ end
         exp = "[1] "
         _, msg = @grab_output begin
             @roc groupsize=128 kernel()
-            AMDGPU.synchronize(; blocking=false)
+            AMDGPU.synchronize(; stop_hostcalls=true)
         end
         @test msg == exp
 
@@ -186,7 +186,7 @@ end
         exp = reduce(*, ["[$i] " for i in [1, 1, 1, 1]])
         _, msg = @grab_output begin
             @roc groupsize=64 gridsize=4 kernel()
-            AMDGPU.synchronize(; blocking=false)
+            AMDGPU.synchronize(; stop_hostcalls=true)
         end
         @test msg == exp
 
@@ -194,7 +194,7 @@ end
         exp = reduce(*, ["[$i] " for i in [1, 1]])
         _, msg = @grab_output begin
             @roc groupsize=128 gridsize=2 kernel()
-            AMDGPU.synchronize(; blocking=false)
+            AMDGPU.synchronize(; stop_hostcalls=true)
         end
         @test msg == exp
     end
@@ -206,7 +206,7 @@ end
         exp = "[1] "
         _, msg = @grab_output begin
             @roc groupsize=8 kernel()
-            AMDGPU.synchronize(; blocking=false)
+            AMDGPU.synchronize(; stop_hostcalls=true)
         end
         @test msg == exp
 
@@ -214,7 +214,7 @@ end
         exp = "[1] "
         _, msg = @grab_output begin
             @roc groupsize=128 kernel()
-            AMDGPU.synchronize(; blocking=false)
+            AMDGPU.synchronize(; stop_hostcalls=true)
         end
         @test msg == exp
 
@@ -222,7 +222,7 @@ end
         exp = "[1] "
         _, msg = @grab_output begin
             @roc groupsize=64 gridsize=4 kernel()
-            AMDGPU.synchronize(; blocking=false)
+            AMDGPU.synchronize(; stop_hostcalls=true)
         end
         @test msg == exp
 
@@ -230,7 +230,7 @@ end
         exp = "[1] "
         _, msg = @grab_output begin
             @roc groupsize=128 gridsize=2 kernel()
-            AMDGPU.synchronize(; blocking=false)
+            AMDGPU.synchronize(; stop_hostcalls=true)
         end
         @test msg == exp
     end

--- a/test/gpuarrays_tests.jl
+++ b/test/gpuarrays_tests.jl
@@ -23,7 +23,7 @@ end
 end
 @testitem "gpuarrays - indexing multidimensional" setup=[TSGPUArrays] begin
     gpuarrays_test("indexing multidimensional")
-    AMDGPU.synchronize(; blocking=false)
+    AMDGPU.synchronize(; stop_hostcalls=true)
 end
 @testitem "gpuarrays - indexing scalar" setup=[TSGPUArrays] begin
     gpuarrays_test("indexing scalar")

--- a/test/ka_tests.jl
+++ b/test/ka_tests.jl
@@ -10,6 +10,6 @@ Testsuite.testsuite(
     skip_tests=Set(["Printing", "sparse"])) # TODO fix KA printing
 
 # Disable global malloc hostcall started by conversion tests.
-AMDGPU.synchronize(; blocking=false)
+AMDGPU.synchronize(; stop_hostcalls=true)
 
 end


### PR DESCRIPTION
Use non-blocking synchronization by default.
Waiting on a stream is done by launching host function on that stream, that triggers an event once it is processed, similar to how CUDA.jl does it.
This requires ROCm 5.4+, therefore we have a fallback that works on previous versions as well.