### PR TITLE
Add workgroup synchronization primitives

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,10 +1,6 @@
 # AMDGPU API Reference
 
-## Device code API
-
-### Thread indexing
-
-#### HSA nomenclature
+## Indexing
 
 ```@docs
 AMDGPU.workitemIdx
@@ -14,8 +10,6 @@ AMDGPU.gridItemDim
 AMDGPU.gridGroupDim
 ```
 
-#### CUDA nomenclature
-
 Use these functions for compatibility with CUDA.jl.
 
 ```@docs
@@ -24,8 +18,11 @@ AMDGPU.Device.blockIdx
 AMDGPU.Device.blockDim
 ```
 
-### Synchronization
+## Synchronization
 
 ```@docs
 AMDGPU.sync_workgroup
+AMDGPU.sync_workgroup_count
+AMDGPU.sync_workgroup_and
+AMDGPU.sync_workgroup_or
 ```

--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -81,13 +81,14 @@ import .Device: report_exception_frame, report_exception_name
 import .Device: ROCDeviceArray, AS, HostCall, HostCallHolder, hostcall!
 import .Device: @ROCDynamicLocalArray, @ROCStaticLocalArray
 import .Device: workitemIdx, workgroupIdx, workgroupDim, gridItemDim, gridGroupDim
-import .Device: threadIdx, blockIdx, blockDim, sync_workgroup
+import .Device: threadIdx, blockIdx, blockDim
+import .Device: sync_workgroup, sync_workgroup_count, sync_workgroup_and, sync_workgroup_or
 import .Device: @rocprint, @rocprintln, @rocprintf
 
 export ROCDeviceArray, @ROCDynamicLocalArray, @ROCStaticLocalArray
 export @rocprint, @rocprintln, @rocprintf
 export workitemIdx, workgroupIdx, workgroupDim, gridItemDim, gridGroupDim
-export sync_workgroup
+export sync_workgroup, sync_workgroup_count, sync_workgroup_and, sync_workgroup_or
 
 include("compiler/Compiler.jl")
 import .Compiler

--- a/src/compiler/device_libs.jl
+++ b/src/compiler/device_libs.jl
@@ -25,7 +25,8 @@ end
 const DEVICE_LIBS::Dict{String, DevLib} = Dict{String, DevLib}()
 
 function link_device_libs!(
-    target::GCNCompilerTarget, mod::LLVM.Module, undefined_fns::Vector{String},
+    target::GCNCompilerTarget, mod::LLVM.Module, undefined_fns::Vector{String};
+    wavefrontsize64::Bool,
 )
     isnothing(libdevice_libs) && return
     isempty(undefined_fns) && return
@@ -58,7 +59,7 @@ function link_device_libs!(
         (:unsafe_math, false),
         (:correctly_rounded_sqrt, true),
         (:daz_opt, false),
-        (:wavefrontsize64, true))
+        (:wavefrontsize64, wavefrontsize64))
 
     for (option, value) in options
         toggle = value ? "on" : "off"

--- a/src/device/gcn/synchronization.jl
+++ b/src/device/gcn/synchronization.jl
@@ -2,6 +2,19 @@
     sync_workgroup()
 
 Waits until all wavefronts in a workgroup have reached this call.
-This function is meant to be used inside kernels.
 """
-@inline sync_workgroup() = ccall("llvm.amdgcn.s.barrier", llvmcall, Cvoid, ())
+@inline sync_workgroup() =
+    ccall("llvm.amdgcn.s.barrier", llvmcall, Cvoid, ())
+
+"""
+    sync_workgroup_count(predicate::Cint)::Cint
+
+Identical to [sync_workgroup](@ref), with the additional feature
+that it evaluates the predicate for all workitems in the workgroup
+and returns the number of workitems for which predicate evaluates to non-zero.
+"""
+@inline sync_workgroup_count(predicate::Cint)::Cint = ccall(
+    "extern __ockl_wgred_add_i32", llvmcall, Cint, (Cint,),
+    __not(__not(predicate)))
+
+@inline __not(x::Cint)::Cint = ifelse(iszero(x), one(x), zero(x))

--- a/src/device/gcn/synchronization.jl
+++ b/src/device/gcn/synchronization.jl
@@ -9,7 +9,7 @@ Waits until all wavefronts in a workgroup have reached this call.
 """
     sync_workgroup_count(predicate::Cint)::Cint
 
-Identical to [sync_workgroup](@ref), with the additional feature
+Identical to `sync_workgroup`, with the additional feature
 that it evaluates the predicate for all workitems in the workgroup
 and returns the number of workitems for which predicate evaluates to non-zero.
 """
@@ -22,7 +22,7 @@ end
 """
     sync_workgroup_and(predicate::Cint)::Cint
 
-Identical to [sync_workgroup](@ref), with the additional feature
+Identical to `sync_workgroup`, with the additional feature
 that it evaluates the predicate for all workitems in the workgroup
 and returns non-zero if and only if predicate evaluates to non-zero for all of them.
 """
@@ -35,7 +35,7 @@ end
 """
     sync_workgroup_or(predicate::Cint)::Cint
 
-Identical to [sync_workgroup](@ref), with the additional feature
+Identical to `sync_workgroup`, with the additional feature
 that it evaluates the predicate for all workitems in the workgroup
 and returns non-zero if and only if predicate evaluates to non-zero for any of them.
 """

--- a/src/device/gcn/synchronization.jl
+++ b/src/device/gcn/synchronization.jl
@@ -13,8 +13,36 @@ Identical to [sync_workgroup](@ref), with the additional feature
 that it evaluates the predicate for all workitems in the workgroup
 and returns the number of workitems for which predicate evaluates to non-zero.
 """
-@inline sync_workgroup_count(predicate::Cint)::Cint = ccall(
-    "extern __ockl_wgred_add_i32", llvmcall, Cint, (Cint,),
-    __not(__not(predicate)))
+@inline function sync_workgroup_count(predicate::Cint)::Cint
+    ccall(
+        "extern __ockl_wgred_add_i32", llvmcall, Cint, (Cint,),
+        __not(__not(predicate)))
+end
+
+"""
+    sync_workgroup_and(predicate::Cint)::Cint
+
+Identical to [sync_workgroup](@ref), with the additional feature
+that it evaluates the predicate for all workitems in the workgroup
+and returns non-zero if and only if predicate evaluates to non-zero for all of them.
+"""
+@inline function sync_workgroup_and(predicate::Cint)::Cint
+    ccall(
+        "extern __ockl_wgred_and_i32", llvmcall, Cint, (Cint,),
+        __not(__not(predicate)))
+end
+
+"""
+    sync_workgroup_or(predicate::Cint)::Cint
+
+Identical to [sync_workgroup](@ref), with the additional feature
+that it evaluates the predicate for all workitems in the workgroup
+and returns non-zero if and only if predicate evaluates to non-zero for any of them.
+"""
+@inline function sync_workgroup_or(predicate::Cint)::Cint
+    ccall(
+        "extern __ockl_wgred_or_i32", llvmcall, Cint, (Cint,),
+        __not(__not(predicate)))
+end
 
 @inline __not(x::Cint)::Cint = ifelse(iszero(x), one(x), zero(x))

--- a/test/device/array.jl
+++ b/test/device/array.jl
@@ -18,5 +18,5 @@
     # Custom show methods are defined
     @test occursin("4×4 device array at", sprint(io->show(io, RD)))
     @test occursin("2×2 device array view", sprint(io->show(io, RD_view)))
-    @test occursin("4×4 device array wrapper Adjoint", sprint(io->show(io, RD_adj)))
+    @test occursin("4×4 device array wrapper LinearAlgebra.Adjoint", sprint(io->show(io, RD_adj)))
 end

--- a/test/device/synchronization.jl
+++ b/test/device/synchronization.jl
@@ -37,9 +37,7 @@ function test_sync_workgroup_count!(
 end
 
 @testset "sync_workgroup_count: block_size=$block_size" for block_size in (
-    # 10, 40, 70,
-    33,
-    # 240, 723, 32, 64, 128, 256, 512, 1024,
+    10, 40, 70, 240, 723, 32, 64, 128, 256, 512, 1024,
 )
     sync_test = ROCArray{Int32}(undef, 2 * block_size)
     all_workitems_zero = ROCArray{Int32}(undef, 2 * block_size)
@@ -51,13 +49,6 @@ end
     @roc groupsize=block_size gridsize=2 test_sync_workgroup_count!(
         sync_test, all_workitems_zero, all_workitems_one, odd_workitems_one,
         all_workitems_minus_one, all_workitems_id)
-
-    @show sync_test
-    @show all_workitems_zero
-    @show all_workitems_one
-    @show odd_workitems_one
-    @show all_workitems_minus_one
-    @show all_workitems_id
 
     @test all(Array(sync_test) .== 30)
     @test all(Array(all_workitems_zero) .== 0)
@@ -72,6 +63,124 @@ end
     AMDGPU.unsafe_free!(odd_workitems_one)
     AMDGPU.unsafe_free!(all_workitems_minus_one)
     AMDGPU.unsafe_free!(all_workitems_id)
+end
+
+function test_sync_workgroup_and!(
+    sync_test,
+    all_workitems_zero,
+    all_workitems_one,
+    one_workitem_zero,
+    all_workitems_minus_one,
+)
+    block_size = workgroupDim().x
+
+    # First block index starts with 0.
+    # Second block index starts with `block_size`.
+    i = workgroupIdx().x == 1 ? workitemIdx().x : (block_size + workitemIdx().x)
+
+    sm = @ROCStaticLocalArray(Int32, 2, false)
+    if workitemIdx().x == 1
+        sm[1] = 10
+    elseif workitemIdx().x == 2
+        sm[2] = 20
+    end
+    Device.sync_workgroup_and(Cint(1))
+    sync_test[i] = sm[1] + sm[2]
+
+    # All workitems pass 0, result should be 0.
+    all_workitems_zero[i] = Device.sync_workgroup_and(Cint(0))
+    # All workitems pass 1, result should be `block_size`.
+    all_workitems_one[i] = Device.sync_workgroup_and(Cint(1))
+    # Workitem 0 passes 0, others - 1.
+    one_workitem_zero[i] = Device.sync_workgroup_and(Cint(workitemIdx().x == 1 ? 0 : 1))
+    # All workitems pass -1, result should be 1.
+    all_workitems_minus_one[i] = Device.sync_workgroup_and(Cint(-1))
+    return
+end
+
+@testset "sync_workgroup_and: block_size=$block_size" for block_size in (
+    10, 40, 70, 240, 723, 32, 64, 128, 256, 512, 1024,
+)
+    sync_test = ROCArray{Int32}(undef, 2 * block_size)
+    all_workitems_zero = ROCArray{Int32}(undef, 2 * block_size)
+    all_workitems_one = ROCArray{Int32}(undef, 2 * block_size)
+    one_workitem_zero = ROCArray{Int32}(undef, 2 * block_size)
+    all_workitems_minus_one = ROCArray{Int32}(undef, 2 * block_size)
+
+    @roc groupsize=block_size gridsize=2 test_sync_workgroup_and!(
+        sync_test, all_workitems_zero, all_workitems_one,
+        one_workitem_zero, all_workitems_minus_one)
+
+    @test all(Array(sync_test) .== 30)
+    @test all(Array(all_workitems_zero) .== 0)
+    @test all(Array(all_workitems_one) .== 1)
+    @test all(Array(one_workitem_zero) .== 0)
+    @test all(Array(all_workitems_minus_one) .== 1)
+
+    AMDGPU.unsafe_free!(sync_test)
+    AMDGPU.unsafe_free!(all_workitems_zero)
+    AMDGPU.unsafe_free!(all_workitems_one)
+    AMDGPU.unsafe_free!(one_workitem_zero)
+    AMDGPU.unsafe_free!(all_workitems_minus_one)
+end
+
+function test_sync_workgroup_or!(
+    sync_test,
+    all_workitems_zero,
+    all_workitems_one,
+    one_workitem_zero,
+    all_workitems_minus_one,
+)
+    block_size = workgroupDim().x
+
+    # First block index starts with 0.
+    # Second block index starts with `block_size`.
+    i = workgroupIdx().x == 1 ? workitemIdx().x : (block_size + workitemIdx().x)
+
+    sm = @ROCStaticLocalArray(Int32, 2, false)
+    if workitemIdx().x == 1
+        sm[1] = 10
+    elseif workitemIdx().x == 2
+        sm[2] = 20
+    end
+    Device.sync_workgroup_or(Cint(1))
+    sync_test[i] = sm[1] + sm[2]
+
+    # All workitems pass 0, result should be 0.
+    all_workitems_zero[i] = Device.sync_workgroup_or(Cint(0))
+    # All workitems pass 1, result should be `block_size`.
+    all_workitems_one[i] = Device.sync_workgroup_or(Cint(1))
+    # Workitem 0 passes 1, others - 0.
+    one_workitem_zero[i] = Device.sync_workgroup_or(Cint(workitemIdx().x == 1 ? 1 : 0))
+    # All workitems pass -1, result should be 1.
+    all_workitems_minus_one[i] = Device.sync_workgroup_or(Cint(-1))
+    return
+end
+
+@testset "sync_workgroup_and: block_size=$block_size" for block_size in (
+    10, 40, 70, 240, 723, 32, 64, 128, 256, 512, 1024,
+)
+    sync_test = ROCArray{Int32}(undef, 2 * block_size)
+    all_workitems_zero = ROCArray{Int32}(undef, 2 * block_size)
+    all_workitems_one = ROCArray{Int32}(undef, 2 * block_size)
+    one_workitem_zero = ROCArray{Int32}(undef, 2 * block_size)
+    all_workitems_minus_one = ROCArray{Int32}(undef, 2 * block_size)
+
+    @roc groupsize=block_size gridsize=2 test_sync_workgroup_or!(
+        sync_test, all_workitems_zero, all_workitems_one,
+        one_workitem_zero, all_workitems_minus_one)
+
+    @test all(Array(sync_test) .== 30)
+    @test all(Array(all_workitems_zero) .== 0)
+    @test all(Array(all_workitems_one) .== 1)
+    @test all(Array(one_workitem_zero) .== 1)
+    @test all(Array(all_workitems_minus_one) .== 1)
+
+    AMDGPU.unsafe_free!(sync_test)
+    AMDGPU.unsafe_free!(all_workitems_zero)
+    AMDGPU.unsafe_free!(all_workitems_one)
+    AMDGPU.unsafe_free!(one_workitem_zero)
+    AMDGPU.unsafe_free!(all_workitems_minus_one)
 end
 
 end

--- a/test/device/synchronization.jl
+++ b/test/device/synchronization.jl
@@ -12,7 +12,8 @@ function test_sync_workgroup_count!(
 
     # First block index starts with 0.
     # Second block index starts with `block_size`.
-    i = workgroupIdx().x == 1 ? workitemIdx().x : (block_size + workitemIdx().x)
+    i = ifelse(workgroupIdx().x == 1,
+        workitemIdx().x, (block_size + workitemIdx().x))
 
     sm = @ROCStaticLocalArray(Int32, 2, false)
     if workitemIdx().x == 1
@@ -28,7 +29,7 @@ function test_sync_workgroup_count!(
     # All workitems pass 1, result should be `block_size`.
     all_workitems_one[i] = Device.sync_workgroup_count(Cint(1))
     # Odd workitems pass 1, result should be `block_size ÷ 2`.
-    odd_workitems_one[i] = Device.sync_workgroup_count(Cint(workitemIdx().x % 2))
+    odd_workitems_one[i] = Device.sync_workgroup_count(Cint((workitemIdx().x - 1) % 2))
     # All workitems pass -1, result should be `block_size`.
     all_workitems_minus_one[i] = Device.sync_workgroup_count(Cint(-1))
     # All workitems pass its id (starting from 0), result should be `block_size - 1`.

--- a/test/device/synchronization.jl
+++ b/test/device/synchronization.jl
@@ -1,0 +1,77 @@
+@testset "Workgroup synchronization" begin
+
+function test_sync_workgroup_count!(
+    sync_test,
+    all_workitems_zero,
+    all_workitems_one,
+    odd_workitems_one,
+    all_workitems_minus_one,
+    all_workitems_id,
+)
+    block_size = workgroupDim().x
+
+    # First block index starts with 0.
+    # Second block index starts with `block_size`.
+    i = workgroupIdx().x == 1 ? workitemIdx().x : (block_size + workitemIdx().x)
+
+    sm = @ROCStaticLocalArray(Int32, 2, false)
+    if workitemIdx().x == 1
+        sm[1] = 10
+    elseif workitemIdx().x == 2
+        sm[2] = 20
+    end
+    Device.sync_workgroup_count(Cint(1))
+    sync_test[i] = sm[1] + sm[2]
+
+    # All workitems pass 0, result should be 0.
+    all_workitems_zero[i] = Device.sync_workgroup_count(Cint(0))
+    # All workitems pass 1, result should be `block_size`.
+    all_workitems_one[i] = Device.sync_workgroup_count(Cint(1))
+    # Odd workitems pass 1, result should be `block_size ÷ 2`.
+    odd_workitems_one[i] = Device.sync_workgroup_count(Cint(workitemIdx().x % 2))
+    # All workitems pass -1, result should be `block_size`.
+    all_workitems_minus_one[i] = Device.sync_workgroup_count(Cint(-1))
+    # All workitems pass its id (starting from 0), result should be `block_size - 1`.
+    all_workitems_id[i] = Device.sync_workgroup_count(Cint(workitemIdx().x - 1))
+    return
+end
+
+@testset "sync_workgroup_count: block_size=$block_size" for block_size in (
+    # 10, 40, 70,
+    33,
+    # 240, 723, 32, 64, 128, 256, 512, 1024,
+)
+    sync_test = ROCArray{Int32}(undef, 2 * block_size)
+    all_workitems_zero = ROCArray{Int32}(undef, 2 * block_size)
+    all_workitems_one = ROCArray{Int32}(undef, 2 * block_size)
+    odd_workitems_one = ROCArray{Int32}(undef, 2 * block_size)
+    all_workitems_minus_one = ROCArray{Int32}(undef, 2 * block_size)
+    all_workitems_id = ROCArray{Int32}(undef, 2 * block_size)
+
+    @roc groupsize=block_size gridsize=2 test_sync_workgroup_count!(
+        sync_test, all_workitems_zero, all_workitems_one, odd_workitems_one,
+        all_workitems_minus_one, all_workitems_id)
+
+    @show sync_test
+    @show all_workitems_zero
+    @show all_workitems_one
+    @show odd_workitems_one
+    @show all_workitems_minus_one
+    @show all_workitems_id
+
+    @test all(Array(sync_test) .== 30)
+    @test all(Array(all_workitems_zero) .== 0)
+    @test all(Array(all_workitems_one) .== block_size)
+    @test all(Array(odd_workitems_one) .== block_size ÷ 2)
+    @test all(Array(all_workitems_minus_one) .== block_size)
+    @test all(Array(all_workitems_id) .== block_size - 1)
+
+    AMDGPU.unsafe_free!(sync_test)
+    AMDGPU.unsafe_free!(all_workitems_zero)
+    AMDGPU.unsafe_free!(all_workitems_one)
+    AMDGPU.unsafe_free!(odd_workitems_one)
+    AMDGPU.unsafe_free!(all_workitems_minus_one)
+    AMDGPU.unsafe_free!(all_workitems_id)
+end
+
+end

--- a/test/device_tests.jl
+++ b/test/device_tests.jl
@@ -1,0 +1,18 @@
+@testitem "core: device" begin
+
+using AMDGPU
+using AMDGPU: Device, Runtime, @allowscalar
+using LinearAlgebra
+
+include("device/launch.jl")
+include("device/array.jl")
+include("device/vadd.jl")
+include("device/memory.jl")
+include("device/indexing.jl")
+include("device/math.jl")
+include("device/wavefront.jl")
+include("device/synchronization.jl")
+include("device/execution_control.jl")
+include("device/exceptions.jl")
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -103,25 +103,26 @@ if "core" in TARGET_TESTS
     @testset verbose=true "Device Functions" begin
         @info "Testing `Device Functions` on the main thread without workers."
 
-        include("device/launch.jl")
-        include("device/array.jl")
-        include("device/vadd.jl")
-        include("device/memory.jl")
-        include("device/indexing.jl")
-        include("device/math.jl")
-        include("device/wavefront.jl")
-        include("device/execution_control.jl")
-        include("device/exceptions.jl")
-        include("device/hostcall.jl")
-        include("device/output.jl")
+        include("device/synchronization.jl")
+        # include("device/launch.jl")
+        # include("device/array.jl")
+        # include("device/vadd.jl")
+        # include("device/memory.jl")
+        # include("device/indexing.jl")
+        # include("device/math.jl")
+        # include("device/wavefront.jl")
+        # include("device/execution_control.jl")
+        # include("device/exceptions.jl")
+        # include("device/hostcall.jl")
+        # include("device/output.jl")
     end
 end
 
-CI = parse(Bool, get(ENV, "CI", "false"))
+# CI = parse(Bool, get(ENV, "CI", "false"))
 
-runtests(AMDGPU; nworkers=np, nworker_threads=1, testitem_timeout=60 * 30) do ti
-    for tt in TARGET_TESTS
-        startswith(ti.name, tt) && return true
-    end
-    return false
-end
+# runtests(AMDGPU; nworkers=np, nworker_threads=1, testitem_timeout=60 * 30) do ti
+#     for tt in TARGET_TESTS
+#         startswith(ti.name, tt) && return true
+#     end
+#     return false
+# end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -104,25 +104,25 @@ if "core" in TARGET_TESTS
         @info "Testing `Device Functions` on the main thread without workers."
 
         include("device/synchronization.jl")
-        # include("device/launch.jl")
-        # include("device/array.jl")
-        # include("device/vadd.jl")
-        # include("device/memory.jl")
-        # include("device/indexing.jl")
-        # include("device/math.jl")
-        # include("device/wavefront.jl")
-        # include("device/execution_control.jl")
-        # include("device/exceptions.jl")
-        # include("device/hostcall.jl")
-        # include("device/output.jl")
+        include("device/launch.jl")
+        include("device/array.jl")
+        include("device/vadd.jl")
+        include("device/memory.jl")
+        include("device/indexing.jl")
+        include("device/math.jl")
+        include("device/wavefront.jl")
+        include("device/execution_control.jl")
+        include("device/exceptions.jl")
+        include("device/hostcall.jl")
+        include("device/output.jl")
     end
 end
 
-# CI = parse(Bool, get(ENV, "CI", "false"))
+CI = parse(Bool, get(ENV, "CI", "false"))
 
-# runtests(AMDGPU; nworkers=np, nworker_threads=1, testitem_timeout=60 * 30) do ti
-#     for tt in TARGET_TESTS
-#         startswith(ti.name, tt) && return true
-#     end
-#     return false
-# end
+runtests(AMDGPU; nworkers=np, nworker_threads=1, testitem_timeout=60 * 30) do ti
+    for tt in TARGET_TESTS
+        startswith(ti.name, tt) && return true
+    end
+    return false
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -100,19 +100,8 @@ np = clamp(np, 1, 4)
 AMDGPU.versioninfo()
 
 if "core" in TARGET_TESTS
-    @testset verbose=true "Device Functions" begin
-        @info "Testing `Device Functions` on the main thread without workers."
-
-        include("device/synchronization.jl")
-        include("device/launch.jl")
-        include("device/array.jl")
-        include("device/vadd.jl")
-        include("device/memory.jl")
-        include("device/indexing.jl")
-        include("device/math.jl")
-        include("device/wavefront.jl")
-        include("device/execution_control.jl")
-        include("device/exceptions.jl")
+    @info "Testing `Hostcalls` on the main thread."
+    @testset "Hostcalls" begin
         include("device/hostcall.jl")
         include("device/output.jl")
     end


### PR DESCRIPTION
~~Strangely on Navi 2 sometimes exactly one warp will fail to synchronize while every other warp succeedes...~~
Turns out we were always compiling kernels for the wavefront 64, which is not correct.

- Use correct wavefront size when compiling kernels.
- Add workgroup synchronization primitives: `sync_workgroup_count`, `sync_workgroup_and`, `sync_workgroup_or`.
- Only run hostcall tests on main thread. Move the rest of the device tests to a separate worker.
