### PR TITLE
Defer freeing hostcall buffers & add 1.10 CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -45,7 +45,7 @@ steps:
   - label: "Julia 1.10 - No Artifacts"
     plugins:
       - JuliaCI/julia#v1:
-          version: 1.10
+          version: "1.10"
       - JuliaCI/julia-test#v1:
       - JuliaCI/julia-coverage#v1:
           codecov: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,10 +22,30 @@ steps:
     if: build.message !~ /\[skip docs\]/
     timeout_in_minutes: 10
 
-  - label: "Julia 1.9 - No Artifacts"
+  # - label: "Julia 1.9 - No Artifacts"
+  #   plugins:
+  #     - JuliaCI/julia#v1:
+  #         version: 1.9
+  #     - JuliaCI/julia-test#v1:
+  #     - JuliaCI/julia-coverage#v1:
+  #         codecov: true
+  #   agents:
+  #     queue: "juliagpu"
+  #     rocm: "*"
+  #     rocmgpu: "gfx1031"
+  #   if: build.message !~ /\[skip tests\]/
+  #   command: "julia --project -e 'using Pkg; Pkg.update()'"
+  #   timeout_in_minutes: 180
+  #   env:
+  #     JULIA_NUM_THREADS: 4
+  #     JULIA_AMDGPU_CORE_MUST_LOAD: "1"
+  #     JULIA_AMDGPU_HIP_MUST_LOAD: "1"
+  #     JULIA_AMDGPU_DISABLE_ARTIFACTS: "1"
+
+  - label: "Julia 1.10 - No Artifacts"
     plugins:
       - JuliaCI/julia#v1:
-          version: 1.9
+          version: 1.10
       - JuliaCI/julia-test#v1:
       - JuliaCI/julia-coverage#v1:
           codecov: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,25 +22,25 @@ steps:
     if: build.message !~ /\[skip docs\]/
     timeout_in_minutes: 10
 
-  # - label: "Julia 1.9 - No Artifacts"
-  #   plugins:
-  #     - JuliaCI/julia#v1:
-  #         version: 1.9
-  #     - JuliaCI/julia-test#v1:
-  #     - JuliaCI/julia-coverage#v1:
-  #         codecov: true
-  #   agents:
-  #     queue: "juliagpu"
-  #     rocm: "*"
-  #     rocmgpu: "gfx1031"
-  #   if: build.message !~ /\[skip tests\]/
-  #   command: "julia --project -e 'using Pkg; Pkg.update()'"
-  #   timeout_in_minutes: 180
-  #   env:
-  #     JULIA_NUM_THREADS: 4
-  #     JULIA_AMDGPU_CORE_MUST_LOAD: "1"
-  #     JULIA_AMDGPU_HIP_MUST_LOAD: "1"
-  #     JULIA_AMDGPU_DISABLE_ARTIFACTS: "1"
+  - label: "Julia 1.9 - No Artifacts"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: 1.9
+      - JuliaCI/julia-test#v1:
+      - JuliaCI/julia-coverage#v1:
+          codecov: true
+    agents:
+      queue: "juliagpu"
+      rocm: "*"
+      rocmgpu: "gfx1031"
+    if: build.message !~ /\[skip tests\]/
+    command: "julia --project -e 'using Pkg; Pkg.update()'"
+    timeout_in_minutes: 180
+    env:
+      JULIA_NUM_THREADS: 4
+      JULIA_AMDGPU_CORE_MUST_LOAD: "1"
+      JULIA_AMDGPU_HIP_MUST_LOAD: "1"
+      JULIA_AMDGPU_DISABLE_ARTIFACTS: "1"
 
   - label: "Julia 1.10 - No Artifacts"
     plugins:

--- a/src/device/gcn/hostcall.jl
+++ b/src/device/gcn/hostcall.jl
@@ -131,7 +131,7 @@ function HostCallHolder(
 
                 try
                     if ret_buf[].ptr != C_NULL && ret_len < sizeof(ret)
-                        Mem.free(ret_buf[])
+                        # Mem.free(ret_buf[])
                         ret_len = sizeof(ret)
                         ret_buf[] = Mem.HostBuffer(ret_len, AMDGPU.HIP.hipHostAllocMapped)
                     elseif ret_buf[].ptr == C_NULL
@@ -179,7 +179,7 @@ function HostCallHolder(
                     prev == HOST_ERR_SENTINEL ||
                     prev == DEVICE_ERR_SENTINEL
                 if not_used
-                    Mem.free(ret_buf[]) # `free` checks for C_NULL.
+                    # Mem.free(ret_buf[]) # `free` checks for C_NULL.
                     buf_ptr = reinterpret(Ptr{Cvoid}, hc.buf_ptr)
                     HIP.hipHostFree(buf_ptr) |> HIP.check
                     break

--- a/src/device/gcn/hostcall.jl
+++ b/src/device/gcn/hostcall.jl
@@ -51,16 +51,17 @@ function HostCall(
             buf_len += sizeof(T)
         end
     end
-
     buf_len = max(sizeof(UInt64), buf_len) # make room for return buffer pointer
     buf = Mem.HostBuffer(buf_len, AMDGPU.HIP.hipHostAllocMapped)
+
     buf_ptr = LLVMPtr{UInt8, AS.Global}(Base.unsafe_convert(Ptr{UInt8}, buf))
     host_signal_store!(HSA.Signal(signal_handle), READY_SENTINEL)
     HostCall{RT, AT}(signal_handle, buf_ptr, buf_len)
 end
 
-struct HostCallHolder
+mutable struct HostCallHolder
     hc::HostCall
+    ret_bufs::Vector{Mem.HostBuffer}
     task::Task
     finish::Ref{Bool}
     continuous::Ref{Bool}
@@ -90,12 +91,13 @@ function HostCallHolder(
     signal = signal_ref[]
 
     hc = HostCall(rettype, argtypes, signal.handle; buf_len)
+    ret_bufs = Mem.HostBuffer[]
+
     finish_ref = Ref{Bool}(false)
     continuous_ref = Ref{Bool}(continuous)
-
     tsk = Threads.@spawn begin
-        ret_buf = Ref{Mem.HostBuffer}(Mem.HostBuffer())
         ret_len = 0
+        push!(ret_bufs, Mem.HostBuffer())
 
         try
             while true
@@ -130,18 +132,19 @@ function HostCallHolder(
                     "Host function result not isbits: $(typeof(ret))"))
 
                 try
-                    if ret_buf[].ptr != C_NULL && ret_len < sizeof(ret)
-                        # Mem.free(ret_buf[])
+                    ret_buf = last(ret_bufs)
+                    do_realloc =
+                        (ret_buf.ptr != C_NULL && ret_len < sizeof(ret)) ||
+                        (ret_buf.ptr == C_NULL)
+                    if do_realloc
                         ret_len = sizeof(ret)
-                        ret_buf[] = Mem.HostBuffer(ret_len, AMDGPU.HIP.hipHostAllocMapped)
-                    elseif ret_buf[].ptr == C_NULL
-                        ret_len = sizeof(ret)
-                        ret_buf[] = Mem.HostBuffer(ret_len, AMDGPU.HIP.hipHostAllocMapped)
+                        ret_buf = Mem.HostBuffer(ret_len, AMDGPU.HIP.hipHostAllocMapped)
+                        push!(ret_bufs, ret_buf)
                     end
 
                     ret_ref = Ref{rettype}(ret)
                     GC.@preserve ret_ref begin
-                        ret_ptr = Base.unsafe_convert(Ptr{Cvoid}, ret_buf[])
+                        ret_ptr = Base.unsafe_convert(Ptr{Cvoid}, ret_buf)
                         if sizeof(ret) > 0
                             src_ptr = reinterpret(Ptr{Cvoid},
                                 Base.unsafe_convert(Ptr{rettype}, ret_ref))
@@ -169,28 +172,30 @@ function HostCallHolder(
                 rethrow(err)
             end
         finally
-            # We need to free the memory buffers, but first we need
-            # to ensure that the device has read from these buffers.
-            # Therefore we wait either for READY_SENTINEL or else an error signal.
+            # We need to destroy HSA signal, but first we need to ensure
+            # that the device is no longer using it.
             while !Runtime.RT_EXITING[]
                 prev = host_signal_load(signal)
                 not_used =
                     prev == READY_SENTINEL ||
                     prev == HOST_ERR_SENTINEL ||
                     prev == DEVICE_ERR_SENTINEL
-                if not_used
-                    # Mem.free(ret_buf[]) # `free` checks for C_NULL.
-                    buf_ptr = reinterpret(Ptr{Cvoid}, hc.buf_ptr)
-                    HIP.hipHostFree(buf_ptr) |> HIP.check
-                    break
-                end
+                not_used && break
             end
-            # Destroy HSA signal.
             HSA.signal_destroy(signal) |> Runtime.check
         end
         return
     end
-    HostCallHolder(hc, tsk, finish_ref, continuous_ref)
+
+    holder = HostCallHolder(hc, ret_bufs, tsk, finish_ref, continuous_ref)
+    finalizer(holder) do holder
+        if !Runtime.RT_EXITING[]
+            buf_ptr = reinterpret(Ptr{Cvoid}, holder.hc.buf_ptr)
+            HIP.hipHostFree(buf_ptr) |> HIP.check
+            Mem.free.(holder.ret_bufs)
+        end
+    end
+    return holder
 end
 
 Adapt.adapt(to::Runtime.Adaptor, hc::HostCallHolder) = hc.hc


### PR DESCRIPTION
Closes #537, #521.

`hipHostUnregister` and `hipHostFree` perform device synchronization under-the-hood: [link](https://github.com/ROCm-Developer-Tools/clr/blob/57cb8400583baa3aa2d30b53372894b3683c6474/hipamd/src/hip_memory.cpp#L1258).
So instead we defer freeing host buffers until the `HostCallHolder` finalizer.