### PR TITLE
[rocSPARSE] Add new constructors

### DIFF
--- a/src/sparse/types.jl
+++ b/src/sparse/types.jl
@@ -149,3 +149,13 @@ function Base.convert(::Type{rocsparse_direction}, dir::SparseChar)
         throw(ArgumentError("Unknown direction $dir"))
     end
 end
+
+function Base.convert(::Type{rocsparse_order}, order::SparseChar)
+    if order == 'R'
+        rocsparse_order_row
+    elseif order == 'C'
+        rocsparse_order_column
+    else
+        throw(ArgumentError("Unknown order $order"))
+    end
+end


### PR DESCRIPTION
We need these constructors if we want to preallocate the buffers for sparse matrix-vector and sparse matrix-matrix products with just `A`.