### PR TITLE
Check context is valid before freeing streams, arrays.

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -25,8 +25,10 @@ end
 
 # Passed to `DataRef` to handle freeing.
 function _free_buf(buf, stream_ordered::Bool)
-    s = stream_ordered ? AMDGPU.stream() : AMDGPU.default_stream()
-    Mem.free(buf; stream=s)
+    context!(buf.ctx) do
+        s = stream_ordered ? AMDGPU.stream() : AMDGPU.default_stream()
+        Mem.free(buf; stream=s)
+    end
 end
 
 unsafe_free!(x::ROCArray) = GPUArrays.unsafe_free!(x.buf, true)

--- a/src/fft/fft.jl
+++ b/src/fft/fft.jl
@@ -208,6 +208,7 @@ function unsafe_execute!(
     plan::cROCFFTPlan{T,K,false,N}, X::ROCArray{T,N}, Y::ROCArray{T},
 ) where {T,N,K}
     X = copy(X) # since input array can also be modified
+    # TODO on 1.11 we need to manually cast `pointer(X)` to `Ptr{Cvoid}`.
     rocfft_execute(plan, [pointer(X),], [pointer(Y),], plan.execution_info)
 end
 

--- a/src/runtime/Runtime.jl
+++ b/src/runtime/Runtime.jl
@@ -25,7 +25,7 @@ module Mem
 
     import AMDGPU
     import AMDGPU: HIP, HSA, Runtime
-    import .HIP: HIPDevice
+    import .HIP: HIPDevice, HIPContext
     import .Runtime: ROCDim, ROCDim3
 
     abstract type AbstractAMDBuffer end

--- a/src/tls.jl
+++ b/src/tls.jl
@@ -114,9 +114,9 @@ function context!(ctx::HIPContext)
         HIP.context!(ctx)
         task_local_state!(HIP.device(), ctx)
     else
-        old_ctx = state.ctx
+        old_ctx = state.context
         if old_ctx != ctx
-            HIP.context!(state.ctx)
+            HIP.context!(state.context)
             state.device = HIP.device()
             state.context = ctx
         end
@@ -125,11 +125,15 @@ function context!(ctx::HIPContext)
 end
 
 function context!(f::Function, ctx::HIPContext)
-    old_ctx = context!(ctx)
-    return try
-        f()
-    finally
-        old_ctx ≢ nothing && old_ctx != ctx && context!(old_ctx)
+    if ctx.valid
+        old_ctx = context!(ctx)
+        return try
+            f()
+        finally
+            old_ctx ≢ nothing && old_ctx != ctx && context!(old_ctx)
+        end
+    else
+        @warn "CTX not valid"
     end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -21,31 +21,31 @@ function versioninfo(io::IO=stdout)
     end
     println(_lib_title("rocBLAS", :rocblas; version_fn=rocBLAS.version))
     if functional(:rocblas)
-        println("    @ $(Libdl.dlpath(librocblas))")
+        println("    @ $librocblas")
     end
     println(_lib_title("rocSOLVER", :rocsolver; version_fn=rocSOLVER.version))
     if functional(:rocsolver)
-        println("    @ $(Libdl.dlpath(librocsolver))")
+        println("    @ $librocsolver")
     end
     println("[$(_status(functional(:rocalution)))] rocALUTION")
     if functional(:rocalution)
-        println("    @ $(Libdl.dlpath(librocalution))")
+        println("    @ $librocalution")
     end
     println("[$(_status(functional(:rocsparse)))] rocSPARSE")
     if functional(:rocsparse)
-        println("    @ $(Libdl.dlpath(librocsparse))")
+        println("    @ $librocsparse")
     end
     println(_lib_title("rocRAND", :rocrand; version_fn=rocRAND.version))
     if functional(:rocrand)
-        println("    @ $(Libdl.dlpath(librocrand))")
+        println("    @ $librocrand")
     end
     println(_lib_title("rocFFT", :rocfft; version_fn=rocFFT.version))
     if functional(:rocfft)
-        println("    @ $(Libdl.dlpath(librocfft))")
+        println("    @ $librocfft")
     end
     println(_lib_title("MIOpen", :MIOpen; version_fn=MIOpen.version))
     if functional(:MIOpen)
-        println("    @ $(Libdl.dlpath(libMIOpen_path))")
+        println("    @ $libMIOpen_path")
     end
 
     if functional(:hip)

--- a/test/device/output.jl
+++ b/test/device/output.jl
@@ -32,21 +32,20 @@
         @test msg == "Hello World!Goodbye World!\n"
     end
 
-    #= TODO
-    @testset "Interpolated string" begin
-        inner_str = "to the"
-        function kernel(oc)
-            @rocprintln oc "Hello $inner_str World!"
-            nothing
-        end
+    # TODO
+    # @testset "Interpolated string" begin
+    #     inner_str = "to the"
+    #     function kernel(oc)
+    #         @rocprintln oc "Hello $inner_str World!"
+    #         nothing
+    #     end
 
-        iob = IOBuffer()
-        oc = OutputContext(iob)
-        @roc kernel(oc)
-        sleep(1)
-        @test String(take!(iob)) == "Hello to the World!\n"
-    end
-    =#
+    #     iob = IOBuffer()
+    #     oc = OutputContext(iob)
+    #     @roc kernel(oc)
+    #     sleep(1)
+    #     @test String(take!(iob)) == "Hello to the World!\n"
+    # end
 end
 
 @testset "@rocprintf" begin

--- a/test/device_tests.jl
+++ b/test/device_tests.jl
@@ -11,10 +11,12 @@ include("device/array.jl")
 include("device/vadd.jl")
 include("device/memory.jl")
 include("device/indexing.jl")
-include("device/math.jl")
 include("device/wavefront.jl")
 include("device/synchronization.jl")
 include("device/execution_control.jl")
 include("device/exceptions.jl")
+
+# TODO https://github.com/JuliaGPU/AMDGPU.jl/issues/546
+include("device/math.jl")
 
 end

--- a/test/hip_core_tests.jl
+++ b/test/hip_core_tests.jl
@@ -1,4 +1,4 @@
-@testitem "hip" begin
+@testitem "hip - core" begin
 
 using Test
 using LinearAlgebra
@@ -9,26 +9,6 @@ import AMDGPU: @allowscalar
 
 Random.seed!(1)
 AMDGPU.allowscalar(false)
-
-if AMDGPU.functional(:rocblas)
-    include("rocarray/blas.jl")
-end
-if AMDGPU.functional(:MIOpen)
-    include("dnn/miopen.jl")
-end
-if AMDGPU.functional(:rocsolver)
-    include("rocarray/solver.jl")
-end
-if AMDGPU.functional(:rocsparse)
-    include("rocsparse/rocsparse.jl")
-end
-if AMDGPU.functional(:rocrand)
-    include("rocarray/random.jl")
-end
-# TODO rocFFT tests crash Windows due to access violation
-if Sys.islinux() && AMDGPU.functional(:rocfft)
-    include("rocarray/fft.jl")
-end
 
 @testset "AMDGPU.@elapsed" begin
     xgpu = AMDGPU.rand(Float32, 100)
@@ -52,5 +32,14 @@ if length(AMDGPU.devices()) > 1
     end
 end
 
+if AMDGPU.functional(:rocblas)
+    include("rocarray/blas.jl")
+end
+if AMDGPU.functional(:MIOpen)
+    include("dnn/miopen.jl")
+end
+if AMDGPU.functional(:rocrand)
+    include("rocarray/random.jl")
+end
 
 end

--- a/test/hip_extra_tests.jl
+++ b/test/hip_extra_tests.jl
@@ -1,0 +1,24 @@
+@testitem "hip - extra" begin
+
+using Test
+using LinearAlgebra
+using Random
+
+using AMDGPU: HIP, Runtime, Device, Mem
+import AMDGPU: @allowscalar
+
+Random.seed!(1)
+AMDGPU.allowscalar(false)
+
+if AMDGPU.functional(:rocsolver)
+    include("rocarray/solver.jl")
+end
+if AMDGPU.functional(:rocsparse)
+    include("rocsparse/rocsparse.jl")
+end
+# TODO rocFFT tests crash Windows due to access violation
+if Sys.islinux() && AMDGPU.functional(:rocfft)
+    include("rocarray/fft.jl")
+end
+
+end


### PR DESCRIPTION
- Check HIP context is valid before reeing HIP streams, arrays in finalizer.
- Do not `dlopen` in `versioninfo` since we already have absolute paths.
- Disable device printing tests on 1.11 for now, see #551.
- Split HIP tests into two to allow parallel processing.