### PR TITLE
Update rocSPARSE to ROCm 6

### DIFF
--- a/gen/rocsparse/generator.jl
+++ b/gen/rocsparse/generator.jl
@@ -1,0 +1,17 @@
+using Clang.Generators
+
+include_dir = normpath("/opt/rocm/include")
+rocfft_dir  = joinpath(include_dir, "rocsparse")
+options = load_options("rocsparse/rocsparse-generator.toml")
+
+args = get_default_args()
+push!(args, "-I$include_dir")
+
+headers = [
+    joinpath(rocfft_dir, header)
+    for header in readdir(rocfft_dir)
+    if endswith(header, ".h")
+]
+
+ctx = create_context(headers, args, options)
+build!(ctx)

--- a/gen/rocsparse/rocsparse-generator.toml
+++ b/gen/rocsparse/rocsparse-generator.toml
@@ -1,0 +1,4 @@
+[general]
+library_name = "librocsparse"
+output_file_path = "./librocsparse.jl"
+export_symbol_prefixes = []

--- a/src/hip/HIP.jl
+++ b/src/hip/HIP.jl
@@ -90,8 +90,6 @@ function memcpy(dst, src, sz, kind, stream::HIPStream)
 end
 
 function __init__()
-    global HIP_VERSION = runtime_version()
-
     global old_nonblock_sync = if AMDGPU.functional(:hip)
         runtime_version() < v"5.4"
     else

--- a/src/hip/HIP.jl
+++ b/src/hip/HIP.jl
@@ -90,6 +90,8 @@ function memcpy(dst, src, sz, kind, stream::HIPStream)
 end
 
 function __init__()
+    global HIP_VERSION = runtime_version()
+
     global old_nonblock_sync = if AMDGPU.functional(:hip)
         runtime_version() < v"5.4"
     else

--- a/src/sparse/generic.jl
+++ b/src/sparse/generic.jl
@@ -31,7 +31,7 @@ function mv!(
 
     function bufferSize()
         out = Ref{Csize_t}()
-        if HIP.HIP_VERSION ≥ v"6-"
+        if HIP.runtime_version() ≥ v"6-"
             rocsparse_spmv(
                 handle(), transa, Ref{T}(alpha), descA, descX,
                 Ref{T}(beta), descY, T, algo,
@@ -47,7 +47,7 @@ function mv!(
     size_ref = Ref{Csize_t}()
     with_workspace(bufferSize) do buffer
         size_ref[] = sizeof(buffer)
-        if HIP.HIP_VERSION ≥ v"6-"
+        if HIP.runtime_version() ≥ v"6-"
             rocsparse_spmv(
                 handle(), transa, Ref{T}(alpha), descA, descX,
                 Ref{T}(beta), descY, T, algo,

--- a/src/sparse/generic.jl
+++ b/src/sparse/generic.jl
@@ -31,18 +31,32 @@ function mv!(
 
     function bufferSize()
         out = Ref{Csize_t}()
-        rocsparse_spmv(
-            handle(), transa, Ref{T}(alpha), descA, descX,
-            Ref{T}(beta), descY, T, algo, out, C_NULL)
+        if HIP.HIP_VERSION ≥ v"6-"
+            rocsparse_spmv(
+                handle(), transa, Ref{T}(alpha), descA, descX,
+                Ref{T}(beta), descY, T, algo,
+                rocsparse_spmv_stage_buffer_size, out, C_NULL)
+        else
+            rocsparse_spmv(
+                handle(), transa, Ref{T}(alpha), descA, descX,
+                Ref{T}(beta), descY, T, algo, out, C_NULL)
+        end
         return out[]
     end
 
     size_ref = Ref{Csize_t}()
     with_workspace(bufferSize) do buffer
         size_ref[] = sizeof(buffer)
-        rocsparse_spmv(
-            handle(), transa, Ref{T}(alpha), descA, descX,
-            Ref{T}(beta), descY, T, algo, size_ref, buffer)
+        if HIP.HIP_VERSION ≥ v"6-"
+            rocsparse_spmv(
+                handle(), transa, Ref{T}(alpha), descA, descX,
+                Ref{T}(beta), descY, T, algo,
+                rocsparse_spmv_stage_compute, size_ref, buffer)
+        else
+            rocsparse_spmv(
+                handle(), transa, Ref{T}(alpha), descA, descX,
+                Ref{T}(beta), descY, T, algo, size_ref, buffer)
+        end
     end
     Y
 end

--- a/src/sparse/librocsparse.jl
+++ b/src/sparse/librocsparse.jl
@@ -5121,14 +5121,18 @@ function rocsparse_spvv(handle, trans, x, y, result, compute_type, buffer_size, 
                  temp_buffer)
 end
 
-function rocsparse_spmv(handle, trans, alpha, mat, x, beta, y, compute_type, alg,
-                        buffer_size, temp_buffer)
+function rocsparse_spmv(
+    handle, trans, alpha, mat, x, beta, y, compute_type, alg,
+    stage, buffer_size, temp_buffer,
+)
     AMDGPU.prepare_state()
     @check ccall((:rocsparse_spmv, librocsparse), rocsparse_status,
-                 (rocsparse_handle, rocsparse_operation, Ptr{Cvoid}, rocsparse_spmat_descr,
-                  rocsparse_dnvec_descr, Ptr{Cvoid}, rocsparse_dnvec_descr,
-                  rocsparse_datatype, rocsparse_spmv_alg, Ptr{Csize_t}, Ptr{Cvoid}), handle,
-                 trans, alpha, mat, x, beta, y, compute_type, alg, buffer_size, temp_buffer)
+        (rocsparse_handle, rocsparse_operation, Ptr{Cvoid},
+        rocsparse_spmat_descr, rocsparse_dnvec_descr, Ptr{Cvoid},
+        rocsparse_dnvec_descr, rocsparse_datatype, rocsparse_spmv_alg,
+        rocsparse_spmv_stage, Ptr{Csize_t}, Ptr{Cvoid}),
+        handle, trans, alpha, mat, x, beta, y, compute_type, alg,
+        stage, buffer_size, temp_buffer)
 end
 
 function rocsparse_spsv(handle, trans, alpha, mat, x, y, compute_type, alg, stage,

--- a/src/sparse/librocsparse_common.jl
+++ b/src/sparse/librocsparse_common.jl
@@ -220,6 +220,14 @@ end
 
 const rocsparse_spmv_alg = rocsparse_spmv_alg_
 
+@cenum rocsparse_spmv_stage_::UInt32 begin
+    rocsparse_spmv_stage_buffer_size = 1
+    rocsparse_spmv_stage_preprocess = 2
+    rocsparse_spmv_stage_compute = 3
+end
+
+const rocsparse_spmv_stage = rocsparse_spmv_stage_
+
 @cenum rocsparse_spsv_alg_::UInt32 begin
     rocsparse_spsv_alg_default = 0
 end

--- a/src/sparse/librocsparse_deprecated.jl
+++ b/src/sparse/librocsparse_deprecated.jl
@@ -1,0 +1,15 @@
+# TODO remove once we support only ROCm 6.0+.
+
+function rocsparse_spmv(
+    handle, trans, alpha, mat, x, beta, y, compute_type, alg,
+    buffer_size, temp_buffer,
+)
+    AMDGPU.prepare_state()
+    @check ccall((:rocsparse_spmv, librocsparse), rocsparse_status,
+        (rocsparse_handle, rocsparse_operation, Ptr{Cvoid},
+        rocsparse_spmat_descr, rocsparse_dnvec_descr, Ptr{Cvoid},
+        rocsparse_dnvec_descr, rocsparse_datatype, rocsparse_spmv_alg,
+        Ptr{Csize_t}, Ptr{Cvoid}),
+        handle, trans, alpha, mat, x, beta, y, compute_type, alg,
+        buffer_size, temp_buffer)
+end

--- a/src/sparse/rocSPARSE.jl
+++ b/src/sparse/rocSPARSE.jl
@@ -22,6 +22,7 @@ const SparseChar = Char
 include("librocsparse_common.jl")
 include("error.jl")
 include("librocsparse.jl")
+include("librocsparse_deprecated.jl")
 
 function create_handle()
     AMDGPU.functional(:rocsparse) || error("rocSPARSE is not available")

--- a/test/hip_extra_tests.jl
+++ b/test/hip_extra_tests.jl
@@ -14,14 +14,8 @@ if AMDGPU.functional(:rocsolver)
     include("rocarray/solver.jl")
 end
 
-# TODO rocSPARSE needs an update to work with ROCm 6.0+:
-# https://github.com/JuliaGPU/AMDGPU.jl/issues/571
-if HIP.runtime_version() ≥ v"6-"
-    @test_skip "rocSPARSE"
-else
-    if AMDGPU.functional(:rocsparse)
-        include("rocsparse/rocsparse.jl")
-    end
+if AMDGPU.functional(:rocsparse)
+    include("rocsparse/rocsparse.jl")
 end
 
 # TODO rocFFT needs an update to work with ROCm 6.0+.


### PR DESCRIPTION
Closes #571.
Seems that only generic `spmv` required an update.

- Use new stage parameter in `spmv` method.
- Add rocSPARSE wrapper generator.