### PR TITLE
Add a generator for ROCsolver

### DIFF
--- a/gen/rocsolver/generator.jl
+++ b/gen/rocsolver/generator.jl
@@ -1,0 +1,18 @@
+using Clang.Generators
+
+include_dir = normpath("/opt/rocm/include")
+
+rocsolver_dir  = joinpath(include_dir, "rocsolver")
+options = load_options("rocsolver/rocsolver-generator.toml")
+
+args = get_default_args()
+push!(args, "-I$include_dir")
+
+headers = [
+    joinpath(rocsolver_dir, header)
+    for header in readdir(rocsolver_dir)
+    if endswith(header, ".h")
+]
+
+ctx = create_context(headers, args, options)
+build!(ctx)

--- a/gen/rocsolver/rocsolver-generator.toml
+++ b/gen/rocsolver/rocsolver-generator.toml
@@ -1,0 +1,4 @@
+[general]
+library_name = "librocsolver"
+output_file_path = "./librocsolver.jl"
+export_symbol_prefixes = []


### PR DESCRIPTION
I can't test it with ROCm 6.0 but it could be possible to generate `librocsolver.jl` with the updated headers. 