### PR TITLE
Implement device side rng in RDNA3 plus fix it on julia master

### DIFF
--- a/src/device/gcn/hostcall_signal_helpers.jl
+++ b/src/device/gcn/hostcall_signal_helpers.jl
@@ -119,3 +119,7 @@ end
 @inline function memrealtime()
     ccall("llvm.amdgcn.s.memrealtime", llvmcall, UInt64, ())
 end
+
+@inline function readcyclecounter()
+    ccall("llvm.readcyclecounter", llvmcall, UInt64, ())
+end

--- a/test/device_tests.jl
+++ b/test/device_tests.jl
@@ -16,11 +16,9 @@ include("device/synchronization.jl")
 include("device/execution_control.jl")
 include("device/exceptions.jl")
 
-const IS_NAVI3 = AMDGPU.device().gcn_arch in ("gfx1100", "gfx1101", "gfx1102", "gfx1103")
 
-# TODO NAVI 3 does not support `memtime` and `memrealtime` llvm intrinsic.
 # TODO Julia 1.9 fails with out-of-bounds error for some reason...
-if VERSION ≥ v"1.10-" && !IS_NAVI3
+if VERSION ≥ v"1.10-"
     include("device/random.jl")
 end
 


### PR DESCRIPTION
This is based on what CUDA.jl did in https://github.com/JuliaGPU/CUDA.jl/pull/2199 + using `readcyclecounter` which is equivalent to the `clock` used in CUDA seems to make the rng stuff happier in rdna3