### PR TITLE
Use adjoint instead of tranpose when returning V in SVD

### DIFF
--- a/src/solver/highlevel.jl
+++ b/src/solver/highlevel.jl
@@ -494,7 +494,7 @@ for (fname, matrix_elty, vector_elty) in (
             info = AMDGPU.@allowscalar dev_info[1]
             AMDGPU.unsafe_free!(dev_info)
 
-            U, S, transpose(V), residual, n_sweeps, info
+            U, S, V', residual, n_sweeps, info
         end
     end
 end

--- a/test/rocarray/solver.jl
+++ b/test/rocarray/solver.jl
@@ -218,7 +218,7 @@ end
         max_sweeps::Int32 = 100
 
         U, S, V, residual, n_sweeps, info = AMDGPU.rocSOLVER.gesvdj!(dA, abstol, max_sweeps)
-        @test U * Diagonal(S) * Transpose(V) ≈ dA
+        @test U * Diagonal(S) * V' ≈ dA
     end
 end
 


### PR DESCRIPTION
I mistakenly returned the transpose of `V` in the SVD wrappers instead of the adjoint, which this PR fixes.

The unit tests I wrote didn't catch this because they used the transpose on `V` as well.