### PR TITLE
Allow disabling eager GC

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -136,6 +136,9 @@ Template of `LocalPreferences.toml` with all options:
 
 ```toml
 [AMDGPU]
+# If `true` (default), eagerly run GC to keep the pool from growing too big.
+# GC is triggered during new allocatoins or synchronization points.
+eager_gc = false
 # If `true` then use ROCm libraries provided by artifacts.
 # However, not all ROCm libraries are available as artifacts.
 use_artifacts = false

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -110,7 +110,16 @@ function account!(stats::MemoryStats, bytes::Integer)
     Base.@atomic stats.live += bytes
 end
 
+const EAGER_GC::Ref{Bool} = Ref{Bool}(@load_preference("eager_gc", true))
+
+function eager_gc!(flag::Bool)
+    global EAGER_GC[] = flag
+    @set_preferences!("eager_gc" => flag)
+end
+
 function maybe_collect(; blocking::Bool = false)
+    EAGER_GC[] || return
+
     stats = memory_stats()
     current_time = time()
 


### PR DESCRIPTION
Either call `AMDGPU.eager_gc!(false)` or set in `LocalPreferences.toml` file following:
```toml
[AMDGPU]
eager_gc = false
```

@luraess 