### PR TITLE
Properly allocate workspace for conv algo search

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -135,11 +135,13 @@ function Base.copyto!(
     amount == 0 && return dest
     @boundscheck checkbounds(dest, d_offset + amount - 1)
     @boundscheck checkbounds(source, s_offset + amount - 1)
+    stm = stream()
     Mem.download!(
         pointer(dest, d_offset),
         Mem.view(convert(Mem.AbstractAMDBuffer, source.buf[]),
             (source.offset + s_offset - 1) * sizeof(T)),
-        amount * sizeof(T); stream=stream(), async)
+        amount * sizeof(T); stream=stm)
+    async || synchronize(stm)
     dest
 end
 


### PR DESCRIPTION
Fixes algorithm selection to select the best candidate.

```julia
c = ConvTranspose((16,), 128 => 64; stride=8, pad=4) |> gpu
x = gpu(rand(Float32, 256, 128, 32))
c(x)
```

- Before (using naive algorithm): `85ms 927us 783ns`
- Now (using GEMM): `635us 82ns`

**Note:** might require deleting your `~/.cache/miopen` to regenerate algorithm database, since it is persistent.