### PR TITLE
Fix feature concatenation

### DIFF
--- a/src/compiler/codegen.jl
+++ b/src/compiler/codegen.jl
@@ -115,6 +115,9 @@ function compiler_config(dev::HIP.HIPDevice;
     unsafe_fp_atomics::Bool = true,
 )
     dev_isa, features = parse_llvm_features(HIP.gcn_arch(dev))
+    if !isempty(features)
+        features = "$features,"
+    end
 
     wavefrontsize64 = HIP.wavefrontsize(dev) == 64
     features = if wavefrontsize64


### PR DESCRIPTION
Add missing comma when concatenating compile target features resulting in:
```
'+sramecc-wavefrontsize32' is not a recognized feature for this target (ignoring feature)
```

CC @pedrovalerolara