### PR TITLE
copy in constructor

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -118,7 +118,7 @@ ROCArray{T}(xs::AbstractArray{S,N}) where {T,N,S} = ROCArray{T,N}(xs)
 (::Type{ROCArray{T,N} where T})(x::AbstractArray{S,N}) where {S,N} = ROCArray{S,N}(x)
 
 # idempotency
-ROCArray{T,N}(xs::ROCArray{T,N}) where {T,N} = xs
+ROCArray{T,N}(xs::ROCArray{T,N}) where {T,N} = copy(xs)
 
 ## conversions
 

--- a/test/rocarray/base.jl
+++ b/test/rocarray/base.jl
@@ -10,6 +10,15 @@
     @test x.buf[].mem isa B
 end
 
+@testset "Constructor" begin
+    x = ROCArray([1.0])
+    y = ROCArray(x)
+    # Constructor doesn't just return its argument.
+    @test y !== x
+    # But is still equal.
+    @test y == x
+end
+
 @testset "ones/zeros" begin
     x = @inferred AMDGPU.ones(4, 3)
     @test x isa ROCArray


### PR DESCRIPTION
Currently the `ROCArray` constructor returns its argument unlike `Array`'s constructor. This change uses `copy` instead.

```jl
julia> let x = rand(5)
           y = Array(x)
           z = Array(y)
           y === z
       end
false

julia> let x = rand(5)
           y = ROCArray(x)
           z = ROCArray(y)
           y === z
       end
true
```