### PR TITLE
Prevent crash when libraries are unavailable during __init__

### DIFF
--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -205,7 +205,7 @@ function __init__()
             @warn """
             HSA runtime is unavailable, compilation and runtime functionality will be disabled.
             """
-            if parse(Bool, ENV["JULIA_AMDGPU_CORE_MUST_LOAD"])
+            if parse(Bool, get(ENV, "JULIA_AMDGPU_CORE_MUST_LOAD", "0"))
                 print_build_diagnostics()
                 error("Failed to load HSA runtime, but HSA must load, bailing out")
             end
@@ -217,7 +217,7 @@ function __init__()
         @warn """
         LLD is unavailable, compilation functionality will be disabled.
         """
-        if parse(Bool, ENV["JULIA_AMDGPU_CORE_MUST_LOAD"])
+        if parse(Bool, get(ENV, "JULIA_AMDGPU_CORE_MUST_LOAD", "0"))
             print_build_diagnostics()
             error("Failed to find ld.lld, but ld.lld must exist, bailing out")
         end
@@ -228,7 +228,7 @@ function __init__()
         @warn """
         Device libraries are unavailable, device intrinsics will be disabled.
         """
-        if parse(Bool, ENV["JULIA_AMDGPU_CORE_MUST_LOAD"])
+        if parse(Bool, get(ENV, "JULIA_AMDGPU_CORE_MUST_LOAD", "0"))
             print_build_diagnostics()
             error("Failed to find Device Libs, but Device Libs must exist, bailing out")
         end
@@ -241,7 +241,7 @@ function __init__()
         @warn """
         HIP library is unavailable, HIP integration will be disabled.
         """
-        if parse(Bool, ENV["JULIA_AMDGPU_HIP_MUST_LOAD"])
+        if parse(Bool, get(ENV, "JULIA_AMDGPU_HIP_MUST_LOAD", "0"))
             print_build_diagnostics()
             error("Failed to load HIP runtime, but HIP must load, bailing out")
         end


### PR DESCRIPTION
Changes the `ENV[string]` lookups to a `get()` with a default of "0". This prevents the `ERROR: InitError: KeyError: key "JULIA_AMDGPU_CORE_MUST_LOAD" not found` when running outside of the CI.

For example, previously I was getting 
```
julia> using AMDGPU
┌ Warning: HSA runtime is unavailable, compilation and runtime functionality will be disabled.
└ @ AMDGPU ~/.julia/packages/AMDGPU/a1v0k/src/AMDGPU.jl:205
ERROR: InitError: KeyError: key "JULIA_AMDGPU_CORE_MUST_LOAD" not found
Stacktrace: ...
```

With this PR, I'm getting
```
julia> using AMDGPU
┌ Warning: HSA runtime is unavailable, compilation and runtime functionality will be disabled.
└ @ AMDGPU ~/.julia/packages/AMDGPU/zQy5G/src/AMDGPU.jl:205
...

julia> AMDGPU.functional()
false
```
as I would have expected for this case.