### PR TITLE
Fix import on non-functional machines

### DIFF
--- a/src/blas/librocblas.jl
+++ b/src/blas/librocblas.jl
@@ -27,7 +27,7 @@ const rocblas_status = rocblas_status_
 
 function rocblas_set_start_stop_events(handle, startEvent, stopEvent)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_set_start_stop_events(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_set_start_stop_events(handle::rocblas_handle,
                                                     startEvent::hipEvent_t,
                                                     stopEvent::hipEvent_t)::rocblas_status
 end
@@ -227,84 +227,84 @@ const rocblas_math_mode = rocblas_math_mode_
 
 function rocblas_create_handle(handle)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_create_handle(handle::Ptr{rocblas_handle})::rocblas_status
+    @check @ccall librocblas.rocblas_create_handle(handle::Ptr{rocblas_handle})::rocblas_status
 end
 
 function rocblas_destroy_handle(handle)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_destroy_handle(handle::rocblas_handle)::rocblas_status
+    @check @ccall librocblas.rocblas_destroy_handle(handle::rocblas_handle)::rocblas_status
 end
 
 function rocblas_set_stream(handle, stream)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_set_stream(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_set_stream(handle::rocblas_handle,
                                          stream::hipStream_t)::rocblas_status
 end
 
 function rocblas_get_stream(handle, stream)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_get_stream(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_get_stream(handle::rocblas_handle,
                                          stream::Ptr{hipStream_t})::rocblas_status
 end
 
 function rocblas_set_pointer_mode(handle, pointer_mode)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_set_pointer_mode(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_set_pointer_mode(handle::rocblas_handle,
                                                pointer_mode::rocblas_pointer_mode)::rocblas_status
 end
 
 function rocblas_get_pointer_mode(handle, pointer_mode)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_get_pointer_mode(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_get_pointer_mode(handle::rocblas_handle,
                                                pointer_mode::Ptr{rocblas_pointer_mode})::rocblas_status
 end
 
 function rocblas_set_atomics_mode(handle, atomics_mode)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_set_atomics_mode(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_set_atomics_mode(handle::rocblas_handle,
                                                atomics_mode::rocblas_atomics_mode)::rocblas_status
 end
 
 function rocblas_get_atomics_mode(handle, atomics_mode)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_get_atomics_mode(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_get_atomics_mode(handle::rocblas_handle,
                                                atomics_mode::Ptr{rocblas_atomics_mode})::rocblas_status
 end
 
 function rocblas_set_math_mode(handle, math_mode)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_set_math_mode(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_set_math_mode(handle::rocblas_handle,
                                             math_mode::rocblas_math_mode)::rocblas_status
 end
 
 function rocblas_get_math_mode(handle, math_mode)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_get_math_mode(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_get_math_mode(handle::rocblas_handle,
                                             math_mode::Ptr{rocblas_math_mode})::rocblas_status
 end
 
 function rocblas_pointer_to_mode(ptr)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_pointer_to_mode(ptr::Ptr{Cvoid})::rocblas_pointer_mode
+    @check @ccall librocblas.rocblas_pointer_to_mode(ptr::Ptr{Cvoid})::rocblas_pointer_mode
 end
 
 function rocblas_set_vector(n, elem_size, x, incx, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_set_vector(n::rocblas_int, elem_size::rocblas_int,
+    @check @ccall librocblas.rocblas_set_vector(n::rocblas_int, elem_size::rocblas_int,
                                          x::Ptr{Cvoid}, incx::rocblas_int, y::Ptr{Cvoid},
                                          incy::rocblas_int)::rocblas_status
 end
 
 function rocblas_get_vector(n, elem_size, x, incx, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_get_vector(n::rocblas_int, elem_size::rocblas_int,
+    @check @ccall librocblas.rocblas_get_vector(n::rocblas_int, elem_size::rocblas_int,
                                          x::Ptr{Cvoid}, incx::rocblas_int, y::Ptr{Cvoid},
                                          incy::rocblas_int)::rocblas_status
 end
 
 function rocblas_set_matrix(rows, cols, elem_size, a, lda, b, ldb)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_set_matrix(rows::rocblas_int, cols::rocblas_int,
+    @check @ccall librocblas.rocblas_set_matrix(rows::rocblas_int, cols::rocblas_int,
                                          elem_size::rocblas_int, a::Ptr{Cvoid},
                                          lda::rocblas_int, b::Ptr{Cvoid},
                                          ldb::rocblas_int)::rocblas_status
@@ -312,7 +312,7 @@ end
 
 function rocblas_get_matrix(rows, cols, elem_size, a, lda, b, ldb)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_get_matrix(rows::rocblas_int, cols::rocblas_int,
+    @check @ccall librocblas.rocblas_get_matrix(rows::rocblas_int, cols::rocblas_int,
                                          elem_size::rocblas_int, a::Ptr{Cvoid},
                                          lda::rocblas_int, b::Ptr{Cvoid},
                                          ldb::rocblas_int)::rocblas_status
@@ -320,7 +320,7 @@ end
 
 function rocblas_set_vector_async(n, elem_size, x, incx, y, incy, stream)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_set_vector_async(n::rocblas_int, elem_size::rocblas_int,
+    @check @ccall librocblas.rocblas_set_vector_async(n::rocblas_int, elem_size::rocblas_int,
                                                x::Ptr{Cvoid}, incx::rocblas_int,
                                                y::Ptr{Cvoid}, incy::rocblas_int,
                                                stream::hipStream_t)::rocblas_status
@@ -328,7 +328,7 @@ end
 
 function rocblas_get_vector_async(n, elem_size, x, incx, y, incy, stream)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_get_vector_async(n::rocblas_int, elem_size::rocblas_int,
+    @check @ccall librocblas.rocblas_get_vector_async(n::rocblas_int, elem_size::rocblas_int,
                                                x::Ptr{Cvoid}, incx::rocblas_int,
                                                y::Ptr{Cvoid}, incy::rocblas_int,
                                                stream::hipStream_t)::rocblas_status
@@ -336,7 +336,7 @@ end
 
 function rocblas_set_matrix_async(rows, cols, elem_size, a, lda, b, ldb, stream)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_set_matrix_async(rows::rocblas_int, cols::rocblas_int,
+    @check @ccall librocblas.rocblas_set_matrix_async(rows::rocblas_int, cols::rocblas_int,
                                                elem_size::rocblas_int, a::Ptr{Cvoid},
                                                lda::rocblas_int, b::Ptr{Cvoid},
                                                ldb::rocblas_int,
@@ -345,7 +345,7 @@ end
 
 function rocblas_get_matrix_async(rows, cols, elem_size, a, lda, b, ldb, stream)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_get_matrix_async(rows::rocblas_int, cols::rocblas_int,
+    @check @ccall librocblas.rocblas_get_matrix_async(rows::rocblas_int, cols::rocblas_int,
                                                elem_size::rocblas_int, a::Ptr{Cvoid},
                                                lda::rocblas_int, b::Ptr{Cvoid},
                                                ldb::rocblas_int,
@@ -354,39 +354,39 @@ end
 
 function rocblas_set_solution_fitness_query(handle, fitness)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_set_solution_fitness_query(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_set_solution_fitness_query(handle::rocblas_handle,
                                                          fitness::Ptr{Cdouble})::rocblas_status
 end
 
 function rocblas_set_performance_metric(handle, metric)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_set_performance_metric(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_set_performance_metric(handle::rocblas_handle,
                                                      metric::rocblas_performance_metric)::rocblas_status
 end
 
 function rocblas_get_performance_metric(handle, metric)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_get_performance_metric(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_get_performance_metric(handle::rocblas_handle,
                                                      metric::Ptr{rocblas_performance_metric})::rocblas_status
 end
 
 function rocblas_sscal(handle, n, alpha, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sscal(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_sscal(handle::rocblas_handle, n::rocblas_int,
                                     alpha::Ptr{Cfloat}, x::Ptr{Cfloat},
                                     incx::rocblas_int)::rocblas_status
 end
 
 function rocblas_dscal(handle, n, alpha, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dscal(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_dscal(handle::rocblas_handle, n::rocblas_int,
                                     alpha::Ptr{Cdouble}, x::Ptr{Cdouble},
                                     incx::rocblas_int)::rocblas_status
 end
 
 function rocblas_cscal(handle, n, alpha, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cscal(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_cscal(handle::rocblas_handle, n::rocblas_int,
                                     alpha::Ptr{rocblas_float_complex},
                                     x::Ptr{rocblas_float_complex},
                                     incx::rocblas_int)::rocblas_status
@@ -394,7 +394,7 @@ end
 
 function rocblas_zscal(handle, n, alpha, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zscal(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zscal(handle::rocblas_handle, n::rocblas_int,
                                     alpha::Ptr{rocblas_double_complex},
                                     x::Ptr{rocblas_double_complex},
                                     incx::rocblas_int)::rocblas_status
@@ -402,21 +402,21 @@ end
 
 function rocblas_csscal(handle, n, alpha, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csscal(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_csscal(handle::rocblas_handle, n::rocblas_int,
                                      alpha::Ptr{Cfloat}, x::Ptr{rocblas_float_complex},
                                      incx::rocblas_int)::rocblas_status
 end
 
 function rocblas_zdscal(handle, n, alpha, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zdscal(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zdscal(handle::rocblas_handle, n::rocblas_int,
                                      alpha::Ptr{Cdouble}, x::Ptr{rocblas_double_complex},
                                      incx::rocblas_int)::rocblas_status
 end
 
 function rocblas_sscal_batched(handle, n, alpha, x, incx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sscal_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_sscal_batched(handle::rocblas_handle, n::rocblas_int,
                                             alpha::Ptr{Cfloat}, x::Ptr{Ptr{Cfloat}},
                                             incx::rocblas_int,
                                             batch_count::rocblas_int)::rocblas_status
@@ -424,7 +424,7 @@ end
 
 function rocblas_dscal_batched(handle, n, alpha, x, incx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dscal_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_dscal_batched(handle::rocblas_handle, n::rocblas_int,
                                             alpha::Ptr{Cdouble}, x::Ptr{Ptr{Cdouble}},
                                             incx::rocblas_int,
                                             batch_count::rocblas_int)::rocblas_status
@@ -432,7 +432,7 @@ end
 
 function rocblas_cscal_batched(handle, n, alpha, x, incx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cscal_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_cscal_batched(handle::rocblas_handle, n::rocblas_int,
                                             alpha::Ptr{rocblas_float_complex},
                                             x::Ptr{Ptr{rocblas_float_complex}},
                                             incx::rocblas_int,
@@ -441,7 +441,7 @@ end
 
 function rocblas_zscal_batched(handle, n, alpha, x, incx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zscal_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zscal_batched(handle::rocblas_handle, n::rocblas_int,
                                             alpha::Ptr{rocblas_double_complex},
                                             x::Ptr{Ptr{rocblas_double_complex}},
                                             incx::rocblas_int,
@@ -450,7 +450,7 @@ end
 
 function rocblas_csscal_batched(handle, n, alpha, x, incx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csscal_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_csscal_batched(handle::rocblas_handle, n::rocblas_int,
                                              alpha::Ptr{Cfloat},
                                              x::Ptr{Ptr{rocblas_float_complex}},
                                              incx::rocblas_int,
@@ -459,7 +459,7 @@ end
 
 function rocblas_zdscal_batched(handle, n, alpha, x, incx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zdscal_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zdscal_batched(handle::rocblas_handle, n::rocblas_int,
                                              alpha::Ptr{Cdouble},
                                              x::Ptr{Ptr{rocblas_double_complex}},
                                              incx::rocblas_int,
@@ -468,7 +468,7 @@ end
 
 function rocblas_sscal_strided_batched(handle, n, alpha, x, incx, stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sscal_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_sscal_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     alpha::Ptr{Cfloat}, x::Ptr{Cfloat},
                                                     incx::rocblas_int,
                                                     stride_x::rocblas_stride,
@@ -477,7 +477,7 @@ end
 
 function rocblas_dscal_strided_batched(handle, n, alpha, x, incx, stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dscal_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_dscal_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     alpha::Ptr{Cdouble}, x::Ptr{Cdouble},
                                                     incx::rocblas_int,
                                                     stride_x::rocblas_stride,
@@ -486,7 +486,7 @@ end
 
 function rocblas_cscal_strided_batched(handle, n, alpha, x, incx, stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cscal_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_cscal_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     alpha::Ptr{rocblas_float_complex},
                                                     x::Ptr{rocblas_float_complex},
                                                     incx::rocblas_int,
@@ -496,7 +496,7 @@ end
 
 function rocblas_zscal_strided_batched(handle, n, alpha, x, incx, stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zscal_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zscal_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     alpha::Ptr{rocblas_double_complex},
                                                     x::Ptr{rocblas_double_complex},
                                                     incx::rocblas_int,
@@ -506,7 +506,7 @@ end
 
 function rocblas_csscal_strided_batched(handle, n, alpha, x, incx, stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csscal_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_csscal_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                      alpha::Ptr{Cfloat},
                                                      x::Ptr{rocblas_float_complex},
                                                      incx::rocblas_int,
@@ -516,7 +516,7 @@ end
 
 function rocblas_zdscal_strided_batched(handle, n, alpha, x, incx, stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zdscal_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zdscal_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                      alpha::Ptr{Cdouble},
                                                      x::Ptr{rocblas_double_complex},
                                                      incx::rocblas_int,
@@ -526,21 +526,21 @@ end
 
 function rocblas_scopy(handle, n, x, incx, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_scopy(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cfloat},
+    @check @ccall librocblas.rocblas_scopy(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cfloat},
                                     incx::rocblas_int, y::Ptr{Cfloat},
                                     incy::rocblas_int)::rocblas_status
 end
 
 function rocblas_dcopy(handle, n, x, incx, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dcopy(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cdouble},
+    @check @ccall librocblas.rocblas_dcopy(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cdouble},
                                     incx::rocblas_int, y::Ptr{Cdouble},
                                     incy::rocblas_int)::rocblas_status
 end
 
 function rocblas_ccopy(handle, n, x, incx, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ccopy(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_ccopy(handle::rocblas_handle, n::rocblas_int,
                                     x::Ptr{rocblas_float_complex}, incx::rocblas_int,
                                     y::Ptr{rocblas_float_complex},
                                     incy::rocblas_int)::rocblas_status
@@ -548,7 +548,7 @@ end
 
 function rocblas_zcopy(handle, n, x, incx, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zcopy(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zcopy(handle::rocblas_handle, n::rocblas_int,
                                     x::Ptr{rocblas_double_complex}, incx::rocblas_int,
                                     y::Ptr{rocblas_double_complex},
                                     incy::rocblas_int)::rocblas_status
@@ -556,7 +556,7 @@ end
 
 function rocblas_scopy_batched(handle, n, x, incx, y, incy, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_scopy_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_scopy_batched(handle::rocblas_handle, n::rocblas_int,
                                             x::Ptr{Ptr{Cfloat}}, incx::rocblas_int,
                                             y::Ptr{Ptr{Cfloat}}, incy::rocblas_int,
                                             batch_count::rocblas_int)::rocblas_status
@@ -564,7 +564,7 @@ end
 
 function rocblas_dcopy_batched(handle, n, x, incx, y, incy, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dcopy_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_dcopy_batched(handle::rocblas_handle, n::rocblas_int,
                                             x::Ptr{Ptr{Cdouble}}, incx::rocblas_int,
                                             y::Ptr{Ptr{Cdouble}}, incy::rocblas_int,
                                             batch_count::rocblas_int)::rocblas_status
@@ -572,7 +572,7 @@ end
 
 function rocblas_ccopy_batched(handle, n, x, incx, y, incy, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ccopy_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_ccopy_batched(handle::rocblas_handle, n::rocblas_int,
                                             x::Ptr{Ptr{rocblas_float_complex}},
                                             incx::rocblas_int,
                                             y::Ptr{Ptr{rocblas_float_complex}},
@@ -582,7 +582,7 @@ end
 
 function rocblas_zcopy_batched(handle, n, x, incx, y, incy, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zcopy_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zcopy_batched(handle::rocblas_handle, n::rocblas_int,
                                             x::Ptr{Ptr{rocblas_double_complex}},
                                             incx::rocblas_int,
                                             y::Ptr{Ptr{rocblas_double_complex}},
@@ -593,7 +593,7 @@ end
 function rocblas_scopy_strided_batched(handle, n, x, incx, stridex, y, incy, stridey,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_scopy_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_scopy_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     x::Ptr{Cfloat}, incx::rocblas_int,
                                                     stridex::rocblas_stride, y::Ptr{Cfloat},
                                                     incy::rocblas_int,
@@ -604,7 +604,7 @@ end
 function rocblas_dcopy_strided_batched(handle, n, x, incx, stridex, y, incy, stridey,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dcopy_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_dcopy_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     x::Ptr{Cdouble}, incx::rocblas_int,
                                                     stridex::rocblas_stride,
                                                     y::Ptr{Cdouble}, incy::rocblas_int,
@@ -615,7 +615,7 @@ end
 function rocblas_ccopy_strided_batched(handle, n, x, incx, stridex, y, incy, stridey,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ccopy_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_ccopy_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     x::Ptr{rocblas_float_complex},
                                                     incx::rocblas_int,
                                                     stridex::rocblas_stride,
@@ -628,7 +628,7 @@ end
 function rocblas_zcopy_strided_batched(handle, n, x, incx, stridex, y, incy, stridey,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zcopy_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zcopy_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     x::Ptr{rocblas_double_complex},
                                                     incx::rocblas_int,
                                                     stridex::rocblas_stride,
@@ -640,21 +640,21 @@ end
 
 function rocblas_sdot(handle, n, x, incx, y, incy, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sdot(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cfloat},
+    @check @ccall librocblas.rocblas_sdot(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cfloat},
                                    incx::rocblas_int, y::Ptr{Cfloat}, incy::rocblas_int,
                                    result::Ptr{Cfloat})::rocblas_status
 end
 
 function rocblas_ddot(handle, n, x, incx, y, incy, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ddot(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cdouble},
+    @check @ccall librocblas.rocblas_ddot(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cdouble},
                                    incx::rocblas_int, y::Ptr{Cdouble}, incy::rocblas_int,
                                    result::Ptr{Cdouble})::rocblas_status
 end
 
 function rocblas_hdot(handle, n, x, incx, y, incy, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_hdot(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_hdot(handle::rocblas_handle, n::rocblas_int,
                                    x::Ptr{rocblas_half}, incx::rocblas_int,
                                    y::Ptr{rocblas_half}, incy::rocblas_int,
                                    result::Ptr{rocblas_half})::rocblas_status
@@ -662,7 +662,7 @@ end
 
 function rocblas_bfdot(handle, n, x, incx, y, incy, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_bfdot(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_bfdot(handle::rocblas_handle, n::rocblas_int,
                                     x::Ptr{rocblas_bfloat16}, incx::rocblas_int,
                                     y::Ptr{rocblas_bfloat16}, incy::rocblas_int,
                                     result::Ptr{rocblas_bfloat16})::rocblas_status
@@ -670,7 +670,7 @@ end
 
 function rocblas_cdotu(handle, n, x, incx, y, incy, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cdotu(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_cdotu(handle::rocblas_handle, n::rocblas_int,
                                     x::Ptr{rocblas_float_complex}, incx::rocblas_int,
                                     y::Ptr{rocblas_float_complex}, incy::rocblas_int,
                                     result::Ptr{rocblas_float_complex})::rocblas_status
@@ -678,7 +678,7 @@ end
 
 function rocblas_zdotu(handle, n, x, incx, y, incy, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zdotu(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zdotu(handle::rocblas_handle, n::rocblas_int,
                                     x::Ptr{rocblas_double_complex}, incx::rocblas_int,
                                     y::Ptr{rocblas_double_complex}, incy::rocblas_int,
                                     result::Ptr{rocblas_double_complex})::rocblas_status
@@ -686,7 +686,7 @@ end
 
 function rocblas_cdotc(handle, n, x, incx, y, incy, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cdotc(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_cdotc(handle::rocblas_handle, n::rocblas_int,
                                     x::Ptr{rocblas_float_complex}, incx::rocblas_int,
                                     y::Ptr{rocblas_float_complex}, incy::rocblas_int,
                                     result::Ptr{rocblas_float_complex})::rocblas_status
@@ -694,7 +694,7 @@ end
 
 function rocblas_zdotc(handle, n, x, incx, y, incy, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zdotc(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zdotc(handle::rocblas_handle, n::rocblas_int,
                                     x::Ptr{rocblas_double_complex}, incx::rocblas_int,
                                     y::Ptr{rocblas_double_complex}, incy::rocblas_int,
                                     result::Ptr{rocblas_double_complex})::rocblas_status
@@ -702,7 +702,7 @@ end
 
 function rocblas_sdot_batched(handle, n, x, incx, y, incy, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sdot_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_sdot_batched(handle::rocblas_handle, n::rocblas_int,
                                            x::Ptr{Ptr{Cfloat}}, incx::rocblas_int,
                                            y::Ptr{Ptr{Cfloat}}, incy::rocblas_int,
                                            batch_count::rocblas_int,
@@ -711,7 +711,7 @@ end
 
 function rocblas_ddot_batched(handle, n, x, incx, y, incy, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ddot_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_ddot_batched(handle::rocblas_handle, n::rocblas_int,
                                            x::Ptr{Ptr{Cdouble}}, incx::rocblas_int,
                                            y::Ptr{Ptr{Cdouble}}, incy::rocblas_int,
                                            batch_count::rocblas_int,
@@ -720,7 +720,7 @@ end
 
 function rocblas_hdot_batched(handle, n, x, incx, y, incy, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_hdot_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_hdot_batched(handle::rocblas_handle, n::rocblas_int,
                                            x::Ptr{Ptr{rocblas_half}}, incx::rocblas_int,
                                            y::Ptr{Ptr{rocblas_half}}, incy::rocblas_int,
                                            batch_count::rocblas_int,
@@ -729,7 +729,7 @@ end
 
 function rocblas_bfdot_batched(handle, n, x, incx, y, incy, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_bfdot_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_bfdot_batched(handle::rocblas_handle, n::rocblas_int,
                                             x::Ptr{Ptr{rocblas_bfloat16}},
                                             incx::rocblas_int,
                                             y::Ptr{Ptr{rocblas_bfloat16}},
@@ -739,7 +739,7 @@ end
 
 function rocblas_cdotu_batched(handle, n, x, incx, y, incy, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cdotu_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_cdotu_batched(handle::rocblas_handle, n::rocblas_int,
                                             x::Ptr{Ptr{rocblas_float_complex}},
                                             incx::rocblas_int,
                                             y::Ptr{Ptr{rocblas_float_complex}},
@@ -749,7 +749,7 @@ end
 
 function rocblas_zdotu_batched(handle, n, x, incx, y, incy, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zdotu_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zdotu_batched(handle::rocblas_handle, n::rocblas_int,
                                             x::Ptr{Ptr{rocblas_double_complex}},
                                             incx::rocblas_int,
                                             y::Ptr{Ptr{rocblas_double_complex}},
@@ -759,7 +759,7 @@ end
 
 function rocblas_cdotc_batched(handle, n, x, incx, y, incy, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cdotc_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_cdotc_batched(handle::rocblas_handle, n::rocblas_int,
                                             x::Ptr{Ptr{rocblas_float_complex}},
                                             incx::rocblas_int,
                                             y::Ptr{Ptr{rocblas_float_complex}},
@@ -769,7 +769,7 @@ end
 
 function rocblas_zdotc_batched(handle, n, x, incx, y, incy, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zdotc_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zdotc_batched(handle::rocblas_handle, n::rocblas_int,
                                             x::Ptr{Ptr{rocblas_double_complex}},
                                             incx::rocblas_int,
                                             y::Ptr{Ptr{rocblas_double_complex}},
@@ -780,7 +780,7 @@ end
 function rocblas_sdot_strided_batched(handle, n, x, incx, stridex, y, incy, stridey,
                                       batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sdot_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_sdot_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                    x::Ptr{Cfloat}, incx::rocblas_int,
                                                    stridex::rocblas_stride, y::Ptr{Cfloat},
                                                    incy::rocblas_int,
@@ -792,7 +792,7 @@ end
 function rocblas_ddot_strided_batched(handle, n, x, incx, stridex, y, incy, stridey,
                                       batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ddot_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_ddot_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                    x::Ptr{Cdouble}, incx::rocblas_int,
                                                    stridex::rocblas_stride, y::Ptr{Cdouble},
                                                    incy::rocblas_int,
@@ -804,7 +804,7 @@ end
 function rocblas_hdot_strided_batched(handle, n, x, incx, stridex, y, incy, stridey,
                                       batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_hdot_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_hdot_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                    x::Ptr{rocblas_half}, incx::rocblas_int,
                                                    stridex::rocblas_stride,
                                                    y::Ptr{rocblas_half}, incy::rocblas_int,
@@ -816,7 +816,7 @@ end
 function rocblas_bfdot_strided_batched(handle, n, x, incx, stridex, y, incy, stridey,
                                        batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_bfdot_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_bfdot_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     x::Ptr{rocblas_bfloat16},
                                                     incx::rocblas_int,
                                                     stridex::rocblas_stride,
@@ -830,7 +830,7 @@ end
 function rocblas_cdotu_strided_batched(handle, n, x, incx, stridex, y, incy, stridey,
                                        batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cdotu_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_cdotu_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     x::Ptr{rocblas_float_complex},
                                                     incx::rocblas_int,
                                                     stridex::rocblas_stride,
@@ -844,7 +844,7 @@ end
 function rocblas_zdotu_strided_batched(handle, n, x, incx, stridex, y, incy, stridey,
                                        batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zdotu_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zdotu_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     x::Ptr{rocblas_double_complex},
                                                     incx::rocblas_int,
                                                     stridex::rocblas_stride,
@@ -858,7 +858,7 @@ end
 function rocblas_cdotc_strided_batched(handle, n, x, incx, stridex, y, incy, stridey,
                                        batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cdotc_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_cdotc_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     x::Ptr{rocblas_float_complex},
                                                     incx::rocblas_int,
                                                     stridex::rocblas_stride,
@@ -872,7 +872,7 @@ end
 function rocblas_zdotc_strided_batched(handle, n, x, incx, stridex, y, incy, stridey,
                                        batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zdotc_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zdotc_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     x::Ptr{rocblas_double_complex},
                                                     incx::rocblas_int,
                                                     stridex::rocblas_stride,
@@ -885,21 +885,21 @@ end
 
 function rocblas_sswap(handle, n, x, incx, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sswap(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cfloat},
+    @check @ccall librocblas.rocblas_sswap(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cfloat},
                                     incx::rocblas_int, y::Ptr{Cfloat},
                                     incy::rocblas_int)::rocblas_status
 end
 
 function rocblas_dswap(handle, n, x, incx, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dswap(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cdouble},
+    @check @ccall librocblas.rocblas_dswap(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cdouble},
                                     incx::rocblas_int, y::Ptr{Cdouble},
                                     incy::rocblas_int)::rocblas_status
 end
 
 function rocblas_cswap(handle, n, x, incx, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cswap(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_cswap(handle::rocblas_handle, n::rocblas_int,
                                     x::Ptr{rocblas_float_complex}, incx::rocblas_int,
                                     y::Ptr{rocblas_float_complex},
                                     incy::rocblas_int)::rocblas_status
@@ -907,7 +907,7 @@ end
 
 function rocblas_zswap(handle, n, x, incx, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zswap(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zswap(handle::rocblas_handle, n::rocblas_int,
                                     x::Ptr{rocblas_double_complex}, incx::rocblas_int,
                                     y::Ptr{rocblas_double_complex},
                                     incy::rocblas_int)::rocblas_status
@@ -915,7 +915,7 @@ end
 
 function rocblas_sswap_batched(handle, n, x, incx, y, incy, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sswap_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_sswap_batched(handle::rocblas_handle, n::rocblas_int,
                                             x::Ptr{Ptr{Cfloat}}, incx::rocblas_int,
                                             y::Ptr{Ptr{Cfloat}}, incy::rocblas_int,
                                             batch_count::rocblas_int)::rocblas_status
@@ -923,7 +923,7 @@ end
 
 function rocblas_dswap_batched(handle, n, x, incx, y, incy, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dswap_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_dswap_batched(handle::rocblas_handle, n::rocblas_int,
                                             x::Ptr{Ptr{Cdouble}}, incx::rocblas_int,
                                             y::Ptr{Ptr{Cdouble}}, incy::rocblas_int,
                                             batch_count::rocblas_int)::rocblas_status
@@ -931,7 +931,7 @@ end
 
 function rocblas_cswap_batched(handle, n, x, incx, y, incy, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cswap_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_cswap_batched(handle::rocblas_handle, n::rocblas_int,
                                             x::Ptr{Ptr{rocblas_float_complex}},
                                             incx::rocblas_int,
                                             y::Ptr{Ptr{rocblas_float_complex}},
@@ -941,7 +941,7 @@ end
 
 function rocblas_zswap_batched(handle, n, x, incx, y, incy, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zswap_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zswap_batched(handle::rocblas_handle, n::rocblas_int,
                                             x::Ptr{Ptr{rocblas_double_complex}},
                                             incx::rocblas_int,
                                             y::Ptr{Ptr{rocblas_double_complex}},
@@ -952,7 +952,7 @@ end
 function rocblas_sswap_strided_batched(handle, n, x, incx, stridex, y, incy, stridey,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sswap_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_sswap_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     x::Ptr{Cfloat}, incx::rocblas_int,
                                                     stridex::rocblas_stride, y::Ptr{Cfloat},
                                                     incy::rocblas_int,
@@ -963,7 +963,7 @@ end
 function rocblas_dswap_strided_batched(handle, n, x, incx, stridex, y, incy, stridey,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dswap_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_dswap_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     x::Ptr{Cdouble}, incx::rocblas_int,
                                                     stridex::rocblas_stride,
                                                     y::Ptr{Cdouble}, incy::rocblas_int,
@@ -974,7 +974,7 @@ end
 function rocblas_cswap_strided_batched(handle, n, x, incx, stridex, y, incy, stridey,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cswap_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_cswap_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     x::Ptr{rocblas_float_complex},
                                                     incx::rocblas_int,
                                                     stridex::rocblas_stride,
@@ -987,7 +987,7 @@ end
 function rocblas_zswap_strided_batched(handle, n, x, incx, stridex, y, incy, stridey,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zswap_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zswap_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     x::Ptr{rocblas_double_complex},
                                                     incx::rocblas_int,
                                                     stridex::rocblas_stride,
@@ -999,21 +999,21 @@ end
 
 function rocblas_saxpy(handle, n, alpha, x, incx, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_saxpy(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_saxpy(handle::rocblas_handle, n::rocblas_int,
                                     alpha::Ptr{Cfloat}, x::Ptr{Cfloat}, incx::rocblas_int,
                                     y::Ptr{Cfloat}, incy::rocblas_int)::rocblas_status
 end
 
 function rocblas_daxpy(handle, n, alpha, x, incx, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_daxpy(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_daxpy(handle::rocblas_handle, n::rocblas_int,
                                     alpha::Ptr{Cdouble}, x::Ptr{Cdouble}, incx::rocblas_int,
                                     y::Ptr{Cdouble}, incy::rocblas_int)::rocblas_status
 end
 
 function rocblas_haxpy(handle, n, alpha, x, incx, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_haxpy(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_haxpy(handle::rocblas_handle, n::rocblas_int,
                                     alpha::Ptr{rocblas_half}, x::Ptr{rocblas_half},
                                     incx::rocblas_int, y::Ptr{rocblas_half},
                                     incy::rocblas_int)::rocblas_status
@@ -1021,7 +1021,7 @@ end
 
 function rocblas_caxpy(handle, n, alpha, x, incx, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_caxpy(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_caxpy(handle::rocblas_handle, n::rocblas_int,
                                     alpha::Ptr{rocblas_float_complex},
                                     x::Ptr{rocblas_float_complex}, incx::rocblas_int,
                                     y::Ptr{rocblas_float_complex},
@@ -1030,7 +1030,7 @@ end
 
 function rocblas_zaxpy(handle, n, alpha, x, incx, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zaxpy(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zaxpy(handle::rocblas_handle, n::rocblas_int,
                                     alpha::Ptr{rocblas_double_complex},
                                     x::Ptr{rocblas_double_complex}, incx::rocblas_int,
                                     y::Ptr{rocblas_double_complex},
@@ -1039,7 +1039,7 @@ end
 
 function rocblas_haxpy_batched(handle, n, alpha, x, incx, y, incy, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_haxpy_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_haxpy_batched(handle::rocblas_handle, n::rocblas_int,
                                             alpha::Ptr{rocblas_half},
                                             x::Ptr{Ptr{rocblas_half}}, incx::rocblas_int,
                                             y::Ptr{Ptr{rocblas_half}}, incy::rocblas_int,
@@ -1048,7 +1048,7 @@ end
 
 function rocblas_saxpy_batched(handle, n, alpha, x, incx, y, incy, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_saxpy_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_saxpy_batched(handle::rocblas_handle, n::rocblas_int,
                                             alpha::Ptr{Cfloat}, x::Ptr{Ptr{Cfloat}},
                                             incx::rocblas_int, y::Ptr{Ptr{Cfloat}},
                                             incy::rocblas_int,
@@ -1057,7 +1057,7 @@ end
 
 function rocblas_daxpy_batched(handle, n, alpha, x, incx, y, incy, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_daxpy_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_daxpy_batched(handle::rocblas_handle, n::rocblas_int,
                                             alpha::Ptr{Cdouble}, x::Ptr{Ptr{Cdouble}},
                                             incx::rocblas_int, y::Ptr{Ptr{Cdouble}},
                                             incy::rocblas_int,
@@ -1066,7 +1066,7 @@ end
 
 function rocblas_caxpy_batched(handle, n, alpha, x, incx, y, incy, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_caxpy_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_caxpy_batched(handle::rocblas_handle, n::rocblas_int,
                                             alpha::Ptr{rocblas_float_complex},
                                             x::Ptr{Ptr{rocblas_float_complex}},
                                             incx::rocblas_int,
@@ -1077,7 +1077,7 @@ end
 
 function rocblas_zaxpy_batched(handle, n, alpha, x, incx, y, incy, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zaxpy_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zaxpy_batched(handle::rocblas_handle, n::rocblas_int,
                                             alpha::Ptr{rocblas_double_complex},
                                             x::Ptr{Ptr{rocblas_double_complex}},
                                             incx::rocblas_int,
@@ -1089,7 +1089,7 @@ end
 function rocblas_haxpy_strided_batched(handle, n, alpha, x, incx, stridex, y, incy, stridey,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_haxpy_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_haxpy_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     alpha::Ptr{rocblas_half},
                                                     x::Ptr{rocblas_half}, incx::rocblas_int,
                                                     stridex::rocblas_stride,
@@ -1101,7 +1101,7 @@ end
 function rocblas_saxpy_strided_batched(handle, n, alpha, x, incx, stridex, y, incy, stridey,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_saxpy_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_saxpy_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     alpha::Ptr{Cfloat}, x::Ptr{Cfloat},
                                                     incx::rocblas_int,
                                                     stridex::rocblas_stride, y::Ptr{Cfloat},
@@ -1113,7 +1113,7 @@ end
 function rocblas_daxpy_strided_batched(handle, n, alpha, x, incx, stridex, y, incy, stridey,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_daxpy_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_daxpy_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     alpha::Ptr{Cdouble}, x::Ptr{Cdouble},
                                                     incx::rocblas_int,
                                                     stridex::rocblas_stride,
@@ -1125,7 +1125,7 @@ end
 function rocblas_caxpy_strided_batched(handle, n, alpha, x, incx, stridex, y, incy, stridey,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_caxpy_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_caxpy_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     alpha::Ptr{rocblas_float_complex},
                                                     x::Ptr{rocblas_float_complex},
                                                     incx::rocblas_int,
@@ -1139,7 +1139,7 @@ end
 function rocblas_zaxpy_strided_batched(handle, n, alpha, x, incx, stridex, y, incy, stridey,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zaxpy_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zaxpy_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     alpha::Ptr{rocblas_double_complex},
                                                     x::Ptr{rocblas_double_complex},
                                                     incx::rocblas_int,
@@ -1152,33 +1152,33 @@ end
 
 function rocblas_sasum(handle, n, x, incx, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sasum(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cfloat},
+    @check @ccall librocblas.rocblas_sasum(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cfloat},
                                     incx::rocblas_int, result::Ptr{Cfloat})::rocblas_status
 end
 
 function rocblas_dasum(handle, n, x, incx, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dasum(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cdouble},
+    @check @ccall librocblas.rocblas_dasum(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cdouble},
                                     incx::rocblas_int, result::Ptr{Cdouble})::rocblas_status
 end
 
 function rocblas_scasum(handle, n, x, incx, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_scasum(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_scasum(handle::rocblas_handle, n::rocblas_int,
                                      x::Ptr{rocblas_float_complex}, incx::rocblas_int,
                                      result::Ptr{Cfloat})::rocblas_status
 end
 
 function rocblas_dzasum(handle, n, x, incx, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dzasum(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_dzasum(handle::rocblas_handle, n::rocblas_int,
                                      x::Ptr{rocblas_double_complex}, incx::rocblas_int,
                                      result::Ptr{Cdouble})::rocblas_status
 end
 
 function rocblas_sasum_batched(handle, n, x, incx, batch_count, results)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sasum_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_sasum_batched(handle::rocblas_handle, n::rocblas_int,
                                             x::Ptr{Ptr{Cfloat}}, incx::rocblas_int,
                                             batch_count::rocblas_int,
                                             results::Ptr{Cfloat})::rocblas_status
@@ -1186,7 +1186,7 @@ end
 
 function rocblas_dasum_batched(handle, n, x, incx, batch_count, results)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dasum_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_dasum_batched(handle::rocblas_handle, n::rocblas_int,
                                             x::Ptr{Ptr{Cdouble}}, incx::rocblas_int,
                                             batch_count::rocblas_int,
                                             results::Ptr{Cdouble})::rocblas_status
@@ -1194,7 +1194,7 @@ end
 
 function rocblas_scasum_batched(handle, n, x, incx, batch_count, results)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_scasum_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_scasum_batched(handle::rocblas_handle, n::rocblas_int,
                                              x::Ptr{Ptr{rocblas_float_complex}},
                                              incx::rocblas_int, batch_count::rocblas_int,
                                              results::Ptr{Cfloat})::rocblas_status
@@ -1202,7 +1202,7 @@ end
 
 function rocblas_dzasum_batched(handle, n, x, incx, batch_count, results)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dzasum_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_dzasum_batched(handle::rocblas_handle, n::rocblas_int,
                                              x::Ptr{Ptr{rocblas_double_complex}},
                                              incx::rocblas_int, batch_count::rocblas_int,
                                              results::Ptr{Cdouble})::rocblas_status
@@ -1210,7 +1210,7 @@ end
 
 function rocblas_sasum_strided_batched(handle, n, x, incx, stridex, batch_count, results)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sasum_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_sasum_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     x::Ptr{Cfloat}, incx::rocblas_int,
                                                     stridex::rocblas_stride,
                                                     batch_count::rocblas_int,
@@ -1219,7 +1219,7 @@ end
 
 function rocblas_dasum_strided_batched(handle, n, x, incx, stridex, batch_count, results)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dasum_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_dasum_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     x::Ptr{Cdouble}, incx::rocblas_int,
                                                     stridex::rocblas_stride,
                                                     batch_count::rocblas_int,
@@ -1228,7 +1228,7 @@ end
 
 function rocblas_scasum_strided_batched(handle, n, x, incx, stridex, batch_count, results)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_scasum_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_scasum_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                      x::Ptr{rocblas_float_complex},
                                                      incx::rocblas_int,
                                                      stridex::rocblas_stride,
@@ -1238,7 +1238,7 @@ end
 
 function rocblas_dzasum_strided_batched(handle, n, x, incx, stridex, batch_count, results)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dzasum_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_dzasum_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                      x::Ptr{rocblas_double_complex},
                                                      incx::rocblas_int,
                                                      stridex::rocblas_stride,
@@ -1248,33 +1248,33 @@ end
 
 function rocblas_snrm2(handle, n, x, incx, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_snrm2(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cfloat},
+    @check @ccall librocblas.rocblas_snrm2(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cfloat},
                                     incx::rocblas_int, result::Ptr{Cfloat})::rocblas_status
 end
 
 function rocblas_dnrm2(handle, n, x, incx, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dnrm2(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cdouble},
+    @check @ccall librocblas.rocblas_dnrm2(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cdouble},
                                     incx::rocblas_int, result::Ptr{Cdouble})::rocblas_status
 end
 
 function rocblas_scnrm2(handle, n, x, incx, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_scnrm2(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_scnrm2(handle::rocblas_handle, n::rocblas_int,
                                      x::Ptr{rocblas_float_complex}, incx::rocblas_int,
                                      result::Ptr{Cfloat})::rocblas_status
 end
 
 function rocblas_dznrm2(handle, n, x, incx, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dznrm2(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_dznrm2(handle::rocblas_handle, n::rocblas_int,
                                      x::Ptr{rocblas_double_complex}, incx::rocblas_int,
                                      result::Ptr{Cdouble})::rocblas_status
 end
 
 function rocblas_snrm2_batched(handle, n, x, incx, batch_count, results)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_snrm2_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_snrm2_batched(handle::rocblas_handle, n::rocblas_int,
                                             x::Ptr{Ptr{Cfloat}}, incx::rocblas_int,
                                             batch_count::rocblas_int,
                                             results::Ptr{Cfloat})::rocblas_status
@@ -1282,7 +1282,7 @@ end
 
 function rocblas_dnrm2_batched(handle, n, x, incx, batch_count, results)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dnrm2_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_dnrm2_batched(handle::rocblas_handle, n::rocblas_int,
                                             x::Ptr{Ptr{Cdouble}}, incx::rocblas_int,
                                             batch_count::rocblas_int,
                                             results::Ptr{Cdouble})::rocblas_status
@@ -1290,7 +1290,7 @@ end
 
 function rocblas_scnrm2_batched(handle, n, x, incx, batch_count, results)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_scnrm2_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_scnrm2_batched(handle::rocblas_handle, n::rocblas_int,
                                              x::Ptr{Ptr{rocblas_float_complex}},
                                              incx::rocblas_int, batch_count::rocblas_int,
                                              results::Ptr{Cfloat})::rocblas_status
@@ -1298,7 +1298,7 @@ end
 
 function rocblas_dznrm2_batched(handle, n, x, incx, batch_count, results)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dznrm2_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_dznrm2_batched(handle::rocblas_handle, n::rocblas_int,
                                              x::Ptr{Ptr{rocblas_double_complex}},
                                              incx::rocblas_int, batch_count::rocblas_int,
                                              results::Ptr{Cdouble})::rocblas_status
@@ -1306,7 +1306,7 @@ end
 
 function rocblas_snrm2_strided_batched(handle, n, x, incx, stridex, batch_count, results)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_snrm2_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_snrm2_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     x::Ptr{Cfloat}, incx::rocblas_int,
                                                     stridex::rocblas_stride,
                                                     batch_count::rocblas_int,
@@ -1315,7 +1315,7 @@ end
 
 function rocblas_dnrm2_strided_batched(handle, n, x, incx, stridex, batch_count, results)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dnrm2_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_dnrm2_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     x::Ptr{Cdouble}, incx::rocblas_int,
                                                     stridex::rocblas_stride,
                                                     batch_count::rocblas_int,
@@ -1324,7 +1324,7 @@ end
 
 function rocblas_scnrm2_strided_batched(handle, n, x, incx, stridex, batch_count, results)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_scnrm2_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_scnrm2_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                      x::Ptr{rocblas_float_complex},
                                                      incx::rocblas_int,
                                                      stridex::rocblas_stride,
@@ -1334,7 +1334,7 @@ end
 
 function rocblas_dznrm2_strided_batched(handle, n, x, incx, stridex, batch_count, results)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dznrm2_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_dznrm2_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                      x::Ptr{rocblas_double_complex},
                                                      incx::rocblas_int,
                                                      stridex::rocblas_stride,
@@ -1344,35 +1344,35 @@ end
 
 function rocblas_isamax(handle, n, x, incx, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_isamax(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cfloat},
+    @check @ccall librocblas.rocblas_isamax(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cfloat},
                                      incx::rocblas_int,
                                      result::Ptr{rocblas_int})::rocblas_status
 end
 
 function rocblas_idamax(handle, n, x, incx, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_idamax(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_idamax(handle::rocblas_handle, n::rocblas_int,
                                      x::Ptr{Cdouble}, incx::rocblas_int,
                                      result::Ptr{rocblas_int})::rocblas_status
 end
 
 function rocblas_icamax(handle, n, x, incx, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_icamax(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_icamax(handle::rocblas_handle, n::rocblas_int,
                                      x::Ptr{rocblas_float_complex}, incx::rocblas_int,
                                      result::Ptr{rocblas_int})::rocblas_status
 end
 
 function rocblas_izamax(handle, n, x, incx, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_izamax(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_izamax(handle::rocblas_handle, n::rocblas_int,
                                      x::Ptr{rocblas_double_complex}, incx::rocblas_int,
                                      result::Ptr{rocblas_int})::rocblas_status
 end
 
 function rocblas_isamax_batched(handle, n, x, incx, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_isamax_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_isamax_batched(handle::rocblas_handle, n::rocblas_int,
                                              x::Ptr{Ptr{Cfloat}}, incx::rocblas_int,
                                              batch_count::rocblas_int,
                                              result::Ptr{rocblas_int})::rocblas_status
@@ -1380,7 +1380,7 @@ end
 
 function rocblas_idamax_batched(handle, n, x, incx, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_idamax_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_idamax_batched(handle::rocblas_handle, n::rocblas_int,
                                              x::Ptr{Ptr{Cdouble}}, incx::rocblas_int,
                                              batch_count::rocblas_int,
                                              result::Ptr{rocblas_int})::rocblas_status
@@ -1388,7 +1388,7 @@ end
 
 function rocblas_icamax_batched(handle, n, x, incx, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_icamax_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_icamax_batched(handle::rocblas_handle, n::rocblas_int,
                                              x::Ptr{Ptr{rocblas_float_complex}},
                                              incx::rocblas_int, batch_count::rocblas_int,
                                              result::Ptr{rocblas_int})::rocblas_status
@@ -1396,7 +1396,7 @@ end
 
 function rocblas_izamax_batched(handle, n, x, incx, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_izamax_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_izamax_batched(handle::rocblas_handle, n::rocblas_int,
                                              x::Ptr{Ptr{rocblas_double_complex}},
                                              incx::rocblas_int, batch_count::rocblas_int,
                                              result::Ptr{rocblas_int})::rocblas_status
@@ -1404,7 +1404,7 @@ end
 
 function rocblas_isamax_strided_batched(handle, n, x, incx, stridex, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_isamax_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_isamax_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                      x::Ptr{Cfloat}, incx::rocblas_int,
                                                      stridex::rocblas_stride,
                                                      batch_count::rocblas_int,
@@ -1413,7 +1413,7 @@ end
 
 function rocblas_idamax_strided_batched(handle, n, x, incx, stridex, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_idamax_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_idamax_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                      x::Ptr{Cdouble}, incx::rocblas_int,
                                                      stridex::rocblas_stride,
                                                      batch_count::rocblas_int,
@@ -1422,7 +1422,7 @@ end
 
 function rocblas_icamax_strided_batched(handle, n, x, incx, stridex, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_icamax_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_icamax_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                      x::Ptr{rocblas_float_complex},
                                                      incx::rocblas_int,
                                                      stridex::rocblas_stride,
@@ -1432,7 +1432,7 @@ end
 
 function rocblas_izamax_strided_batched(handle, n, x, incx, stridex, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_izamax_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_izamax_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                      x::Ptr{rocblas_double_complex},
                                                      incx::rocblas_int,
                                                      stridex::rocblas_stride,
@@ -1442,35 +1442,35 @@ end
 
 function rocblas_isamin(handle, n, x, incx, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_isamin(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cfloat},
+    @check @ccall librocblas.rocblas_isamin(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cfloat},
                                      incx::rocblas_int,
                                      result::Ptr{rocblas_int})::rocblas_status
 end
 
 function rocblas_idamin(handle, n, x, incx, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_idamin(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_idamin(handle::rocblas_handle, n::rocblas_int,
                                      x::Ptr{Cdouble}, incx::rocblas_int,
                                      result::Ptr{rocblas_int})::rocblas_status
 end
 
 function rocblas_icamin(handle, n, x, incx, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_icamin(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_icamin(handle::rocblas_handle, n::rocblas_int,
                                      x::Ptr{rocblas_float_complex}, incx::rocblas_int,
                                      result::Ptr{rocblas_int})::rocblas_status
 end
 
 function rocblas_izamin(handle, n, x, incx, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_izamin(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_izamin(handle::rocblas_handle, n::rocblas_int,
                                      x::Ptr{rocblas_double_complex}, incx::rocblas_int,
                                      result::Ptr{rocblas_int})::rocblas_status
 end
 
 function rocblas_isamin_batched(handle, n, x, incx, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_isamin_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_isamin_batched(handle::rocblas_handle, n::rocblas_int,
                                              x::Ptr{Ptr{Cfloat}}, incx::rocblas_int,
                                              batch_count::rocblas_int,
                                              result::Ptr{rocblas_int})::rocblas_status
@@ -1478,7 +1478,7 @@ end
 
 function rocblas_idamin_batched(handle, n, x, incx, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_idamin_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_idamin_batched(handle::rocblas_handle, n::rocblas_int,
                                              x::Ptr{Ptr{Cdouble}}, incx::rocblas_int,
                                              batch_count::rocblas_int,
                                              result::Ptr{rocblas_int})::rocblas_status
@@ -1486,7 +1486,7 @@ end
 
 function rocblas_icamin_batched(handle, n, x, incx, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_icamin_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_icamin_batched(handle::rocblas_handle, n::rocblas_int,
                                              x::Ptr{Ptr{rocblas_float_complex}},
                                              incx::rocblas_int, batch_count::rocblas_int,
                                              result::Ptr{rocblas_int})::rocblas_status
@@ -1494,7 +1494,7 @@ end
 
 function rocblas_izamin_batched(handle, n, x, incx, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_izamin_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_izamin_batched(handle::rocblas_handle, n::rocblas_int,
                                              x::Ptr{Ptr{rocblas_double_complex}},
                                              incx::rocblas_int, batch_count::rocblas_int,
                                              result::Ptr{rocblas_int})::rocblas_status
@@ -1502,7 +1502,7 @@ end
 
 function rocblas_isamin_strided_batched(handle, n, x, incx, stridex, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_isamin_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_isamin_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                      x::Ptr{Cfloat}, incx::rocblas_int,
                                                      stridex::rocblas_stride,
                                                      batch_count::rocblas_int,
@@ -1511,7 +1511,7 @@ end
 
 function rocblas_idamin_strided_batched(handle, n, x, incx, stridex, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_idamin_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_idamin_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                      x::Ptr{Cdouble}, incx::rocblas_int,
                                                      stridex::rocblas_stride,
                                                      batch_count::rocblas_int,
@@ -1520,7 +1520,7 @@ end
 
 function rocblas_icamin_strided_batched(handle, n, x, incx, stridex, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_icamin_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_icamin_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                      x::Ptr{rocblas_float_complex},
                                                      incx::rocblas_int,
                                                      stridex::rocblas_stride,
@@ -1530,7 +1530,7 @@ end
 
 function rocblas_izamin_strided_batched(handle, n, x, incx, stridex, batch_count, result)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_izamin_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_izamin_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                      x::Ptr{rocblas_double_complex},
                                                      incx::rocblas_int,
                                                      stridex::rocblas_stride,
@@ -1540,21 +1540,21 @@ end
 
 function rocblas_srot(handle, n, x, incx, y, incy, c, s)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_srot(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cfloat},
+    @check @ccall librocblas.rocblas_srot(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cfloat},
                                    incx::rocblas_int, y::Ptr{Cfloat}, incy::rocblas_int,
                                    c::Ptr{Cfloat}, s::Ptr{Cfloat})::rocblas_status
 end
 
 function rocblas_drot(handle, n, x, incx, y, incy, c, s)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_drot(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cdouble},
+    @check @ccall librocblas.rocblas_drot(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cdouble},
                                    incx::rocblas_int, y::Ptr{Cdouble}, incy::rocblas_int,
                                    c::Ptr{Cdouble}, s::Ptr{Cdouble})::rocblas_status
 end
 
 function rocblas_crot(handle, n, x, incx, y, incy, c, s)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_crot(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_crot(handle::rocblas_handle, n::rocblas_int,
                                    x::Ptr{rocblas_float_complex}, incx::rocblas_int,
                                    y::Ptr{rocblas_float_complex}, incy::rocblas_int,
                                    c::Ptr{Cfloat},
@@ -1563,7 +1563,7 @@ end
 
 function rocblas_csrot(handle, n, x, incx, y, incy, c, s)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csrot(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_csrot(handle::rocblas_handle, n::rocblas_int,
                                     x::Ptr{rocblas_float_complex}, incx::rocblas_int,
                                     y::Ptr{rocblas_float_complex}, incy::rocblas_int,
                                     c::Ptr{Cfloat}, s::Ptr{Cfloat})::rocblas_status
@@ -1571,7 +1571,7 @@ end
 
 function rocblas_zrot(handle, n, x, incx, y, incy, c, s)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zrot(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zrot(handle::rocblas_handle, n::rocblas_int,
                                    x::Ptr{rocblas_double_complex}, incx::rocblas_int,
                                    y::Ptr{rocblas_double_complex}, incy::rocblas_int,
                                    c::Ptr{Cdouble},
@@ -1580,7 +1580,7 @@ end
 
 function rocblas_zdrot(handle, n, x, incx, y, incy, c, s)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zdrot(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zdrot(handle::rocblas_handle, n::rocblas_int,
                                     x::Ptr{rocblas_double_complex}, incx::rocblas_int,
                                     y::Ptr{rocblas_double_complex}, incy::rocblas_int,
                                     c::Ptr{Cdouble}, s::Ptr{Cdouble})::rocblas_status
@@ -1588,7 +1588,7 @@ end
 
 function rocblas_srot_batched(handle, n, x, incx, y, incy, c, s, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_srot_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_srot_batched(handle::rocblas_handle, n::rocblas_int,
                                            x::Ptr{Ptr{Cfloat}}, incx::rocblas_int,
                                            y::Ptr{Ptr{Cfloat}}, incy::rocblas_int,
                                            c::Ptr{Cfloat}, s::Ptr{Cfloat},
@@ -1597,7 +1597,7 @@ end
 
 function rocblas_drot_batched(handle, n, x, incx, y, incy, c, s, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_drot_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_drot_batched(handle::rocblas_handle, n::rocblas_int,
                                            x::Ptr{Ptr{Cdouble}}, incx::rocblas_int,
                                            y::Ptr{Ptr{Cdouble}}, incy::rocblas_int,
                                            c::Ptr{Cdouble}, s::Ptr{Cdouble},
@@ -1606,7 +1606,7 @@ end
 
 function rocblas_crot_batched(handle, n, x, incx, y, incy, c, s, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_crot_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_crot_batched(handle::rocblas_handle, n::rocblas_int,
                                            x::Ptr{Ptr{rocblas_float_complex}},
                                            incx::rocblas_int,
                                            y::Ptr{Ptr{rocblas_float_complex}},
@@ -1617,7 +1617,7 @@ end
 
 function rocblas_csrot_batched(handle, n, x, incx, y, incy, c, s, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csrot_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_csrot_batched(handle::rocblas_handle, n::rocblas_int,
                                             x::Ptr{Ptr{rocblas_float_complex}},
                                             incx::rocblas_int,
                                             y::Ptr{Ptr{rocblas_float_complex}},
@@ -1628,7 +1628,7 @@ end
 
 function rocblas_zrot_batched(handle, n, x, incx, y, incy, c, s, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zrot_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zrot_batched(handle::rocblas_handle, n::rocblas_int,
                                            x::Ptr{Ptr{rocblas_double_complex}},
                                            incx::rocblas_int,
                                            y::Ptr{Ptr{rocblas_double_complex}},
@@ -1639,7 +1639,7 @@ end
 
 function rocblas_zdrot_batched(handle, n, x, incx, y, incy, c, s, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zdrot_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zdrot_batched(handle::rocblas_handle, n::rocblas_int,
                                             x::Ptr{Ptr{rocblas_double_complex}},
                                             incx::rocblas_int,
                                             y::Ptr{Ptr{rocblas_double_complex}},
@@ -1651,7 +1651,7 @@ end
 function rocblas_srot_strided_batched(handle, n, x, incx, stride_x, y, incy, stride_y, c, s,
                                       batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_srot_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_srot_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                    x::Ptr{Cfloat}, incx::rocblas_int,
                                                    stride_x::rocblas_stride, y::Ptr{Cfloat},
                                                    incy::rocblas_int,
@@ -1663,7 +1663,7 @@ end
 function rocblas_drot_strided_batched(handle, n, x, incx, stride_x, y, incy, stride_y, c, s,
                                       batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_drot_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_drot_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                    x::Ptr{Cdouble}, incx::rocblas_int,
                                                    stride_x::rocblas_stride,
                                                    y::Ptr{Cdouble}, incy::rocblas_int,
@@ -1675,7 +1675,7 @@ end
 function rocblas_crot_strided_batched(handle, n, x, incx, stride_x, y, incy, stride_y, c, s,
                                       batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_crot_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_crot_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                    x::Ptr{rocblas_float_complex},
                                                    incx::rocblas_int,
                                                    stride_x::rocblas_stride,
@@ -1689,7 +1689,7 @@ end
 function rocblas_csrot_strided_batched(handle, n, x, incx, stride_x, y, incy, stride_y, c,
                                        s, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csrot_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_csrot_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     x::Ptr{rocblas_float_complex},
                                                     incx::rocblas_int,
                                                     stride_x::rocblas_stride,
@@ -1703,7 +1703,7 @@ end
 function rocblas_zrot_strided_batched(handle, n, x, incx, stride_x, y, incy, stride_y, c, s,
                                       batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zrot_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zrot_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                    x::Ptr{rocblas_double_complex},
                                                    incx::rocblas_int,
                                                    stride_x::rocblas_stride,
@@ -1718,7 +1718,7 @@ end
 function rocblas_zdrot_strided_batched(handle, n, x, incx, stride_x, y, incy, stride_y, c,
                                        s, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zdrot_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zdrot_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     x::Ptr{rocblas_double_complex},
                                                     incx::rocblas_int,
                                                     stride_x::rocblas_stride,
@@ -1731,34 +1731,34 @@ end
 
 function rocblas_srotg(handle, a, b, c, s)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_srotg(handle::rocblas_handle, a::Ptr{Cfloat}, b::Ptr{Cfloat},
+    @check @ccall librocblas.rocblas_srotg(handle::rocblas_handle, a::Ptr{Cfloat}, b::Ptr{Cfloat},
                                     c::Ptr{Cfloat}, s::Ptr{Cfloat})::rocblas_status
 end
 
 function rocblas_drotg(handle, a, b, c, s)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_drotg(handle::rocblas_handle, a::Ptr{Cdouble},
+    @check @ccall librocblas.rocblas_drotg(handle::rocblas_handle, a::Ptr{Cdouble},
                                     b::Ptr{Cdouble}, c::Ptr{Cdouble},
                                     s::Ptr{Cdouble})::rocblas_status
 end
 
 function rocblas_crotg(handle, a, b, c, s)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_crotg(handle::rocblas_handle, a::Ptr{rocblas_float_complex},
+    @check @ccall librocblas.rocblas_crotg(handle::rocblas_handle, a::Ptr{rocblas_float_complex},
                                     b::Ptr{rocblas_float_complex}, c::Ptr{Cfloat},
                                     s::Ptr{rocblas_float_complex})::rocblas_status
 end
 
 function rocblas_zrotg(handle, a, b, c, s)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zrotg(handle::rocblas_handle, a::Ptr{rocblas_double_complex},
+    @check @ccall librocblas.rocblas_zrotg(handle::rocblas_handle, a::Ptr{rocblas_double_complex},
                                     b::Ptr{rocblas_double_complex}, c::Ptr{Cdouble},
                                     s::Ptr{rocblas_double_complex})::rocblas_status
 end
 
 function rocblas_srotg_batched(handle, a, b, c, s, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_srotg_batched(handle::rocblas_handle, a::Ptr{Ptr{Cfloat}},
+    @check @ccall librocblas.rocblas_srotg_batched(handle::rocblas_handle, a::Ptr{Ptr{Cfloat}},
                                             b::Ptr{Ptr{Cfloat}}, c::Ptr{Ptr{Cfloat}},
                                             s::Ptr{Ptr{Cfloat}},
                                             batch_count::rocblas_int)::rocblas_status
@@ -1766,7 +1766,7 @@ end
 
 function rocblas_drotg_batched(handle, a, b, c, s, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_drotg_batched(handle::rocblas_handle, a::Ptr{Ptr{Cdouble}},
+    @check @ccall librocblas.rocblas_drotg_batched(handle::rocblas_handle, a::Ptr{Ptr{Cdouble}},
                                             b::Ptr{Ptr{Cdouble}}, c::Ptr{Ptr{Cdouble}},
                                             s::Ptr{Ptr{Cdouble}},
                                             batch_count::rocblas_int)::rocblas_status
@@ -1774,7 +1774,7 @@ end
 
 function rocblas_crotg_batched(handle, a, b, c, s, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_crotg_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_crotg_batched(handle::rocblas_handle,
                                             a::Ptr{Ptr{rocblas_float_complex}},
                                             b::Ptr{Ptr{rocblas_float_complex}},
                                             c::Ptr{Ptr{Cfloat}},
@@ -1784,7 +1784,7 @@ end
 
 function rocblas_zrotg_batched(handle, a, b, c, s, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zrotg_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zrotg_batched(handle::rocblas_handle,
                                             a::Ptr{Ptr{rocblas_double_complex}},
                                             b::Ptr{Ptr{rocblas_double_complex}},
                                             c::Ptr{Ptr{Cdouble}},
@@ -1795,7 +1795,7 @@ end
 function rocblas_srotg_strided_batched(handle, a, stride_a, b, stride_b, c, stride_c, s,
                                        stride_s, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_srotg_strided_batched(handle::rocblas_handle, a::Ptr{Cfloat},
+    @check @ccall librocblas.rocblas_srotg_strided_batched(handle::rocblas_handle, a::Ptr{Cfloat},
                                                     stride_a::rocblas_stride,
                                                     b::Ptr{Cfloat},
                                                     stride_b::rocblas_stride,
@@ -1809,7 +1809,7 @@ end
 function rocblas_drotg_strided_batched(handle, a, stride_a, b, stride_b, c, stride_c, s,
                                        stride_s, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_drotg_strided_batched(handle::rocblas_handle, a::Ptr{Cdouble},
+    @check @ccall librocblas.rocblas_drotg_strided_batched(handle::rocblas_handle, a::Ptr{Cdouble},
                                                     stride_a::rocblas_stride,
                                                     b::Ptr{Cdouble},
                                                     stride_b::rocblas_stride,
@@ -1823,7 +1823,7 @@ end
 function rocblas_crotg_strided_batched(handle, a, stride_a, b, stride_b, c, stride_c, s,
                                        stride_s, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_crotg_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_crotg_strided_batched(handle::rocblas_handle,
                                                     a::Ptr{rocblas_float_complex},
                                                     stride_a::rocblas_stride,
                                                     b::Ptr{rocblas_float_complex},
@@ -1838,7 +1838,7 @@ end
 function rocblas_zrotg_strided_batched(handle, a, stride_a, b, stride_b, c, stride_c, s,
                                        stride_s, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zrotg_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zrotg_strided_batched(handle::rocblas_handle,
                                                     a::Ptr{rocblas_double_complex},
                                                     stride_a::rocblas_stride,
                                                     b::Ptr{rocblas_double_complex},
@@ -1852,21 +1852,21 @@ end
 
 function rocblas_srotm(handle, n, x, incx, y, incy, param)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_srotm(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cfloat},
+    @check @ccall librocblas.rocblas_srotm(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cfloat},
                                     incx::rocblas_int, y::Ptr{Cfloat}, incy::rocblas_int,
                                     param::Ptr{Cfloat})::rocblas_status
 end
 
 function rocblas_drotm(handle, n, x, incx, y, incy, param)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_drotm(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cdouble},
+    @check @ccall librocblas.rocblas_drotm(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cdouble},
                                     incx::rocblas_int, y::Ptr{Cdouble}, incy::rocblas_int,
                                     param::Ptr{Cdouble})::rocblas_status
 end
 
 function rocblas_srotm_batched(handle, n, x, incx, y, incy, param, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_srotm_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_srotm_batched(handle::rocblas_handle, n::rocblas_int,
                                             x::Ptr{Ptr{Cfloat}}, incx::rocblas_int,
                                             y::Ptr{Ptr{Cfloat}}, incy::rocblas_int,
                                             param::Ptr{Ptr{Cfloat}},
@@ -1875,7 +1875,7 @@ end
 
 function rocblas_drotm_batched(handle, n, x, incx, y, incy, param, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_drotm_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_drotm_batched(handle::rocblas_handle, n::rocblas_int,
                                             x::Ptr{Ptr{Cdouble}}, incx::rocblas_int,
                                             y::Ptr{Ptr{Cdouble}}, incy::rocblas_int,
                                             param::Ptr{Ptr{Cdouble}},
@@ -1885,7 +1885,7 @@ end
 function rocblas_srotm_strided_batched(handle, n, x, incx, stride_x, y, incy, stride_y,
                                        param, stride_param, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_srotm_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_srotm_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     x::Ptr{Cfloat}, incx::rocblas_int,
                                                     stride_x::rocblas_stride,
                                                     y::Ptr{Cfloat}, incy::rocblas_int,
@@ -1898,7 +1898,7 @@ end
 function rocblas_drotm_strided_batched(handle, n, x, incx, stride_x, y, incy, stride_y,
                                        param, stride_param, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_drotm_strided_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_drotm_strided_batched(handle::rocblas_handle, n::rocblas_int,
                                                     x::Ptr{Cdouble}, incx::rocblas_int,
                                                     stride_x::rocblas_stride,
                                                     y::Ptr{Cdouble}, incy::rocblas_int,
@@ -1910,21 +1910,21 @@ end
 
 function rocblas_srotmg(handle, d1, d2, x1, y1, param)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_srotmg(handle::rocblas_handle, d1::Ptr{Cfloat},
+    @check @ccall librocblas.rocblas_srotmg(handle::rocblas_handle, d1::Ptr{Cfloat},
                                      d2::Ptr{Cfloat}, x1::Ptr{Cfloat}, y1::Ptr{Cfloat},
                                      param::Ptr{Cfloat})::rocblas_status
 end
 
 function rocblas_drotmg(handle, d1, d2, x1, y1, param)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_drotmg(handle::rocblas_handle, d1::Ptr{Cdouble},
+    @check @ccall librocblas.rocblas_drotmg(handle::rocblas_handle, d1::Ptr{Cdouble},
                                      d2::Ptr{Cdouble}, x1::Ptr{Cdouble}, y1::Ptr{Cdouble},
                                      param::Ptr{Cdouble})::rocblas_status
 end
 
 function rocblas_srotmg_batched(handle, d1, d2, x1, y1, param, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_srotmg_batched(handle::rocblas_handle, d1::Ptr{Ptr{Cfloat}},
+    @check @ccall librocblas.rocblas_srotmg_batched(handle::rocblas_handle, d1::Ptr{Ptr{Cfloat}},
                                              d2::Ptr{Ptr{Cfloat}}, x1::Ptr{Ptr{Cfloat}},
                                              y1::Ptr{Ptr{Cfloat}}, param::Ptr{Ptr{Cfloat}},
                                              batch_count::rocblas_int)::rocblas_status
@@ -1932,7 +1932,7 @@ end
 
 function rocblas_drotmg_batched(handle, d1, d2, x1, y1, param, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_drotmg_batched(handle::rocblas_handle, d1::Ptr{Ptr{Cdouble}},
+    @check @ccall librocblas.rocblas_drotmg_batched(handle::rocblas_handle, d1::Ptr{Ptr{Cdouble}},
                                              d2::Ptr{Ptr{Cdouble}}, x1::Ptr{Ptr{Cdouble}},
                                              y1::Ptr{Ptr{Cdouble}},
                                              param::Ptr{Ptr{Cdouble}},
@@ -1942,7 +1942,7 @@ end
 function rocblas_srotmg_strided_batched(handle, d1, stride_d1, d2, stride_d2, x1, stride_x1,
                                         y1, stride_y1, param, stride_param, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_srotmg_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_srotmg_strided_batched(handle::rocblas_handle,
                                                      d1::Ptr{Cfloat},
                                                      stride_d1::rocblas_stride,
                                                      d2::Ptr{Cfloat},
@@ -1959,7 +1959,7 @@ end
 function rocblas_drotmg_strided_batched(handle, d1, stride_d1, d2, stride_d2, x1, stride_x1,
                                         y1, stride_y1, param, stride_param, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_drotmg_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_drotmg_strided_batched(handle::rocblas_handle,
                                                      d1::Ptr{Cdouble},
                                                      stride_d1::rocblas_stride,
                                                      d2::Ptr{Cdouble},
@@ -1975,7 +1975,7 @@ end
 
 function rocblas_sgbmv(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sgbmv(handle::rocblas_handle, trans::rocblas_operation,
+    @check @ccall librocblas.rocblas_sgbmv(handle::rocblas_handle, trans::rocblas_operation,
                                     m::rocblas_int, n::rocblas_int, kl::rocblas_int,
                                     ku::rocblas_int, alpha::Ptr{Cfloat}, A::Ptr{Cfloat},
                                     lda::rocblas_int, x::Ptr{Cfloat}, incx::rocblas_int,
@@ -1985,7 +1985,7 @@ end
 
 function rocblas_dgbmv(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dgbmv(handle::rocblas_handle, trans::rocblas_operation,
+    @check @ccall librocblas.rocblas_dgbmv(handle::rocblas_handle, trans::rocblas_operation,
                                     m::rocblas_int, n::rocblas_int, kl::rocblas_int,
                                     ku::rocblas_int, alpha::Ptr{Cdouble}, A::Ptr{Cdouble},
                                     lda::rocblas_int, x::Ptr{Cdouble}, incx::rocblas_int,
@@ -1995,7 +1995,7 @@ end
 
 function rocblas_cgbmv(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cgbmv(handle::rocblas_handle, trans::rocblas_operation,
+    @check @ccall librocblas.rocblas_cgbmv(handle::rocblas_handle, trans::rocblas_operation,
                                     m::rocblas_int, n::rocblas_int, kl::rocblas_int,
                                     ku::rocblas_int, alpha::Ptr{rocblas_float_complex},
                                     A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -2007,7 +2007,7 @@ end
 
 function rocblas_zgbmv(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zgbmv(handle::rocblas_handle, trans::rocblas_operation,
+    @check @ccall librocblas.rocblas_zgbmv(handle::rocblas_handle, trans::rocblas_operation,
                                     m::rocblas_int, n::rocblas_int, kl::rocblas_int,
                                     ku::rocblas_int, alpha::Ptr{rocblas_double_complex},
                                     A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -2020,7 +2020,7 @@ end
 function rocblas_sgbmv_batched(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y,
                                incy, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sgbmv_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_sgbmv_batched(handle::rocblas_handle,
                                             trans::rocblas_operation, m::rocblas_int,
                                             n::rocblas_int, kl::rocblas_int,
                                             ku::rocblas_int, alpha::Ptr{Cfloat},
@@ -2034,7 +2034,7 @@ end
 function rocblas_dgbmv_batched(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y,
                                incy, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dgbmv_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dgbmv_batched(handle::rocblas_handle,
                                             trans::rocblas_operation, m::rocblas_int,
                                             n::rocblas_int, kl::rocblas_int,
                                             ku::rocblas_int, alpha::Ptr{Cdouble},
@@ -2048,7 +2048,7 @@ end
 function rocblas_cgbmv_batched(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y,
                                incy, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cgbmv_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_cgbmv_batched(handle::rocblas_handle,
                                             trans::rocblas_operation, m::rocblas_int,
                                             n::rocblas_int, kl::rocblas_int,
                                             ku::rocblas_int,
@@ -2066,7 +2066,7 @@ end
 function rocblas_zgbmv_batched(handle, trans, m, n, kl, ku, alpha, A, lda, x, incx, beta, y,
                                incy, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zgbmv_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zgbmv_batched(handle::rocblas_handle,
                                             trans::rocblas_operation, m::rocblas_int,
                                             n::rocblas_int, kl::rocblas_int,
                                             ku::rocblas_int,
@@ -2085,7 +2085,7 @@ function rocblas_sgbmv_strided_batched(handle, trans, m, n, kl, ku, alpha, A, ld
                                        x, incx, stride_x, beta, y, incy, stride_y,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sgbmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_sgbmv_strided_batched(handle::rocblas_handle,
                                                     trans::rocblas_operation,
                                                     m::rocblas_int, n::rocblas_int,
                                                     kl::rocblas_int, ku::rocblas_int,
@@ -2104,7 +2104,7 @@ function rocblas_dgbmv_strided_batched(handle, trans, m, n, kl, ku, alpha, A, ld
                                        x, incx, stride_x, beta, y, incy, stride_y,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dgbmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dgbmv_strided_batched(handle::rocblas_handle,
                                                     trans::rocblas_operation,
                                                     m::rocblas_int, n::rocblas_int,
                                                     kl::rocblas_int, ku::rocblas_int,
@@ -2123,7 +2123,7 @@ function rocblas_cgbmv_strided_batched(handle, trans, m, n, kl, ku, alpha, A, ld
                                        x, incx, stride_x, beta, y, incy, stride_y,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cgbmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_cgbmv_strided_batched(handle::rocblas_handle,
                                                     trans::rocblas_operation,
                                                     m::rocblas_int, n::rocblas_int,
                                                     kl::rocblas_int, ku::rocblas_int,
@@ -2145,7 +2145,7 @@ function rocblas_zgbmv_strided_batched(handle, trans, m, n, kl, ku, alpha, A, ld
                                        x, incx, stride_x, beta, y, incy, stride_y,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zgbmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zgbmv_strided_batched(handle::rocblas_handle,
                                                     trans::rocblas_operation,
                                                     m::rocblas_int, n::rocblas_int,
                                                     kl::rocblas_int, ku::rocblas_int,
@@ -2165,7 +2165,7 @@ end
 
 function rocblas_sgemv(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sgemv(handle::rocblas_handle, trans::rocblas_operation,
+    @check @ccall librocblas.rocblas_sgemv(handle::rocblas_handle, trans::rocblas_operation,
                                     m::rocblas_int, n::rocblas_int, alpha::Ptr{Cfloat},
                                     A::Ptr{Cfloat}, lda::rocblas_int, x::Ptr{Cfloat},
                                     incx::rocblas_int, beta::Ptr{Cfloat}, y::Ptr{Cfloat},
@@ -2174,7 +2174,7 @@ end
 
 function rocblas_dgemv(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dgemv(handle::rocblas_handle, trans::rocblas_operation,
+    @check @ccall librocblas.rocblas_dgemv(handle::rocblas_handle, trans::rocblas_operation,
                                     m::rocblas_int, n::rocblas_int, alpha::Ptr{Cdouble},
                                     A::Ptr{Cdouble}, lda::rocblas_int, x::Ptr{Cdouble},
                                     incx::rocblas_int, beta::Ptr{Cdouble}, y::Ptr{Cdouble},
@@ -2183,7 +2183,7 @@ end
 
 function rocblas_cgemv(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cgemv(handle::rocblas_handle, trans::rocblas_operation,
+    @check @ccall librocblas.rocblas_cgemv(handle::rocblas_handle, trans::rocblas_operation,
                                     m::rocblas_int, n::rocblas_int,
                                     alpha::Ptr{rocblas_float_complex},
                                     A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -2195,7 +2195,7 @@ end
 
 function rocblas_zgemv(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zgemv(handle::rocblas_handle, trans::rocblas_operation,
+    @check @ccall librocblas.rocblas_zgemv(handle::rocblas_handle, trans::rocblas_operation,
                                     m::rocblas_int, n::rocblas_int,
                                     alpha::Ptr{rocblas_double_complex},
                                     A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -2208,7 +2208,7 @@ end
 function rocblas_sgemv_batched(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sgemv_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_sgemv_batched(handle::rocblas_handle,
                                             trans::rocblas_operation, m::rocblas_int,
                                             n::rocblas_int, alpha::Ptr{Cfloat},
                                             A::Ptr{Ptr{Cfloat}}, lda::rocblas_int,
@@ -2221,7 +2221,7 @@ end
 function rocblas_dgemv_batched(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dgemv_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dgemv_batched(handle::rocblas_handle,
                                             trans::rocblas_operation, m::rocblas_int,
                                             n::rocblas_int, alpha::Ptr{Cdouble},
                                             A::Ptr{Ptr{Cdouble}}, lda::rocblas_int,
@@ -2234,7 +2234,7 @@ end
 function rocblas_cgemv_batched(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cgemv_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_cgemv_batched(handle::rocblas_handle,
                                             trans::rocblas_operation, m::rocblas_int,
                                             n::rocblas_int,
                                             alpha::Ptr{rocblas_float_complex},
@@ -2251,7 +2251,7 @@ end
 function rocblas_zgemv_batched(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zgemv_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zgemv_batched(handle::rocblas_handle,
                                             trans::rocblas_operation, m::rocblas_int,
                                             n::rocblas_int,
                                             alpha::Ptr{rocblas_double_complex},
@@ -2268,7 +2268,7 @@ end
 function rocblas_hshgemv_batched(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy,
                                  batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_hshgemv_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_hshgemv_batched(handle::rocblas_handle,
                                               trans::rocblas_operation, m::rocblas_int,
                                               n::rocblas_int, alpha::Ptr{Cfloat},
                                               A::Ptr{Ptr{rocblas_half}}, lda::rocblas_int,
@@ -2281,7 +2281,7 @@ end
 function rocblas_hssgemv_batched(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy,
                                  batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_hssgemv_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_hssgemv_batched(handle::rocblas_handle,
                                               trans::rocblas_operation, m::rocblas_int,
                                               n::rocblas_int, alpha::Ptr{Cfloat},
                                               A::Ptr{Ptr{rocblas_half}}, lda::rocblas_int,
@@ -2294,7 +2294,7 @@ end
 function rocblas_tstgemv_batched(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy,
                                  batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_tstgemv_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_tstgemv_batched(handle::rocblas_handle,
                                               trans::rocblas_operation, m::rocblas_int,
                                               n::rocblas_int, alpha::Ptr{Cfloat},
                                               A::Ptr{Ptr{rocblas_bfloat16}},
@@ -2309,7 +2309,7 @@ end
 function rocblas_tssgemv_batched(handle, trans, m, n, alpha, A, lda, x, incx, beta, y, incy,
                                  batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_tssgemv_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_tssgemv_batched(handle::rocblas_handle,
                                               trans::rocblas_operation, m::rocblas_int,
                                               n::rocblas_int, alpha::Ptr{Cfloat},
                                               A::Ptr{Ptr{rocblas_bfloat16}},
@@ -2323,7 +2323,7 @@ end
 function rocblas_sgemv_strided_batched(handle, transA, m, n, alpha, A, lda, strideA, x,
                                        incx, stridex, beta, y, incy, stridey, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sgemv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_sgemv_strided_batched(handle::rocblas_handle,
                                                     transA::rocblas_operation,
                                                     m::rocblas_int, n::rocblas_int,
                                                     alpha::Ptr{Cfloat}, A::Ptr{Cfloat},
@@ -2340,7 +2340,7 @@ end
 function rocblas_dgemv_strided_batched(handle, transA, m, n, alpha, A, lda, strideA, x,
                                        incx, stridex, beta, y, incy, stridey, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dgemv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dgemv_strided_batched(handle::rocblas_handle,
                                                     transA::rocblas_operation,
                                                     m::rocblas_int, n::rocblas_int,
                                                     alpha::Ptr{Cdouble}, A::Ptr{Cdouble},
@@ -2357,7 +2357,7 @@ end
 function rocblas_cgemv_strided_batched(handle, transA, m, n, alpha, A, lda, strideA, x,
                                        incx, stridex, beta, y, incy, stridey, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cgemv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_cgemv_strided_batched(handle::rocblas_handle,
                                                     transA::rocblas_operation,
                                                     m::rocblas_int, n::rocblas_int,
                                                     alpha::Ptr{rocblas_float_complex},
@@ -2377,7 +2377,7 @@ end
 function rocblas_zgemv_strided_batched(handle, transA, m, n, alpha, A, lda, strideA, x,
                                        incx, stridex, beta, y, incy, stridey, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zgemv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zgemv_strided_batched(handle::rocblas_handle,
                                                     transA::rocblas_operation,
                                                     m::rocblas_int, n::rocblas_int,
                                                     alpha::Ptr{rocblas_double_complex},
@@ -2397,7 +2397,7 @@ end
 function rocblas_hshgemv_strided_batched(handle, transA, m, n, alpha, A, lda, strideA, x,
                                          incx, stridex, beta, y, incy, stridey, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_hshgemv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_hshgemv_strided_batched(handle::rocblas_handle,
                                                       transA::rocblas_operation,
                                                       m::rocblas_int, n::rocblas_int,
                                                       alpha::Ptr{Cfloat},
@@ -2417,7 +2417,7 @@ end
 function rocblas_hssgemv_strided_batched(handle, transA, m, n, alpha, A, lda, strideA, x,
                                          incx, stridex, beta, y, incy, stridey, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_hssgemv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_hssgemv_strided_batched(handle::rocblas_handle,
                                                       transA::rocblas_operation,
                                                       m::rocblas_int, n::rocblas_int,
                                                       alpha::Ptr{Cfloat},
@@ -2436,7 +2436,7 @@ end
 function rocblas_tstgemv_strided_batched(handle, transA, m, n, alpha, A, lda, strideA, x,
                                          incx, stridex, beta, y, incy, stridey, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_tstgemv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_tstgemv_strided_batched(handle::rocblas_handle,
                                                       transA::rocblas_operation,
                                                       m::rocblas_int, n::rocblas_int,
                                                       alpha::Ptr{Cfloat},
@@ -2456,7 +2456,7 @@ end
 function rocblas_tssgemv_strided_batched(handle, transA, m, n, alpha, A, lda, strideA, x,
                                          incx, stridex, beta, y, incy, stridey, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_tssgemv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_tssgemv_strided_batched(handle::rocblas_handle,
                                                       transA::rocblas_operation,
                                                       m::rocblas_int, n::rocblas_int,
                                                       alpha::Ptr{Cfloat},
@@ -2474,7 +2474,7 @@ end
 
 function rocblas_chbmv(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_chbmv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_chbmv(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, k::rocblas_int,
                                     alpha::Ptr{rocblas_float_complex},
                                     A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -2486,7 +2486,7 @@ end
 
 function rocblas_zhbmv(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zhbmv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zhbmv(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, k::rocblas_int,
                                     alpha::Ptr{rocblas_double_complex},
                                     A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -2499,7 +2499,7 @@ end
 function rocblas_chbmv_batched(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_chbmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_chbmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int, k::rocblas_int,
                                             alpha::Ptr{rocblas_float_complex},
                                             A::Ptr{Ptr{rocblas_float_complex}},
@@ -2515,7 +2515,7 @@ end
 function rocblas_zhbmv_batched(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zhbmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zhbmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int, k::rocblas_int,
                                             alpha::Ptr{rocblas_double_complex},
                                             A::Ptr{Ptr{rocblas_double_complex}},
@@ -2531,7 +2531,7 @@ end
 function rocblas_chbmv_strided_batched(handle, uplo, n, k, alpha, A, lda, stride_A, x, incx,
                                        stride_x, beta, y, incy, stride_y, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_chbmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_chbmv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     k::rocblas_int,
                                                     alpha::Ptr{rocblas_float_complex},
@@ -2551,7 +2551,7 @@ end
 function rocblas_zhbmv_strided_batched(handle, uplo, n, k, alpha, A, lda, stride_A, x, incx,
                                        stride_x, beta, y, incy, stride_y, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zhbmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zhbmv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     k::rocblas_int,
                                                     alpha::Ptr{rocblas_double_complex},
@@ -2570,7 +2570,7 @@ end
 
 function rocblas_chemv(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_chemv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_chemv(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, alpha::Ptr{rocblas_float_complex},
                                     A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                     x::Ptr{rocblas_float_complex}, incx::rocblas_int,
@@ -2581,7 +2581,7 @@ end
 
 function rocblas_zhemv(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zhemv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zhemv(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, alpha::Ptr{rocblas_double_complex},
                                     A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                     x::Ptr{rocblas_double_complex}, incx::rocblas_int,
@@ -2593,7 +2593,7 @@ end
 function rocblas_chemv_batched(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_chemv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_chemv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int,
                                             alpha::Ptr{rocblas_float_complex},
                                             A::Ptr{Ptr{rocblas_float_complex}},
@@ -2609,7 +2609,7 @@ end
 function rocblas_zhemv_batched(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zhemv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zhemv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int,
                                             alpha::Ptr{rocblas_double_complex},
                                             A::Ptr{Ptr{rocblas_double_complex}},
@@ -2625,7 +2625,7 @@ end
 function rocblas_chemv_strided_batched(handle, uplo, n, alpha, A, lda, stride_A, x, incx,
                                        stride_x, beta, y, incy, stride_y, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_chemv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_chemv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     alpha::Ptr{rocblas_float_complex},
                                                     A::Ptr{rocblas_float_complex},
@@ -2644,7 +2644,7 @@ end
 function rocblas_zhemv_strided_batched(handle, uplo, n, alpha, A, lda, stride_A, x, incx,
                                        stride_x, beta, y, incy, stride_y, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zhemv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zhemv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     alpha::Ptr{rocblas_double_complex},
                                                     A::Ptr{rocblas_double_complex},
@@ -2662,7 +2662,7 @@ end
 
 function rocblas_cher(handle, uplo, n, alpha, x, incx, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cher(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_cher(handle::rocblas_handle, uplo::rocblas_fill,
                                    n::rocblas_int, alpha::Ptr{Cfloat},
                                    x::Ptr{rocblas_float_complex}, incx::rocblas_int,
                                    A::Ptr{rocblas_float_complex},
@@ -2671,7 +2671,7 @@ end
 
 function rocblas_zher(handle, uplo, n, alpha, x, incx, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zher(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zher(handle::rocblas_handle, uplo::rocblas_fill,
                                    n::rocblas_int, alpha::Ptr{Cdouble},
                                    x::Ptr{rocblas_double_complex}, incx::rocblas_int,
                                    A::Ptr{rocblas_double_complex},
@@ -2680,7 +2680,7 @@ end
 
 function rocblas_cher_batched(handle, uplo, n, alpha, x, incx, A, lda, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cher_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_cher_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                            n::rocblas_int, alpha::Ptr{Cfloat},
                                            x::Ptr{Ptr{rocblas_float_complex}},
                                            incx::rocblas_int,
@@ -2691,7 +2691,7 @@ end
 
 function rocblas_zher_batched(handle, uplo, n, alpha, x, incx, A, lda, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zher_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zher_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                            n::rocblas_int, alpha::Ptr{Cdouble},
                                            x::Ptr{Ptr{rocblas_double_complex}},
                                            incx::rocblas_int,
@@ -2703,7 +2703,7 @@ end
 function rocblas_cher_strided_batched(handle, uplo, n, alpha, x, incx, stride_x, A, lda,
                                       stride_A, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cher_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_cher_strided_batched(handle::rocblas_handle,
                                                    uplo::rocblas_fill, n::rocblas_int,
                                                    alpha::Ptr{Cfloat},
                                                    x::Ptr{rocblas_float_complex},
@@ -2718,7 +2718,7 @@ end
 function rocblas_zher_strided_batched(handle, uplo, n, alpha, x, incx, stride_x, A, lda,
                                       stride_A, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zher_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zher_strided_batched(handle::rocblas_handle,
                                                    uplo::rocblas_fill, n::rocblas_int,
                                                    alpha::Ptr{Cdouble},
                                                    x::Ptr{rocblas_double_complex},
@@ -2732,7 +2732,7 @@ end
 
 function rocblas_cher2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cher2(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_cher2(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, alpha::Ptr{rocblas_float_complex},
                                     x::Ptr{rocblas_float_complex}, incx::rocblas_int,
                                     y::Ptr{rocblas_float_complex}, incy::rocblas_int,
@@ -2742,7 +2742,7 @@ end
 
 function rocblas_zher2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zher2(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zher2(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, alpha::Ptr{rocblas_double_complex},
                                     x::Ptr{rocblas_double_complex}, incx::rocblas_int,
                                     y::Ptr{rocblas_double_complex}, incy::rocblas_int,
@@ -2753,7 +2753,7 @@ end
 function rocblas_cher2_batched(handle, uplo, n, alpha, x, incx, y, incy, A, lda,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cher2_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_cher2_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int,
                                             alpha::Ptr{rocblas_float_complex},
                                             x::Ptr{Ptr{rocblas_float_complex}},
@@ -2768,7 +2768,7 @@ end
 function rocblas_zher2_batched(handle, uplo, n, alpha, x, incx, y, incy, A, lda,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zher2_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zher2_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int,
                                             alpha::Ptr{rocblas_double_complex},
                                             x::Ptr{Ptr{rocblas_double_complex}},
@@ -2783,7 +2783,7 @@ end
 function rocblas_cher2_strided_batched(handle, uplo, n, alpha, x, incx, stride_x, y, incy,
                                        stride_y, A, lda, stride_A, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cher2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_cher2_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     alpha::Ptr{rocblas_float_complex},
                                                     x::Ptr{rocblas_float_complex},
@@ -2801,7 +2801,7 @@ end
 function rocblas_zher2_strided_batched(handle, uplo, n, alpha, x, incx, stride_x, y, incy,
                                        stride_y, A, lda, stride_A, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zher2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zher2_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     alpha::Ptr{rocblas_double_complex},
                                                     x::Ptr{rocblas_double_complex},
@@ -2818,7 +2818,7 @@ end
 
 function rocblas_chpmv(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_chpmv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_chpmv(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, alpha::Ptr{rocblas_float_complex},
                                     AP::Ptr{rocblas_float_complex},
                                     x::Ptr{rocblas_float_complex}, incx::rocblas_int,
@@ -2829,7 +2829,7 @@ end
 
 function rocblas_zhpmv(handle, uplo, n, alpha, AP, x, incx, beta, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zhpmv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zhpmv(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, alpha::Ptr{rocblas_double_complex},
                                     AP::Ptr{rocblas_double_complex},
                                     x::Ptr{rocblas_double_complex}, incx::rocblas_int,
@@ -2841,7 +2841,7 @@ end
 function rocblas_chpmv_batched(handle, uplo, n, alpha, AP, x, incx, beta, y, incy,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_chpmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_chpmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int,
                                             alpha::Ptr{rocblas_float_complex},
                                             AP::Ptr{Ptr{rocblas_float_complex}},
@@ -2856,7 +2856,7 @@ end
 function rocblas_zhpmv_batched(handle, uplo, n, alpha, AP, x, incx, beta, y, incy,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zhpmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zhpmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int,
                                             alpha::Ptr{rocblas_double_complex},
                                             AP::Ptr{Ptr{rocblas_double_complex}},
@@ -2871,7 +2871,7 @@ end
 function rocblas_chpmv_strided_batched(handle, uplo, n, alpha, AP, stride_A, x, incx,
                                        stride_x, beta, y, incy, stride_y, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_chpmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_chpmv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     alpha::Ptr{rocblas_float_complex},
                                                     AP::Ptr{rocblas_float_complex},
@@ -2889,7 +2889,7 @@ end
 function rocblas_zhpmv_strided_batched(handle, uplo, n, alpha, AP, stride_A, x, incx,
                                        stride_x, beta, y, incy, stride_y, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zhpmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zhpmv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     alpha::Ptr{rocblas_double_complex},
                                                     AP::Ptr{rocblas_double_complex},
@@ -2906,7 +2906,7 @@ end
 
 function rocblas_chpr(handle, uplo, n, alpha, x, incx, AP)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_chpr(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_chpr(handle::rocblas_handle, uplo::rocblas_fill,
                                    n::rocblas_int, alpha::Ptr{Cfloat},
                                    x::Ptr{rocblas_float_complex}, incx::rocblas_int,
                                    AP::Ptr{rocblas_float_complex})::rocblas_status
@@ -2914,7 +2914,7 @@ end
 
 function rocblas_zhpr(handle, uplo, n, alpha, x, incx, AP)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zhpr(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zhpr(handle::rocblas_handle, uplo::rocblas_fill,
                                    n::rocblas_int, alpha::Ptr{Cdouble},
                                    x::Ptr{rocblas_double_complex}, incx::rocblas_int,
                                    AP::Ptr{rocblas_double_complex})::rocblas_status
@@ -2922,7 +2922,7 @@ end
 
 function rocblas_chpr_batched(handle, uplo, n, alpha, x, incx, AP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_chpr_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_chpr_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                            n::rocblas_int, alpha::Ptr{Cfloat},
                                            x::Ptr{Ptr{rocblas_float_complex}},
                                            incx::rocblas_int,
@@ -2932,7 +2932,7 @@ end
 
 function rocblas_zhpr_batched(handle, uplo, n, alpha, x, incx, AP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zhpr_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zhpr_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                            n::rocblas_int, alpha::Ptr{Cdouble},
                                            x::Ptr{Ptr{rocblas_double_complex}},
                                            incx::rocblas_int,
@@ -2943,7 +2943,7 @@ end
 function rocblas_chpr_strided_batched(handle, uplo, n, alpha, x, incx, stride_x, AP,
                                       stride_A, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_chpr_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_chpr_strided_batched(handle::rocblas_handle,
                                                    uplo::rocblas_fill, n::rocblas_int,
                                                    alpha::Ptr{Cfloat},
                                                    x::Ptr{rocblas_float_complex},
@@ -2957,7 +2957,7 @@ end
 function rocblas_zhpr_strided_batched(handle, uplo, n, alpha, x, incx, stride_x, AP,
                                       stride_A, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zhpr_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zhpr_strided_batched(handle::rocblas_handle,
                                                    uplo::rocblas_fill, n::rocblas_int,
                                                    alpha::Ptr{Cdouble},
                                                    x::Ptr{rocblas_double_complex},
@@ -2970,7 +2970,7 @@ end
 
 function rocblas_chpr2(handle, uplo, n, alpha, x, incx, y, incy, AP)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_chpr2(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_chpr2(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, alpha::Ptr{rocblas_float_complex},
                                     x::Ptr{rocblas_float_complex}, incx::rocblas_int,
                                     y::Ptr{rocblas_float_complex}, incy::rocblas_int,
@@ -2979,7 +2979,7 @@ end
 
 function rocblas_zhpr2(handle, uplo, n, alpha, x, incx, y, incy, AP)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zhpr2(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zhpr2(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, alpha::Ptr{rocblas_double_complex},
                                     x::Ptr{rocblas_double_complex}, incx::rocblas_int,
                                     y::Ptr{rocblas_double_complex}, incy::rocblas_int,
@@ -2988,7 +2988,7 @@ end
 
 function rocblas_chpr2_batched(handle, uplo, n, alpha, x, incx, y, incy, AP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_chpr2_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_chpr2_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int,
                                             alpha::Ptr{rocblas_float_complex},
                                             x::Ptr{Ptr{rocblas_float_complex}},
@@ -3001,7 +3001,7 @@ end
 
 function rocblas_zhpr2_batched(handle, uplo, n, alpha, x, incx, y, incy, AP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zhpr2_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zhpr2_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int,
                                             alpha::Ptr{rocblas_double_complex},
                                             x::Ptr{Ptr{rocblas_double_complex}},
@@ -3015,7 +3015,7 @@ end
 function rocblas_chpr2_strided_batched(handle, uplo, n, alpha, x, incx, stride_x, y, incy,
                                        stride_y, AP, stride_A, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_chpr2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_chpr2_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     alpha::Ptr{rocblas_float_complex},
                                                     x::Ptr{rocblas_float_complex},
@@ -3032,7 +3032,7 @@ end
 function rocblas_zhpr2_strided_batched(handle, uplo, n, alpha, x, incx, stride_x, y, incy,
                                        stride_y, AP, stride_A, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zhpr2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zhpr2_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     alpha::Ptr{rocblas_double_complex},
                                                     x::Ptr{rocblas_double_complex},
@@ -3048,7 +3048,7 @@ end
 
 function rocblas_strmv(handle, uplo, transA, diag, m, A, lda, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_strmv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_strmv(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, diag::rocblas_diagonal,
                                     m::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                     x::Ptr{Cfloat}, incx::rocblas_int)::rocblas_status
@@ -3056,7 +3056,7 @@ end
 
 function rocblas_dtrmv(handle, uplo, transA, diag, m, A, lda, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtrmv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dtrmv(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, diag::rocblas_diagonal,
                                     m::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                     x::Ptr{Cdouble}, incx::rocblas_int)::rocblas_status
@@ -3064,7 +3064,7 @@ end
 
 function rocblas_ctrmv(handle, uplo, transA, diag, m, A, lda, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctrmv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ctrmv(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, diag::rocblas_diagonal,
                                     m::rocblas_int, A::Ptr{rocblas_float_complex},
                                     lda::rocblas_int, x::Ptr{rocblas_float_complex},
@@ -3073,7 +3073,7 @@ end
 
 function rocblas_ztrmv(handle, uplo, transA, diag, m, A, lda, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztrmv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ztrmv(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, diag::rocblas_diagonal,
                                     m::rocblas_int, A::Ptr{rocblas_double_complex},
                                     lda::rocblas_int, x::Ptr{rocblas_double_complex},
@@ -3082,7 +3082,7 @@ end
 
 function rocblas_strmv_batched(handle, uplo, transA, diag, m, A, lda, x, incx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_strmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_strmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             A::Ptr{Ptr{Cfloat}}, lda::rocblas_int,
@@ -3092,7 +3092,7 @@ end
 
 function rocblas_dtrmv_batched(handle, uplo, transA, diag, m, A, lda, x, incx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtrmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dtrmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             A::Ptr{Ptr{Cdouble}}, lda::rocblas_int,
@@ -3102,7 +3102,7 @@ end
 
 function rocblas_ctrmv_batched(handle, uplo, transA, diag, m, A, lda, x, incx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctrmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ctrmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             A::Ptr{Ptr{rocblas_float_complex}},
@@ -3114,7 +3114,7 @@ end
 
 function rocblas_ztrmv_batched(handle, uplo, transA, diag, m, A, lda, x, incx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztrmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ztrmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             A::Ptr{Ptr{rocblas_double_complex}},
@@ -3127,7 +3127,7 @@ end
 function rocblas_strmv_strided_batched(handle, uplo, transA, diag, m, A, lda, stride_A, x,
                                        incx, stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_strmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_strmv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -3141,7 +3141,7 @@ end
 function rocblas_dtrmv_strided_batched(handle, uplo, transA, diag, m, A, lda, stride_A, x,
                                        incx, stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtrmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dtrmv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -3155,7 +3155,7 @@ end
 function rocblas_ctrmv_strided_batched(handle, uplo, transA, diag, m, A, lda, stride_A, x,
                                        incx, stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctrmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ctrmv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -3171,7 +3171,7 @@ end
 function rocblas_ztrmv_strided_batched(handle, uplo, transA, diag, m, A, lda, stride_A, x,
                                        incx, stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztrmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ztrmv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -3186,7 +3186,7 @@ end
 
 function rocblas_stpmv(handle, uplo, transA, diag, m, A, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_stpmv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_stpmv(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, diag::rocblas_diagonal,
                                     m::rocblas_int, A::Ptr{Cfloat}, x::Ptr{Cfloat},
                                     incx::rocblas_int)::rocblas_status
@@ -3194,7 +3194,7 @@ end
 
 function rocblas_dtpmv(handle, uplo, transA, diag, m, A, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtpmv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dtpmv(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, diag::rocblas_diagonal,
                                     m::rocblas_int, A::Ptr{Cdouble}, x::Ptr{Cdouble},
                                     incx::rocblas_int)::rocblas_status
@@ -3202,7 +3202,7 @@ end
 
 function rocblas_ctpmv(handle, uplo, transA, diag, m, A, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctpmv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ctpmv(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, diag::rocblas_diagonal,
                                     m::rocblas_int, A::Ptr{rocblas_float_complex},
                                     x::Ptr{rocblas_float_complex},
@@ -3211,7 +3211,7 @@ end
 
 function rocblas_ztpmv(handle, uplo, transA, diag, m, A, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztpmv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ztpmv(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, diag::rocblas_diagonal,
                                     m::rocblas_int, A::Ptr{rocblas_double_complex},
                                     x::Ptr{rocblas_double_complex},
@@ -3220,7 +3220,7 @@ end
 
 function rocblas_stpmv_batched(handle, uplo, transA, diag, m, A, x, incx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_stpmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_stpmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             A::Ptr{Ptr{Cfloat}}, x::Ptr{Ptr{Cfloat}},
@@ -3230,7 +3230,7 @@ end
 
 function rocblas_dtpmv_batched(handle, uplo, transA, diag, m, A, x, incx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtpmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dtpmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             A::Ptr{Ptr{Cdouble}}, x::Ptr{Ptr{Cdouble}},
@@ -3240,7 +3240,7 @@ end
 
 function rocblas_ctpmv_batched(handle, uplo, transA, diag, m, A, x, incx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctpmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ctpmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             A::Ptr{Ptr{rocblas_float_complex}},
@@ -3251,7 +3251,7 @@ end
 
 function rocblas_ztpmv_batched(handle, uplo, transA, diag, m, A, x, incx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztpmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ztpmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             A::Ptr{Ptr{rocblas_double_complex}},
@@ -3263,7 +3263,7 @@ end
 function rocblas_stpmv_strided_batched(handle, uplo, transA, diag, m, A, stride_A, x, incx,
                                        stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_stpmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_stpmv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -3277,7 +3277,7 @@ end
 function rocblas_dtpmv_strided_batched(handle, uplo, transA, diag, m, A, stride_A, x, incx,
                                        stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtpmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dtpmv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -3291,7 +3291,7 @@ end
 function rocblas_ctpmv_strided_batched(handle, uplo, transA, diag, m, A, stride_A, x, incx,
                                        stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctpmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ctpmv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -3306,7 +3306,7 @@ end
 function rocblas_ztpmv_strided_batched(handle, uplo, transA, diag, m, A, stride_A, x, incx,
                                        stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztpmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ztpmv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -3320,7 +3320,7 @@ end
 
 function rocblas_stbmv(handle, uplo, trans, diag, m, k, A, lda, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_stbmv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_stbmv(handle::rocblas_handle, uplo::rocblas_fill,
                                     trans::rocblas_operation, diag::rocblas_diagonal,
                                     m::rocblas_int, k::rocblas_int, A::Ptr{Cfloat},
                                     lda::rocblas_int, x::Ptr{Cfloat},
@@ -3329,7 +3329,7 @@ end
 
 function rocblas_dtbmv(handle, uplo, trans, diag, m, k, A, lda, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtbmv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dtbmv(handle::rocblas_handle, uplo::rocblas_fill,
                                     trans::rocblas_operation, diag::rocblas_diagonal,
                                     m::rocblas_int, k::rocblas_int, A::Ptr{Cdouble},
                                     lda::rocblas_int, x::Ptr{Cdouble},
@@ -3338,7 +3338,7 @@ end
 
 function rocblas_ctbmv(handle, uplo, trans, diag, m, k, A, lda, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctbmv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ctbmv(handle::rocblas_handle, uplo::rocblas_fill,
                                     trans::rocblas_operation, diag::rocblas_diagonal,
                                     m::rocblas_int, k::rocblas_int,
                                     A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -3348,7 +3348,7 @@ end
 
 function rocblas_ztbmv(handle, uplo, trans, diag, m, k, A, lda, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztbmv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ztbmv(handle::rocblas_handle, uplo::rocblas_fill,
                                     trans::rocblas_operation, diag::rocblas_diagonal,
                                     m::rocblas_int, k::rocblas_int,
                                     A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -3359,7 +3359,7 @@ end
 function rocblas_stbmv_batched(handle, uplo, trans, diag, m, k, A, lda, x, incx,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_stbmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_stbmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             trans::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             k::rocblas_int, A::Ptr{Ptr{Cfloat}},
@@ -3371,7 +3371,7 @@ end
 function rocblas_dtbmv_batched(handle, uplo, trans, diag, m, k, A, lda, x, incx,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtbmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dtbmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             trans::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             k::rocblas_int, A::Ptr{Ptr{Cdouble}},
@@ -3383,7 +3383,7 @@ end
 function rocblas_ctbmv_batched(handle, uplo, trans, diag, m, k, A, lda, x, incx,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctbmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ctbmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             trans::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             k::rocblas_int,
@@ -3397,7 +3397,7 @@ end
 function rocblas_ztbmv_batched(handle, uplo, trans, diag, m, k, A, lda, x, incx,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztbmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ztbmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             trans::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             k::rocblas_int,
@@ -3411,7 +3411,7 @@ end
 function rocblas_stbmv_strided_batched(handle, uplo, trans, diag, m, k, A, lda, stride_A, x,
                                        incx, stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_stbmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_stbmv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     trans::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -3426,7 +3426,7 @@ end
 function rocblas_dtbmv_strided_batched(handle, uplo, trans, diag, m, k, A, lda, stride_A, x,
                                        incx, stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtbmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dtbmv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     trans::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -3441,7 +3441,7 @@ end
 function rocblas_ctbmv_strided_batched(handle, uplo, trans, diag, m, k, A, lda, stride_A, x,
                                        incx, stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctbmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ctbmv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     trans::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -3458,7 +3458,7 @@ end
 function rocblas_ztbmv_strided_batched(handle, uplo, trans, diag, m, k, A, lda, stride_A, x,
                                        incx, stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztbmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ztbmv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     trans::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -3474,7 +3474,7 @@ end
 
 function rocblas_stbsv(handle, uplo, transA, diag, n, k, A, lda, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_stbsv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_stbsv(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, diag::rocblas_diagonal,
                                     n::rocblas_int, k::rocblas_int, A::Ptr{Cfloat},
                                     lda::rocblas_int, x::Ptr{Cfloat},
@@ -3483,7 +3483,7 @@ end
 
 function rocblas_dtbsv(handle, uplo, transA, diag, n, k, A, lda, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtbsv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dtbsv(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, diag::rocblas_diagonal,
                                     n::rocblas_int, k::rocblas_int, A::Ptr{Cdouble},
                                     lda::rocblas_int, x::Ptr{Cdouble},
@@ -3492,7 +3492,7 @@ end
 
 function rocblas_ctbsv(handle, uplo, transA, diag, n, k, A, lda, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctbsv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ctbsv(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, diag::rocblas_diagonal,
                                     n::rocblas_int, k::rocblas_int,
                                     A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -3502,7 +3502,7 @@ end
 
 function rocblas_ztbsv(handle, uplo, transA, diag, n, k, A, lda, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztbsv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ztbsv(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, diag::rocblas_diagonal,
                                     n::rocblas_int, k::rocblas_int,
                                     A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -3513,7 +3513,7 @@ end
 function rocblas_stbsv_batched(handle, uplo, transA, diag, n, k, A, lda, x, incx,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_stbsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_stbsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation,
                                             diag::rocblas_diagonal, n::rocblas_int,
                                             k::rocblas_int, A::Ptr{Ptr{Cfloat}},
@@ -3525,7 +3525,7 @@ end
 function rocblas_dtbsv_batched(handle, uplo, transA, diag, n, k, A, lda, x, incx,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtbsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dtbsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation,
                                             diag::rocblas_diagonal, n::rocblas_int,
                                             k::rocblas_int, A::Ptr{Ptr{Cdouble}},
@@ -3537,7 +3537,7 @@ end
 function rocblas_ctbsv_batched(handle, uplo, transA, diag, n, k, A, lda, x, incx,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctbsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ctbsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation,
                                             diag::rocblas_diagonal, n::rocblas_int,
                                             k::rocblas_int,
@@ -3551,7 +3551,7 @@ end
 function rocblas_ztbsv_batched(handle, uplo, transA, diag, n, k, A, lda, x, incx,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztbsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ztbsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation,
                                             diag::rocblas_diagonal, n::rocblas_int,
                                             k::rocblas_int,
@@ -3565,7 +3565,7 @@ end
 function rocblas_stbsv_strided_batched(handle, uplo, transA, diag, n, k, A, lda, stride_A,
                                        x, incx, stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_stbsv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_stbsv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, n::rocblas_int,
@@ -3580,7 +3580,7 @@ end
 function rocblas_dtbsv_strided_batched(handle, uplo, transA, diag, n, k, A, lda, stride_A,
                                        x, incx, stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtbsv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dtbsv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, n::rocblas_int,
@@ -3595,7 +3595,7 @@ end
 function rocblas_ctbsv_strided_batched(handle, uplo, transA, diag, n, k, A, lda, stride_A,
                                        x, incx, stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctbsv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ctbsv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, n::rocblas_int,
@@ -3612,7 +3612,7 @@ end
 function rocblas_ztbsv_strided_batched(handle, uplo, transA, diag, n, k, A, lda, stride_A,
                                        x, incx, stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztbsv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ztbsv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, n::rocblas_int,
@@ -3628,7 +3628,7 @@ end
 
 function rocblas_strsv(handle, uplo, transA, diag, m, A, lda, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_strsv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_strsv(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, diag::rocblas_diagonal,
                                     m::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                     x::Ptr{Cfloat}, incx::rocblas_int)::rocblas_status
@@ -3636,7 +3636,7 @@ end
 
 function rocblas_dtrsv(handle, uplo, transA, diag, m, A, lda, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtrsv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dtrsv(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, diag::rocblas_diagonal,
                                     m::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                     x::Ptr{Cdouble}, incx::rocblas_int)::rocblas_status
@@ -3644,7 +3644,7 @@ end
 
 function rocblas_ctrsv(handle, uplo, transA, diag, m, A, lda, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctrsv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ctrsv(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, diag::rocblas_diagonal,
                                     m::rocblas_int, A::Ptr{rocblas_float_complex},
                                     lda::rocblas_int, x::Ptr{rocblas_float_complex},
@@ -3653,7 +3653,7 @@ end
 
 function rocblas_ztrsv(handle, uplo, transA, diag, m, A, lda, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztrsv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ztrsv(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, diag::rocblas_diagonal,
                                     m::rocblas_int, A::Ptr{rocblas_double_complex},
                                     lda::rocblas_int, x::Ptr{rocblas_double_complex},
@@ -3662,7 +3662,7 @@ end
 
 function rocblas_strsv_batched(handle, uplo, transA, diag, m, A, lda, x, incx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_strsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_strsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             A::Ptr{Ptr{Cfloat}}, lda::rocblas_int,
@@ -3672,7 +3672,7 @@ end
 
 function rocblas_dtrsv_batched(handle, uplo, transA, diag, m, A, lda, x, incx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtrsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dtrsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             A::Ptr{Ptr{Cdouble}}, lda::rocblas_int,
@@ -3682,7 +3682,7 @@ end
 
 function rocblas_ctrsv_batched(handle, uplo, transA, diag, m, A, lda, x, incx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctrsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ctrsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             A::Ptr{Ptr{rocblas_float_complex}},
@@ -3694,7 +3694,7 @@ end
 
 function rocblas_ztrsv_batched(handle, uplo, transA, diag, m, A, lda, x, incx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztrsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ztrsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             A::Ptr{Ptr{rocblas_double_complex}},
@@ -3707,7 +3707,7 @@ end
 function rocblas_strsv_strided_batched(handle, uplo, transA, diag, m, A, lda, stride_A, x,
                                        incx, stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_strsv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_strsv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -3721,7 +3721,7 @@ end
 function rocblas_dtrsv_strided_batched(handle, uplo, transA, diag, m, A, lda, stride_A, x,
                                        incx, stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtrsv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dtrsv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -3735,7 +3735,7 @@ end
 function rocblas_ctrsv_strided_batched(handle, uplo, transA, diag, m, A, lda, stride_A, x,
                                        incx, stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctrsv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ctrsv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -3751,7 +3751,7 @@ end
 function rocblas_ztrsv_strided_batched(handle, uplo, transA, diag, m, A, lda, stride_A, x,
                                        incx, stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztrsv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ztrsv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -3766,7 +3766,7 @@ end
 
 function rocblas_stpsv(handle, uplo, transA, diag, n, AP, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_stpsv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_stpsv(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, diag::rocblas_diagonal,
                                     n::rocblas_int, AP::Ptr{Cfloat}, x::Ptr{Cfloat},
                                     incx::rocblas_int)::rocblas_status
@@ -3774,7 +3774,7 @@ end
 
 function rocblas_dtpsv(handle, uplo, transA, diag, n, AP, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtpsv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dtpsv(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, diag::rocblas_diagonal,
                                     n::rocblas_int, AP::Ptr{Cdouble}, x::Ptr{Cdouble},
                                     incx::rocblas_int)::rocblas_status
@@ -3782,7 +3782,7 @@ end
 
 function rocblas_ctpsv(handle, uplo, transA, diag, n, AP, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctpsv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ctpsv(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, diag::rocblas_diagonal,
                                     n::rocblas_int, AP::Ptr{rocblas_float_complex},
                                     x::Ptr{rocblas_float_complex},
@@ -3791,7 +3791,7 @@ end
 
 function rocblas_ztpsv(handle, uplo, transA, diag, n, AP, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztpsv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ztpsv(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, diag::rocblas_diagonal,
                                     n::rocblas_int, AP::Ptr{rocblas_double_complex},
                                     x::Ptr{rocblas_double_complex},
@@ -3800,7 +3800,7 @@ end
 
 function rocblas_stpsv_batched(handle, uplo, transA, diag, n, AP, x, incx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_stpsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_stpsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation,
                                             diag::rocblas_diagonal, n::rocblas_int,
                                             AP::Ptr{Ptr{Cfloat}}, x::Ptr{Ptr{Cfloat}},
@@ -3810,7 +3810,7 @@ end
 
 function rocblas_dtpsv_batched(handle, uplo, transA, diag, n, AP, x, incx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtpsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dtpsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation,
                                             diag::rocblas_diagonal, n::rocblas_int,
                                             AP::Ptr{Ptr{Cdouble}}, x::Ptr{Ptr{Cdouble}},
@@ -3820,7 +3820,7 @@ end
 
 function rocblas_ctpsv_batched(handle, uplo, transA, diag, n, AP, x, incx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctpsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ctpsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation,
                                             diag::rocblas_diagonal, n::rocblas_int,
                                             AP::Ptr{Ptr{rocblas_float_complex}},
@@ -3831,7 +3831,7 @@ end
 
 function rocblas_ztpsv_batched(handle, uplo, transA, diag, n, AP, x, incx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztpsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ztpsv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation,
                                             diag::rocblas_diagonal, n::rocblas_int,
                                             AP::Ptr{Ptr{rocblas_double_complex}},
@@ -3843,7 +3843,7 @@ end
 function rocblas_stpsv_strided_batched(handle, uplo, transA, diag, n, AP, stride_A, x, incx,
                                        stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_stpsv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_stpsv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, n::rocblas_int,
@@ -3857,7 +3857,7 @@ end
 function rocblas_dtpsv_strided_batched(handle, uplo, transA, diag, n, AP, stride_A, x, incx,
                                        stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtpsv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dtpsv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, n::rocblas_int,
@@ -3871,7 +3871,7 @@ end
 function rocblas_ctpsv_strided_batched(handle, uplo, transA, diag, n, AP, stride_A, x, incx,
                                        stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctpsv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ctpsv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, n::rocblas_int,
@@ -3886,7 +3886,7 @@ end
 function rocblas_ztpsv_strided_batched(handle, uplo, transA, diag, n, AP, stride_A, x, incx,
                                        stride_x, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztpsv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ztpsv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, n::rocblas_int,
@@ -3900,7 +3900,7 @@ end
 
 function rocblas_ssymv(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssymv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ssymv(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, alpha::Ptr{Cfloat}, A::Ptr{Cfloat},
                                     lda::rocblas_int, x::Ptr{Cfloat}, incx::rocblas_int,
                                     beta::Ptr{Cfloat}, y::Ptr{Cfloat},
@@ -3909,7 +3909,7 @@ end
 
 function rocblas_dsymv(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsymv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dsymv(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, alpha::Ptr{Cdouble}, A::Ptr{Cdouble},
                                     lda::rocblas_int, x::Ptr{Cdouble}, incx::rocblas_int,
                                     beta::Ptr{Cdouble}, y::Ptr{Cdouble},
@@ -3918,7 +3918,7 @@ end
 
 function rocblas_csymv(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csymv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_csymv(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, alpha::Ptr{rocblas_float_complex},
                                     A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                     x::Ptr{rocblas_float_complex}, incx::rocblas_int,
@@ -3929,7 +3929,7 @@ end
 
 function rocblas_zsymv(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zsymv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zsymv(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, alpha::Ptr{rocblas_double_complex},
                                     A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                     x::Ptr{rocblas_double_complex}, incx::rocblas_int,
@@ -3941,7 +3941,7 @@ end
 function rocblas_ssymv_batched(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssymv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ssymv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int, alpha::Ptr{Cfloat},
                                             A::Ptr{Ptr{Cfloat}}, lda::rocblas_int,
                                             x::Ptr{Ptr{Cfloat}}, incx::rocblas_int,
@@ -3953,7 +3953,7 @@ end
 function rocblas_dsymv_batched(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsymv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dsymv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int, alpha::Ptr{Cdouble},
                                             A::Ptr{Ptr{Cdouble}}, lda::rocblas_int,
                                             x::Ptr{Ptr{Cdouble}}, incx::rocblas_int,
@@ -3965,7 +3965,7 @@ end
 function rocblas_csymv_batched(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csymv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_csymv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int,
                                             alpha::Ptr{rocblas_float_complex},
                                             A::Ptr{Ptr{rocblas_float_complex}},
@@ -3981,7 +3981,7 @@ end
 function rocblas_zsymv_batched(handle, uplo, n, alpha, A, lda, x, incx, beta, y, incy,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zsymv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zsymv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int,
                                             alpha::Ptr{rocblas_double_complex},
                                             A::Ptr{Ptr{rocblas_double_complex}},
@@ -3997,7 +3997,7 @@ end
 function rocblas_ssymv_strided_batched(handle, uplo, n, alpha, A, lda, strideA, x, incx,
                                        stridex, beta, y, incy, stridey, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssymv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ssymv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     alpha::Ptr{Cfloat}, A::Ptr{Cfloat},
                                                     lda::rocblas_int,
@@ -4013,7 +4013,7 @@ end
 function rocblas_dsymv_strided_batched(handle, uplo, n, alpha, A, lda, strideA, x, incx,
                                        stridex, beta, y, incy, stridey, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsymv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dsymv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     alpha::Ptr{Cdouble}, A::Ptr{Cdouble},
                                                     lda::rocblas_int,
@@ -4029,7 +4029,7 @@ end
 function rocblas_csymv_strided_batched(handle, uplo, n, alpha, A, lda, strideA, x, incx,
                                        stridex, beta, y, incy, stridey, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csymv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_csymv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     alpha::Ptr{rocblas_float_complex},
                                                     A::Ptr{rocblas_float_complex},
@@ -4048,7 +4048,7 @@ end
 function rocblas_zsymv_strided_batched(handle, uplo, n, alpha, A, lda, strideA, x, incx,
                                        stridex, beta, y, incy, stridey, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zsymv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zsymv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     alpha::Ptr{rocblas_double_complex},
                                                     A::Ptr{rocblas_double_complex},
@@ -4066,7 +4066,7 @@ end
 
 function rocblas_sspmv(handle, uplo, n, alpha, A, x, incx, beta, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sspmv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_sspmv(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, alpha::Ptr{Cfloat}, A::Ptr{Cfloat},
                                     x::Ptr{Cfloat}, incx::rocblas_int, beta::Ptr{Cfloat},
                                     y::Ptr{Cfloat}, incy::rocblas_int)::rocblas_status
@@ -4074,7 +4074,7 @@ end
 
 function rocblas_dspmv(handle, uplo, n, alpha, A, x, incx, beta, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dspmv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dspmv(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, alpha::Ptr{Cdouble}, A::Ptr{Cdouble},
                                     x::Ptr{Cdouble}, incx::rocblas_int, beta::Ptr{Cdouble},
                                     y::Ptr{Cdouble}, incy::rocblas_int)::rocblas_status
@@ -4083,7 +4083,7 @@ end
 function rocblas_sspmv_batched(handle, uplo, n, alpha, A, x, incx, beta, y, incy,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sspmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_sspmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int, alpha::Ptr{Cfloat},
                                             A::Ptr{Ptr{Cfloat}}, x::Ptr{Ptr{Cfloat}},
                                             incx::rocblas_int, beta::Ptr{Cfloat},
@@ -4094,7 +4094,7 @@ end
 function rocblas_dspmv_batched(handle, uplo, n, alpha, A, x, incx, beta, y, incy,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dspmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dspmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int, alpha::Ptr{Cdouble},
                                             A::Ptr{Ptr{Cdouble}}, x::Ptr{Ptr{Cdouble}},
                                             incx::rocblas_int, beta::Ptr{Cdouble},
@@ -4105,7 +4105,7 @@ end
 function rocblas_sspmv_strided_batched(handle, uplo, n, alpha, A, strideA, x, incx, stridex,
                                        beta, y, incy, stridey, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sspmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_sspmv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     alpha::Ptr{Cfloat}, A::Ptr{Cfloat},
                                                     strideA::rocblas_stride, x::Ptr{Cfloat},
@@ -4120,7 +4120,7 @@ end
 function rocblas_dspmv_strided_batched(handle, uplo, n, alpha, A, strideA, x, incx, stridex,
                                        beta, y, incy, stridey, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dspmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dspmv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     alpha::Ptr{Cdouble}, A::Ptr{Cdouble},
                                                     strideA::rocblas_stride,
@@ -4134,7 +4134,7 @@ end
 
 function rocblas_ssbmv(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssbmv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ssbmv(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, k::rocblas_int, alpha::Ptr{Cfloat},
                                     A::Ptr{Cfloat}, lda::rocblas_int, x::Ptr{Cfloat},
                                     incx::rocblas_int, beta::Ptr{Cfloat}, y::Ptr{Cfloat},
@@ -4143,7 +4143,7 @@ end
 
 function rocblas_dsbmv(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsbmv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dsbmv(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, k::rocblas_int, alpha::Ptr{Cdouble},
                                     A::Ptr{Cdouble}, lda::rocblas_int, x::Ptr{Cdouble},
                                     incx::rocblas_int, beta::Ptr{Cdouble}, y::Ptr{Cdouble},
@@ -4153,7 +4153,7 @@ end
 function rocblas_dsbmv_batched(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsbmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dsbmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int, k::rocblas_int,
                                             alpha::Ptr{Cdouble}, A::Ptr{Ptr{Cdouble}},
                                             lda::rocblas_int, x::Ptr{Ptr{Cdouble}},
@@ -4165,7 +4165,7 @@ end
 function rocblas_ssbmv_batched(handle, uplo, n, k, alpha, A, lda, x, incx, beta, y, incy,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssbmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ssbmv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int, k::rocblas_int,
                                             alpha::Ptr{Cfloat}, A::Ptr{Ptr{Cfloat}},
                                             lda::rocblas_int, x::Ptr{Ptr{Cfloat}},
@@ -4177,7 +4177,7 @@ end
 function rocblas_ssbmv_strided_batched(handle, uplo, n, k, alpha, A, lda, strideA, x, incx,
                                        stridex, beta, y, incy, stridey, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssbmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ssbmv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     k::rocblas_int, alpha::Ptr{Cfloat},
                                                     A::Ptr{Cfloat}, lda::rocblas_int,
@@ -4193,7 +4193,7 @@ end
 function rocblas_dsbmv_strided_batched(handle, uplo, n, k, alpha, A, lda, strideA, x, incx,
                                        stridex, beta, y, incy, stridey, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsbmv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dsbmv_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     k::rocblas_int, alpha::Ptr{Cdouble},
                                                     A::Ptr{Cdouble}, lda::rocblas_int,
@@ -4208,7 +4208,7 @@ end
 
 function rocblas_sger(handle, m, n, alpha, x, incx, y, incy, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sger(handle::rocblas_handle, m::rocblas_int, n::rocblas_int,
+    @check @ccall librocblas.rocblas_sger(handle::rocblas_handle, m::rocblas_int, n::rocblas_int,
                                    alpha::Ptr{Cfloat}, x::Ptr{Cfloat}, incx::rocblas_int,
                                    y::Ptr{Cfloat}, incy::rocblas_int, A::Ptr{Cfloat},
                                    lda::rocblas_int)::rocblas_status
@@ -4216,7 +4216,7 @@ end
 
 function rocblas_dger(handle, m, n, alpha, x, incx, y, incy, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dger(handle::rocblas_handle, m::rocblas_int, n::rocblas_int,
+    @check @ccall librocblas.rocblas_dger(handle::rocblas_handle, m::rocblas_int, n::rocblas_int,
                                    alpha::Ptr{Cdouble}, x::Ptr{Cdouble}, incx::rocblas_int,
                                    y::Ptr{Cdouble}, incy::rocblas_int, A::Ptr{Cdouble},
                                    lda::rocblas_int)::rocblas_status
@@ -4224,7 +4224,7 @@ end
 
 function rocblas_cgeru(handle, m, n, alpha, x, incx, y, incy, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cgeru(handle::rocblas_handle, m::rocblas_int, n::rocblas_int,
+    @check @ccall librocblas.rocblas_cgeru(handle::rocblas_handle, m::rocblas_int, n::rocblas_int,
                                     alpha::Ptr{rocblas_float_complex},
                                     x::Ptr{rocblas_float_complex}, incx::rocblas_int,
                                     y::Ptr{rocblas_float_complex}, incy::rocblas_int,
@@ -4234,7 +4234,7 @@ end
 
 function rocblas_zgeru(handle, m, n, alpha, x, incx, y, incy, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zgeru(handle::rocblas_handle, m::rocblas_int, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zgeru(handle::rocblas_handle, m::rocblas_int, n::rocblas_int,
                                     alpha::Ptr{rocblas_double_complex},
                                     x::Ptr{rocblas_double_complex}, incx::rocblas_int,
                                     y::Ptr{rocblas_double_complex}, incy::rocblas_int,
@@ -4244,7 +4244,7 @@ end
 
 function rocblas_cgerc(handle, m, n, alpha, x, incx, y, incy, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cgerc(handle::rocblas_handle, m::rocblas_int, n::rocblas_int,
+    @check @ccall librocblas.rocblas_cgerc(handle::rocblas_handle, m::rocblas_int, n::rocblas_int,
                                     alpha::Ptr{rocblas_float_complex},
                                     x::Ptr{rocblas_float_complex}, incx::rocblas_int,
                                     y::Ptr{rocblas_float_complex}, incy::rocblas_int,
@@ -4254,7 +4254,7 @@ end
 
 function rocblas_zgerc(handle, m, n, alpha, x, incx, y, incy, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zgerc(handle::rocblas_handle, m::rocblas_int, n::rocblas_int,
+    @check @ccall librocblas.rocblas_zgerc(handle::rocblas_handle, m::rocblas_int, n::rocblas_int,
                                     alpha::Ptr{rocblas_double_complex},
                                     x::Ptr{rocblas_double_complex}, incx::rocblas_int,
                                     y::Ptr{rocblas_double_complex}, incy::rocblas_int,
@@ -4264,7 +4264,7 @@ end
 
 function rocblas_sger_batched(handle, m, n, alpha, x, incx, y, incy, A, lda, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sger_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocblas.rocblas_sger_batched(handle::rocblas_handle, m::rocblas_int,
                                            n::rocblas_int, alpha::Ptr{Cfloat},
                                            x::Ptr{Ptr{Cfloat}}, incx::rocblas_int,
                                            y::Ptr{Ptr{Cfloat}}, incy::rocblas_int,
@@ -4274,7 +4274,7 @@ end
 
 function rocblas_dger_batched(handle, m, n, alpha, x, incx, y, incy, A, lda, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dger_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocblas.rocblas_dger_batched(handle::rocblas_handle, m::rocblas_int,
                                            n::rocblas_int, alpha::Ptr{Cdouble},
                                            x::Ptr{Ptr{Cdouble}}, incx::rocblas_int,
                                            y::Ptr{Ptr{Cdouble}}, incy::rocblas_int,
@@ -4284,7 +4284,7 @@ end
 
 function rocblas_cgeru_batched(handle, m, n, alpha, x, incx, y, incy, A, lda, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cgeru_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocblas.rocblas_cgeru_batched(handle::rocblas_handle, m::rocblas_int,
                                             n::rocblas_int,
                                             alpha::Ptr{rocblas_float_complex},
                                             x::Ptr{Ptr{rocblas_float_complex}},
@@ -4298,7 +4298,7 @@ end
 
 function rocblas_zgeru_batched(handle, m, n, alpha, x, incx, y, incy, A, lda, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zgeru_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocblas.rocblas_zgeru_batched(handle::rocblas_handle, m::rocblas_int,
                                             n::rocblas_int,
                                             alpha::Ptr{rocblas_double_complex},
                                             x::Ptr{Ptr{rocblas_double_complex}},
@@ -4312,7 +4312,7 @@ end
 
 function rocblas_cgerc_batched(handle, m, n, alpha, x, incx, y, incy, A, lda, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cgerc_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocblas.rocblas_cgerc_batched(handle::rocblas_handle, m::rocblas_int,
                                             n::rocblas_int,
                                             alpha::Ptr{rocblas_float_complex},
                                             x::Ptr{Ptr{rocblas_float_complex}},
@@ -4326,7 +4326,7 @@ end
 
 function rocblas_zgerc_batched(handle, m, n, alpha, x, incx, y, incy, A, lda, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zgerc_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocblas.rocblas_zgerc_batched(handle::rocblas_handle, m::rocblas_int,
                                             n::rocblas_int,
                                             alpha::Ptr{rocblas_double_complex},
                                             x::Ptr{Ptr{rocblas_double_complex}},
@@ -4341,7 +4341,7 @@ end
 function rocblas_sger_strided_batched(handle, m, n, alpha, x, incx, stridex, y, incy,
                                       stridey, A, lda, strideA, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sger_strided_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocblas.rocblas_sger_strided_batched(handle::rocblas_handle, m::rocblas_int,
                                                    n::rocblas_int, alpha::Ptr{Cfloat},
                                                    x::Ptr{Cfloat}, incx::rocblas_int,
                                                    stridex::rocblas_stride, y::Ptr{Cfloat},
@@ -4355,7 +4355,7 @@ end
 function rocblas_dger_strided_batched(handle, m, n, alpha, x, incx, stridex, y, incy,
                                       stridey, A, lda, strideA, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dger_strided_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocblas.rocblas_dger_strided_batched(handle::rocblas_handle, m::rocblas_int,
                                                    n::rocblas_int, alpha::Ptr{Cdouble},
                                                    x::Ptr{Cdouble}, incx::rocblas_int,
                                                    stridex::rocblas_stride, y::Ptr{Cdouble},
@@ -4369,7 +4369,7 @@ end
 function rocblas_cgeru_strided_batched(handle, m, n, alpha, x, incx, stridex, y, incy,
                                        stridey, A, lda, strideA, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cgeru_strided_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocblas.rocblas_cgeru_strided_batched(handle::rocblas_handle, m::rocblas_int,
                                                     n::rocblas_int,
                                                     alpha::Ptr{rocblas_float_complex},
                                                     x::Ptr{rocblas_float_complex},
@@ -4387,7 +4387,7 @@ end
 function rocblas_zgeru_strided_batched(handle, m, n, alpha, x, incx, stridex, y, incy,
                                        stridey, A, lda, strideA, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zgeru_strided_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocblas.rocblas_zgeru_strided_batched(handle::rocblas_handle, m::rocblas_int,
                                                     n::rocblas_int,
                                                     alpha::Ptr{rocblas_double_complex},
                                                     x::Ptr{rocblas_double_complex},
@@ -4405,7 +4405,7 @@ end
 function rocblas_cgerc_strided_batched(handle, m, n, alpha, x, incx, stridex, y, incy,
                                        stridey, A, lda, strideA, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cgerc_strided_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocblas.rocblas_cgerc_strided_batched(handle::rocblas_handle, m::rocblas_int,
                                                     n::rocblas_int,
                                                     alpha::Ptr{rocblas_float_complex},
                                                     x::Ptr{rocblas_float_complex},
@@ -4423,7 +4423,7 @@ end
 function rocblas_zgerc_strided_batched(handle, m, n, alpha, x, incx, stridex, y, incy,
                                        stridey, A, lda, strideA, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zgerc_strided_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocblas.rocblas_zgerc_strided_batched(handle::rocblas_handle, m::rocblas_int,
                                                     n::rocblas_int,
                                                     alpha::Ptr{rocblas_double_complex},
                                                     x::Ptr{rocblas_double_complex},
@@ -4440,21 +4440,21 @@ end
 
 function rocblas_sspr(handle, uplo, n, alpha, x, incx, AP)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sspr(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_sspr(handle::rocblas_handle, uplo::rocblas_fill,
                                    n::rocblas_int, alpha::Ptr{Cfloat}, x::Ptr{Cfloat},
                                    incx::rocblas_int, AP::Ptr{Cfloat})::rocblas_status
 end
 
 function rocblas_dspr(handle, uplo, n, alpha, x, incx, AP)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dspr(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dspr(handle::rocblas_handle, uplo::rocblas_fill,
                                    n::rocblas_int, alpha::Ptr{Cdouble}, x::Ptr{Cdouble},
                                    incx::rocblas_int, AP::Ptr{Cdouble})::rocblas_status
 end
 
 function rocblas_cspr(handle, uplo, n, alpha, x, incx, AP)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cspr(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_cspr(handle::rocblas_handle, uplo::rocblas_fill,
                                    n::rocblas_int, alpha::Ptr{rocblas_float_complex},
                                    x::Ptr{rocblas_float_complex}, incx::rocblas_int,
                                    AP::Ptr{rocblas_float_complex})::rocblas_status
@@ -4462,7 +4462,7 @@ end
 
 function rocblas_zspr(handle, uplo, n, alpha, x, incx, AP)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zspr(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zspr(handle::rocblas_handle, uplo::rocblas_fill,
                                    n::rocblas_int, alpha::Ptr{rocblas_double_complex},
                                    x::Ptr{rocblas_double_complex}, incx::rocblas_int,
                                    AP::Ptr{rocblas_double_complex})::rocblas_status
@@ -4470,7 +4470,7 @@ end
 
 function rocblas_sspr_batched(handle, uplo, n, alpha, x, incx, AP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sspr_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_sspr_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                            n::rocblas_int, alpha::Ptr{Cfloat},
                                            x::Ptr{Ptr{Cfloat}}, incx::rocblas_int,
                                            AP::Ptr{Ptr{Cfloat}},
@@ -4479,7 +4479,7 @@ end
 
 function rocblas_dspr_batched(handle, uplo, n, alpha, x, incx, AP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dspr_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dspr_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                            n::rocblas_int, alpha::Ptr{Cdouble},
                                            x::Ptr{Ptr{Cdouble}}, incx::rocblas_int,
                                            AP::Ptr{Ptr{Cdouble}},
@@ -4488,7 +4488,7 @@ end
 
 function rocblas_cspr_batched(handle, uplo, n, alpha, x, incx, AP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cspr_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_cspr_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                            n::rocblas_int,
                                            alpha::Ptr{rocblas_float_complex},
                                            x::Ptr{Ptr{rocblas_float_complex}},
@@ -4499,7 +4499,7 @@ end
 
 function rocblas_zspr_batched(handle, uplo, n, alpha, x, incx, AP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zspr_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zspr_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                            n::rocblas_int,
                                            alpha::Ptr{rocblas_double_complex},
                                            x::Ptr{Ptr{rocblas_double_complex}},
@@ -4511,7 +4511,7 @@ end
 function rocblas_sspr_strided_batched(handle, uplo, n, alpha, x, incx, stride_x, AP,
                                       stride_A, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sspr_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_sspr_strided_batched(handle::rocblas_handle,
                                                    uplo::rocblas_fill, n::rocblas_int,
                                                    alpha::Ptr{Cfloat}, x::Ptr{Cfloat},
                                                    incx::rocblas_int,
@@ -4524,7 +4524,7 @@ end
 function rocblas_dspr_strided_batched(handle, uplo, n, alpha, x, incx, stride_x, AP,
                                       stride_A, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dspr_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dspr_strided_batched(handle::rocblas_handle,
                                                    uplo::rocblas_fill, n::rocblas_int,
                                                    alpha::Ptr{Cdouble}, x::Ptr{Cdouble},
                                                    incx::rocblas_int,
@@ -4537,7 +4537,7 @@ end
 function rocblas_cspr_strided_batched(handle, uplo, n, alpha, x, incx, stride_x, AP,
                                       stride_A, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cspr_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_cspr_strided_batched(handle::rocblas_handle,
                                                    uplo::rocblas_fill, n::rocblas_int,
                                                    alpha::Ptr{rocblas_float_complex},
                                                    x::Ptr{rocblas_float_complex},
@@ -4551,7 +4551,7 @@ end
 function rocblas_zspr_strided_batched(handle, uplo, n, alpha, x, incx, stride_x, AP,
                                       stride_A, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zspr_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zspr_strided_batched(handle::rocblas_handle,
                                                    uplo::rocblas_fill, n::rocblas_int,
                                                    alpha::Ptr{rocblas_double_complex},
                                                    x::Ptr{rocblas_double_complex},
@@ -4564,7 +4564,7 @@ end
 
 function rocblas_sspr2(handle, uplo, n, alpha, x, incx, y, incy, AP)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sspr2(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_sspr2(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, alpha::Ptr{Cfloat}, x::Ptr{Cfloat},
                                     incx::rocblas_int, y::Ptr{Cfloat}, incy::rocblas_int,
                                     AP::Ptr{Cfloat})::rocblas_status
@@ -4572,7 +4572,7 @@ end
 
 function rocblas_dspr2(handle, uplo, n, alpha, x, incx, y, incy, AP)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dspr2(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dspr2(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, alpha::Ptr{Cdouble}, x::Ptr{Cdouble},
                                     incx::rocblas_int, y::Ptr{Cdouble}, incy::rocblas_int,
                                     AP::Ptr{Cdouble})::rocblas_status
@@ -4580,7 +4580,7 @@ end
 
 function rocblas_sspr2_batched(handle, uplo, n, alpha, x, incx, y, incy, AP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sspr2_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_sspr2_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int, alpha::Ptr{Cfloat},
                                             x::Ptr{Ptr{Cfloat}}, incx::rocblas_int,
                                             y::Ptr{Ptr{Cfloat}}, incy::rocblas_int,
@@ -4590,7 +4590,7 @@ end
 
 function rocblas_dspr2_batched(handle, uplo, n, alpha, x, incx, y, incy, AP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dspr2_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dspr2_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int, alpha::Ptr{Cdouble},
                                             x::Ptr{Ptr{Cdouble}}, incx::rocblas_int,
                                             y::Ptr{Ptr{Cdouble}}, incy::rocblas_int,
@@ -4601,7 +4601,7 @@ end
 function rocblas_sspr2_strided_batched(handle, uplo, n, alpha, x, incx, stride_x, y, incy,
                                        stride_y, AP, stride_A, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sspr2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_sspr2_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     alpha::Ptr{Cfloat}, x::Ptr{Cfloat},
                                                     incx::rocblas_int,
@@ -4616,7 +4616,7 @@ end
 function rocblas_dspr2_strided_batched(handle, uplo, n, alpha, x, incx, stride_x, y, incy,
                                        stride_y, AP, stride_A, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dspr2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dspr2_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     alpha::Ptr{Cdouble}, x::Ptr{Cdouble},
                                                     incx::rocblas_int,
@@ -4630,7 +4630,7 @@ end
 
 function rocblas_ssyr(handle, uplo, n, alpha, x, incx, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssyr(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ssyr(handle::rocblas_handle, uplo::rocblas_fill,
                                    n::rocblas_int, alpha::Ptr{Cfloat}, x::Ptr{Cfloat},
                                    incx::rocblas_int, A::Ptr{Cfloat},
                                    lda::rocblas_int)::rocblas_status
@@ -4638,7 +4638,7 @@ end
 
 function rocblas_dsyr(handle, uplo, n, alpha, x, incx, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsyr(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dsyr(handle::rocblas_handle, uplo::rocblas_fill,
                                    n::rocblas_int, alpha::Ptr{Cdouble}, x::Ptr{Cdouble},
                                    incx::rocblas_int, A::Ptr{Cdouble},
                                    lda::rocblas_int)::rocblas_status
@@ -4646,7 +4646,7 @@ end
 
 function rocblas_csyr(handle, uplo, n, alpha, x, incx, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csyr(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_csyr(handle::rocblas_handle, uplo::rocblas_fill,
                                    n::rocblas_int, alpha::Ptr{rocblas_float_complex},
                                    x::Ptr{rocblas_float_complex}, incx::rocblas_int,
                                    A::Ptr{rocblas_float_complex},
@@ -4655,7 +4655,7 @@ end
 
 function rocblas_zsyr(handle, uplo, n, alpha, x, incx, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zsyr(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zsyr(handle::rocblas_handle, uplo::rocblas_fill,
                                    n::rocblas_int, alpha::Ptr{rocblas_double_complex},
                                    x::Ptr{rocblas_double_complex}, incx::rocblas_int,
                                    A::Ptr{rocblas_double_complex},
@@ -4664,7 +4664,7 @@ end
 
 function rocblas_ssyr_batched(handle, uplo, n, alpha, x, incx, A, lda, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssyr_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ssyr_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                            n::rocblas_int, alpha::Ptr{Cfloat},
                                            x::Ptr{Ptr{Cfloat}}, incx::rocblas_int,
                                            A::Ptr{Ptr{Cfloat}}, lda::rocblas_int,
@@ -4673,7 +4673,7 @@ end
 
 function rocblas_dsyr_batched(handle, uplo, n, alpha, x, incx, A, lda, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsyr_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dsyr_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                            n::rocblas_int, alpha::Ptr{Cdouble},
                                            x::Ptr{Ptr{Cdouble}}, incx::rocblas_int,
                                            A::Ptr{Ptr{Cdouble}}, lda::rocblas_int,
@@ -4682,7 +4682,7 @@ end
 
 function rocblas_csyr_batched(handle, uplo, n, alpha, x, incx, A, lda, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csyr_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_csyr_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                            n::rocblas_int,
                                            alpha::Ptr{rocblas_float_complex},
                                            x::Ptr{Ptr{rocblas_float_complex}},
@@ -4694,7 +4694,7 @@ end
 
 function rocblas_zsyr_batched(handle, uplo, n, alpha, x, incx, A, lda, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zsyr_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zsyr_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                            n::rocblas_int,
                                            alpha::Ptr{rocblas_double_complex},
                                            x::Ptr{Ptr{rocblas_double_complex}},
@@ -4707,7 +4707,7 @@ end
 function rocblas_ssyr_strided_batched(handle, uplo, n, alpha, x, incx, stridex, A, lda,
                                       strideA, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssyr_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ssyr_strided_batched(handle::rocblas_handle,
                                                    uplo::rocblas_fill, n::rocblas_int,
                                                    alpha::Ptr{Cfloat}, x::Ptr{Cfloat},
                                                    incx::rocblas_int,
@@ -4720,7 +4720,7 @@ end
 function rocblas_dsyr_strided_batched(handle, uplo, n, alpha, x, incx, stridex, A, lda,
                                       strideA, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsyr_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dsyr_strided_batched(handle::rocblas_handle,
                                                    uplo::rocblas_fill, n::rocblas_int,
                                                    alpha::Ptr{Cdouble}, x::Ptr{Cdouble},
                                                    incx::rocblas_int,
@@ -4733,7 +4733,7 @@ end
 function rocblas_csyr_strided_batched(handle, uplo, n, alpha, x, incx, stridex, A, lda,
                                       strideA, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csyr_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_csyr_strided_batched(handle::rocblas_handle,
                                                    uplo::rocblas_fill, n::rocblas_int,
                                                    alpha::Ptr{rocblas_float_complex},
                                                    x::Ptr{rocblas_float_complex},
@@ -4748,7 +4748,7 @@ end
 function rocblas_zsyr_strided_batched(handle, uplo, n, alpha, x, incx, stridex, A, lda,
                                       strideA, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zsyr_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zsyr_strided_batched(handle::rocblas_handle,
                                                    uplo::rocblas_fill, n::rocblas_int,
                                                    alpha::Ptr{rocblas_double_complex},
                                                    x::Ptr{rocblas_double_complex},
@@ -4762,7 +4762,7 @@ end
 
 function rocblas_ssyr2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssyr2(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ssyr2(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, alpha::Ptr{Cfloat}, x::Ptr{Cfloat},
                                     incx::rocblas_int, y::Ptr{Cfloat}, incy::rocblas_int,
                                     A::Ptr{Cfloat}, lda::rocblas_int)::rocblas_status
@@ -4770,7 +4770,7 @@ end
 
 function rocblas_dsyr2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsyr2(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dsyr2(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, alpha::Ptr{Cdouble}, x::Ptr{Cdouble},
                                     incx::rocblas_int, y::Ptr{Cdouble}, incy::rocblas_int,
                                     A::Ptr{Cdouble}, lda::rocblas_int)::rocblas_status
@@ -4778,7 +4778,7 @@ end
 
 function rocblas_csyr2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csyr2(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_csyr2(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, alpha::Ptr{rocblas_float_complex},
                                     x::Ptr{rocblas_float_complex}, incx::rocblas_int,
                                     y::Ptr{rocblas_float_complex}, incy::rocblas_int,
@@ -4788,7 +4788,7 @@ end
 
 function rocblas_zsyr2(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zsyr2(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zsyr2(handle::rocblas_handle, uplo::rocblas_fill,
                                     n::rocblas_int, alpha::Ptr{rocblas_double_complex},
                                     x::Ptr{rocblas_double_complex}, incx::rocblas_int,
                                     y::Ptr{rocblas_double_complex}, incy::rocblas_int,
@@ -4799,7 +4799,7 @@ end
 function rocblas_ssyr2_batched(handle, uplo, n, alpha, x, incx, y, incy, A, lda,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssyr2_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ssyr2_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int, alpha::Ptr{Cfloat},
                                             x::Ptr{Ptr{Cfloat}}, incx::rocblas_int,
                                             y::Ptr{Ptr{Cfloat}}, incy::rocblas_int,
@@ -4810,7 +4810,7 @@ end
 function rocblas_dsyr2_batched(handle, uplo, n, alpha, x, incx, y, incy, A, lda,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsyr2_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dsyr2_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int, alpha::Ptr{Cdouble},
                                             x::Ptr{Ptr{Cdouble}}, incx::rocblas_int,
                                             y::Ptr{Ptr{Cdouble}}, incy::rocblas_int,
@@ -4821,7 +4821,7 @@ end
 function rocblas_csyr2_batched(handle, uplo, n, alpha, x, incx, y, incy, A, lda,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csyr2_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_csyr2_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int,
                                             alpha::Ptr{rocblas_float_complex},
                                             x::Ptr{Ptr{rocblas_float_complex}},
@@ -4836,7 +4836,7 @@ end
 function rocblas_zsyr2_batched(handle, uplo, n, alpha, x, incx, y, incy, A, lda,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zsyr2_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zsyr2_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             n::rocblas_int,
                                             alpha::Ptr{rocblas_double_complex},
                                             x::Ptr{Ptr{rocblas_double_complex}},
@@ -4851,7 +4851,7 @@ end
 function rocblas_ssyr2_strided_batched(handle, uplo, n, alpha, x, incx, stridex, y, incy,
                                        stridey, A, lda, strideA, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssyr2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ssyr2_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     alpha::Ptr{Cfloat}, x::Ptr{Cfloat},
                                                     incx::rocblas_int,
@@ -4866,7 +4866,7 @@ end
 function rocblas_dsyr2_strided_batched(handle, uplo, n, alpha, x, incx, stridex, y, incy,
                                        stridey, A, lda, strideA, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsyr2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dsyr2_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     alpha::Ptr{Cdouble}, x::Ptr{Cdouble},
                                                     incx::rocblas_int,
@@ -4881,7 +4881,7 @@ end
 function rocblas_csyr2_strided_batched(handle, uplo, n, alpha, x, incx, stridex, y, incy,
                                        stridey, A, lda, strideA, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csyr2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_csyr2_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     alpha::Ptr{rocblas_float_complex},
                                                     x::Ptr{rocblas_float_complex},
@@ -4899,7 +4899,7 @@ end
 function rocblas_zsyr2_strided_batched(handle, uplo, n, alpha, x, incx, stridex, y, incy,
                                        stridey, A, lda, strideA, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zsyr2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zsyr2_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill, n::rocblas_int,
                                                     alpha::Ptr{rocblas_double_complex},
                                                     x::Ptr{rocblas_double_complex},
@@ -4916,7 +4916,7 @@ end
 
 function rocblas_chemm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_chemm(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_chemm(handle::rocblas_handle, side::rocblas_side,
                                     uplo::rocblas_fill, m::rocblas_int, n::rocblas_int,
                                     alpha::Ptr{rocblas_float_complex},
                                     A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -4928,7 +4928,7 @@ end
 
 function rocblas_zhemm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zhemm(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_zhemm(handle::rocblas_handle, side::rocblas_side,
                                     uplo::rocblas_fill, m::rocblas_int, n::rocblas_int,
                                     alpha::Ptr{rocblas_double_complex},
                                     A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -4941,7 +4941,7 @@ end
 function rocblas_chemm_batched(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_chemm_batched(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_chemm_batched(handle::rocblas_handle, side::rocblas_side,
                                             uplo::rocblas_fill, m::rocblas_int,
                                             n::rocblas_int,
                                             alpha::Ptr{rocblas_float_complex},
@@ -4958,7 +4958,7 @@ end
 function rocblas_zhemm_batched(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zhemm_batched(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_zhemm_batched(handle::rocblas_handle, side::rocblas_side,
                                             uplo::rocblas_fill, m::rocblas_int,
                                             n::rocblas_int,
                                             alpha::Ptr{rocblas_double_complex},
@@ -4975,7 +4975,7 @@ end
 function rocblas_chemm_strided_batched(handle, side, uplo, m, n, alpha, A, lda, stride_A, B,
                                        ldb, stride_B, beta, C, ldc, stride_C, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_chemm_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_chemm_strided_batched(handle::rocblas_handle,
                                                     side::rocblas_side, uplo::rocblas_fill,
                                                     m::rocblas_int, n::rocblas_int,
                                                     alpha::Ptr{rocblas_float_complex},
@@ -4995,7 +4995,7 @@ end
 function rocblas_zhemm_strided_batched(handle, side, uplo, m, n, alpha, A, lda, stride_A, B,
                                        ldb, stride_B, beta, C, ldc, stride_C, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zhemm_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zhemm_strided_batched(handle::rocblas_handle,
                                                     side::rocblas_side, uplo::rocblas_fill,
                                                     m::rocblas_int, n::rocblas_int,
                                                     alpha::Ptr{rocblas_double_complex},
@@ -5014,7 +5014,7 @@ end
 
 function rocblas_cherk(handle, uplo, transA, n, k, alpha, A, lda, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cherk(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_cherk(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, n::rocblas_int,
                                     k::rocblas_int, alpha::Ptr{Cfloat},
                                     A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -5024,7 +5024,7 @@ end
 
 function rocblas_zherk(handle, uplo, transA, n, k, alpha, A, lda, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zherk(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zherk(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, n::rocblas_int,
                                     k::rocblas_int, alpha::Ptr{Cdouble},
                                     A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -5035,7 +5035,7 @@ end
 function rocblas_cherk_batched(handle, uplo, transA, n, k, alpha, A, lda, beta, C, ldc,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cherk_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_cherk_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation, n::rocblas_int,
                                             k::rocblas_int, alpha::Ptr{Cfloat},
                                             A::Ptr{Ptr{rocblas_float_complex}},
@@ -5048,7 +5048,7 @@ end
 function rocblas_zherk_batched(handle, uplo, transA, n, k, alpha, A, lda, beta, C, ldc,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zherk_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zherk_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation, n::rocblas_int,
                                             k::rocblas_int, alpha::Ptr{Cdouble},
                                             A::Ptr{Ptr{rocblas_double_complex}},
@@ -5061,7 +5061,7 @@ end
 function rocblas_cherk_strided_batched(handle, uplo, transA, n, k, alpha, A, lda, stride_A,
                                        beta, C, ldc, stride_C, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cherk_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_cherk_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     n::rocblas_int, k::rocblas_int,
@@ -5079,7 +5079,7 @@ end
 function rocblas_zherk_strided_batched(handle, uplo, transA, n, k, alpha, A, lda, stride_A,
                                        beta, C, ldc, stride_C, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zherk_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zherk_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     n::rocblas_int, k::rocblas_int,
@@ -5096,7 +5096,7 @@ end
 
 function rocblas_cher2k(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cher2k(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_cher2k(handle::rocblas_handle, uplo::rocblas_fill,
                                      trans::rocblas_operation, n::rocblas_int,
                                      k::rocblas_int, alpha::Ptr{rocblas_float_complex},
                                      A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -5107,7 +5107,7 @@ end
 
 function rocblas_zher2k(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zher2k(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zher2k(handle::rocblas_handle, uplo::rocblas_fill,
                                      trans::rocblas_operation, n::rocblas_int,
                                      k::rocblas_int, alpha::Ptr{rocblas_double_complex},
                                      A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -5119,7 +5119,7 @@ end
 function rocblas_cher2k_batched(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                 ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cher2k_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_cher2k_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                              trans::rocblas_operation, n::rocblas_int,
                                              k::rocblas_int,
                                              alpha::Ptr{rocblas_float_complex},
@@ -5135,7 +5135,7 @@ end
 function rocblas_zher2k_batched(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                 ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zher2k_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zher2k_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                              trans::rocblas_operation, n::rocblas_int,
                                              k::rocblas_int,
                                              alpha::Ptr{rocblas_double_complex},
@@ -5152,7 +5152,7 @@ function rocblas_cher2k_strided_batched(handle, uplo, trans, n, k, alpha, A, lda
                                         B, ldb, stride_B, beta, C, ldc, stride_C,
                                         batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cher2k_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_cher2k_strided_batched(handle::rocblas_handle,
                                                      uplo::rocblas_fill,
                                                      trans::rocblas_operation,
                                                      n::rocblas_int, k::rocblas_int,
@@ -5174,7 +5174,7 @@ function rocblas_zher2k_strided_batched(handle, uplo, trans, n, k, alpha, A, lda
                                         B, ldb, stride_B, beta, C, ldc, stride_C,
                                         batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zher2k_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zher2k_strided_batched(handle::rocblas_handle,
                                                      uplo::rocblas_fill,
                                                      trans::rocblas_operation,
                                                      n::rocblas_int, k::rocblas_int,
@@ -5194,7 +5194,7 @@ end
 
 function rocblas_cherkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cherkx(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_cherkx(handle::rocblas_handle, uplo::rocblas_fill,
                                      trans::rocblas_operation, n::rocblas_int,
                                      k::rocblas_int, alpha::Ptr{rocblas_float_complex},
                                      A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -5205,7 +5205,7 @@ end
 
 function rocblas_zherkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zherkx(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zherkx(handle::rocblas_handle, uplo::rocblas_fill,
                                      trans::rocblas_operation, n::rocblas_int,
                                      k::rocblas_int, alpha::Ptr{rocblas_double_complex},
                                      A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -5217,7 +5217,7 @@ end
 function rocblas_cherkx_batched(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                 ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cherkx_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_cherkx_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                              trans::rocblas_operation, n::rocblas_int,
                                              k::rocblas_int,
                                              alpha::Ptr{rocblas_float_complex},
@@ -5233,7 +5233,7 @@ end
 function rocblas_zherkx_batched(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                 ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zherkx_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zherkx_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                              trans::rocblas_operation, n::rocblas_int,
                                              k::rocblas_int,
                                              alpha::Ptr{rocblas_double_complex},
@@ -5250,7 +5250,7 @@ function rocblas_cherkx_strided_batched(handle, uplo, trans, n, k, alpha, A, lda
                                         B, ldb, stride_B, beta, C, ldc, stride_C,
                                         batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cherkx_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_cherkx_strided_batched(handle::rocblas_handle,
                                                      uplo::rocblas_fill,
                                                      trans::rocblas_operation,
                                                      n::rocblas_int, k::rocblas_int,
@@ -5272,7 +5272,7 @@ function rocblas_zherkx_strided_batched(handle, uplo, trans, n, k, alpha, A, lda
                                         B, ldb, stride_B, beta, C, ldc, stride_C,
                                         batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zherkx_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zherkx_strided_batched(handle::rocblas_handle,
                                                      uplo::rocblas_fill,
                                                      trans::rocblas_operation,
                                                      n::rocblas_int, k::rocblas_int,
@@ -5292,7 +5292,7 @@ end
 
 function rocblas_ssymm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssymm(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_ssymm(handle::rocblas_handle, side::rocblas_side,
                                     uplo::rocblas_fill, m::rocblas_int, n::rocblas_int,
                                     alpha::Ptr{Cfloat}, A::Ptr{Cfloat}, lda::rocblas_int,
                                     B::Ptr{Cfloat}, ldb::rocblas_int, beta::Ptr{Cfloat},
@@ -5301,7 +5301,7 @@ end
 
 function rocblas_dsymm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsymm(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_dsymm(handle::rocblas_handle, side::rocblas_side,
                                     uplo::rocblas_fill, m::rocblas_int, n::rocblas_int,
                                     alpha::Ptr{Cdouble}, A::Ptr{Cdouble}, lda::rocblas_int,
                                     B::Ptr{Cdouble}, ldb::rocblas_int, beta::Ptr{Cdouble},
@@ -5310,7 +5310,7 @@ end
 
 function rocblas_csymm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csymm(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_csymm(handle::rocblas_handle, side::rocblas_side,
                                     uplo::rocblas_fill, m::rocblas_int, n::rocblas_int,
                                     alpha::Ptr{rocblas_float_complex},
                                     A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -5322,7 +5322,7 @@ end
 
 function rocblas_zsymm(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zsymm(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_zsymm(handle::rocblas_handle, side::rocblas_side,
                                     uplo::rocblas_fill, m::rocblas_int, n::rocblas_int,
                                     alpha::Ptr{rocblas_double_complex},
                                     A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -5335,7 +5335,7 @@ end
 function rocblas_ssymm_batched(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssymm_batched(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_ssymm_batched(handle::rocblas_handle, side::rocblas_side,
                                             uplo::rocblas_fill, m::rocblas_int,
                                             n::rocblas_int, alpha::Ptr{Cfloat},
                                             A::Ptr{Ptr{Cfloat}}, lda::rocblas_int,
@@ -5348,7 +5348,7 @@ end
 function rocblas_dsymm_batched(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsymm_batched(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_dsymm_batched(handle::rocblas_handle, side::rocblas_side,
                                             uplo::rocblas_fill, m::rocblas_int,
                                             n::rocblas_int, alpha::Ptr{Cdouble},
                                             A::Ptr{Ptr{Cdouble}}, lda::rocblas_int,
@@ -5361,7 +5361,7 @@ end
 function rocblas_csymm_batched(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csymm_batched(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_csymm_batched(handle::rocblas_handle, side::rocblas_side,
                                             uplo::rocblas_fill, m::rocblas_int,
                                             n::rocblas_int,
                                             alpha::Ptr{rocblas_float_complex},
@@ -5378,7 +5378,7 @@ end
 function rocblas_zsymm_batched(handle, side, uplo, m, n, alpha, A, lda, B, ldb, beta, C,
                                ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zsymm_batched(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_zsymm_batched(handle::rocblas_handle, side::rocblas_side,
                                             uplo::rocblas_fill, m::rocblas_int,
                                             n::rocblas_int,
                                             alpha::Ptr{rocblas_double_complex},
@@ -5395,7 +5395,7 @@ end
 function rocblas_ssymm_strided_batched(handle, side, uplo, m, n, alpha, A, lda, stride_A, B,
                                        ldb, stride_B, beta, C, ldc, stride_C, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssymm_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ssymm_strided_batched(handle::rocblas_handle,
                                                     side::rocblas_side, uplo::rocblas_fill,
                                                     m::rocblas_int, n::rocblas_int,
                                                     alpha::Ptr{Cfloat}, A::Ptr{Cfloat},
@@ -5412,7 +5412,7 @@ end
 function rocblas_dsymm_strided_batched(handle, side, uplo, m, n, alpha, A, lda, stride_A, B,
                                        ldb, stride_B, beta, C, ldc, stride_C, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsymm_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dsymm_strided_batched(handle::rocblas_handle,
                                                     side::rocblas_side, uplo::rocblas_fill,
                                                     m::rocblas_int, n::rocblas_int,
                                                     alpha::Ptr{Cdouble}, A::Ptr{Cdouble},
@@ -5429,7 +5429,7 @@ end
 function rocblas_csymm_strided_batched(handle, side, uplo, m, n, alpha, A, lda, stride_A, B,
                                        ldb, stride_B, beta, C, ldc, stride_C, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csymm_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_csymm_strided_batched(handle::rocblas_handle,
                                                     side::rocblas_side, uplo::rocblas_fill,
                                                     m::rocblas_int, n::rocblas_int,
                                                     alpha::Ptr{rocblas_float_complex},
@@ -5449,7 +5449,7 @@ end
 function rocblas_zsymm_strided_batched(handle, side, uplo, m, n, alpha, A, lda, stride_A, B,
                                        ldb, stride_B, beta, C, ldc, stride_C, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zsymm_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zsymm_strided_batched(handle::rocblas_handle,
                                                     side::rocblas_side, uplo::rocblas_fill,
                                                     m::rocblas_int, n::rocblas_int,
                                                     alpha::Ptr{rocblas_double_complex},
@@ -5468,7 +5468,7 @@ end
 
 function rocblas_ssyrk(handle, uplo, transA, n, k, alpha, A, lda, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssyrk(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ssyrk(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, n::rocblas_int,
                                     k::rocblas_int, alpha::Ptr{Cfloat}, A::Ptr{Cfloat},
                                     lda::rocblas_int, beta::Ptr{Cfloat}, C::Ptr{Cfloat},
@@ -5477,7 +5477,7 @@ end
 
 function rocblas_dsyrk(handle, uplo, transA, n, k, alpha, A, lda, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsyrk(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dsyrk(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, n::rocblas_int,
                                     k::rocblas_int, alpha::Ptr{Cdouble}, A::Ptr{Cdouble},
                                     lda::rocblas_int, beta::Ptr{Cdouble}, C::Ptr{Cdouble},
@@ -5486,7 +5486,7 @@ end
 
 function rocblas_csyrk(handle, uplo, transA, n, k, alpha, A, lda, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csyrk(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_csyrk(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, n::rocblas_int,
                                     k::rocblas_int, alpha::Ptr{rocblas_float_complex},
                                     A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -5497,7 +5497,7 @@ end
 
 function rocblas_zsyrk(handle, uplo, transA, n, k, alpha, A, lda, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zsyrk(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zsyrk(handle::rocblas_handle, uplo::rocblas_fill,
                                     transA::rocblas_operation, n::rocblas_int,
                                     k::rocblas_int, alpha::Ptr{rocblas_double_complex},
                                     A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -5509,7 +5509,7 @@ end
 function rocblas_ssyrk_batched(handle, uplo, transA, n, k, alpha, A, lda, beta, C, ldc,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssyrk_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ssyrk_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation, n::rocblas_int,
                                             k::rocblas_int, alpha::Ptr{Cfloat},
                                             A::Ptr{Ptr{Cfloat}}, lda::rocblas_int,
@@ -5521,7 +5521,7 @@ end
 function rocblas_dsyrk_batched(handle, uplo, transA, n, k, alpha, A, lda, beta, C, ldc,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsyrk_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dsyrk_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation, n::rocblas_int,
                                             k::rocblas_int, alpha::Ptr{Cdouble},
                                             A::Ptr{Ptr{Cdouble}}, lda::rocblas_int,
@@ -5533,7 +5533,7 @@ end
 function rocblas_csyrk_batched(handle, uplo, transA, n, k, alpha, A, lda, beta, C, ldc,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csyrk_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_csyrk_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation, n::rocblas_int,
                                             k::rocblas_int,
                                             alpha::Ptr{rocblas_float_complex},
@@ -5548,7 +5548,7 @@ end
 function rocblas_zsyrk_batched(handle, uplo, transA, n, k, alpha, A, lda, beta, C, ldc,
                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zsyrk_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zsyrk_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                             transA::rocblas_operation, n::rocblas_int,
                                             k::rocblas_int,
                                             alpha::Ptr{rocblas_double_complex},
@@ -5563,7 +5563,7 @@ end
 function rocblas_ssyrk_strided_batched(handle, uplo, transA, n, k, alpha, A, lda, stride_A,
                                        beta, C, ldc, stride_C, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssyrk_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ssyrk_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     n::rocblas_int, k::rocblas_int,
@@ -5579,7 +5579,7 @@ end
 function rocblas_dsyrk_strided_batched(handle, uplo, transA, n, k, alpha, A, lda, stride_A,
                                        beta, C, ldc, stride_C, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsyrk_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dsyrk_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     n::rocblas_int, k::rocblas_int,
@@ -5595,7 +5595,7 @@ end
 function rocblas_csyrk_strided_batched(handle, uplo, transA, n, k, alpha, A, lda, stride_A,
                                        beta, C, ldc, stride_C, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csyrk_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_csyrk_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     n::rocblas_int, k::rocblas_int,
@@ -5613,7 +5613,7 @@ end
 function rocblas_zsyrk_strided_batched(handle, uplo, transA, n, k, alpha, A, lda, stride_A,
                                        beta, C, ldc, stride_C, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zsyrk_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zsyrk_strided_batched(handle::rocblas_handle,
                                                     uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     n::rocblas_int, k::rocblas_int,
@@ -5630,7 +5630,7 @@ end
 
 function rocblas_ssyr2k(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssyr2k(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ssyr2k(handle::rocblas_handle, uplo::rocblas_fill,
                                      trans::rocblas_operation, n::rocblas_int,
                                      k::rocblas_int, alpha::Ptr{Cfloat}, A::Ptr{Cfloat},
                                      lda::rocblas_int, B::Ptr{Cfloat}, ldb::rocblas_int,
@@ -5640,7 +5640,7 @@ end
 
 function rocblas_dsyr2k(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsyr2k(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dsyr2k(handle::rocblas_handle, uplo::rocblas_fill,
                                      trans::rocblas_operation, n::rocblas_int,
                                      k::rocblas_int, alpha::Ptr{Cdouble}, A::Ptr{Cdouble},
                                      lda::rocblas_int, B::Ptr{Cdouble}, ldb::rocblas_int,
@@ -5650,7 +5650,7 @@ end
 
 function rocblas_csyr2k(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csyr2k(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_csyr2k(handle::rocblas_handle, uplo::rocblas_fill,
                                      trans::rocblas_operation, n::rocblas_int,
                                      k::rocblas_int, alpha::Ptr{rocblas_float_complex},
                                      A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -5662,7 +5662,7 @@ end
 
 function rocblas_zsyr2k(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zsyr2k(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zsyr2k(handle::rocblas_handle, uplo::rocblas_fill,
                                      trans::rocblas_operation, n::rocblas_int,
                                      k::rocblas_int, alpha::Ptr{rocblas_double_complex},
                                      A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -5675,7 +5675,7 @@ end
 function rocblas_ssyr2k_batched(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                 ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssyr2k_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ssyr2k_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                              trans::rocblas_operation, n::rocblas_int,
                                              k::rocblas_int, alpha::Ptr{Cfloat},
                                              A::Ptr{Ptr{Cfloat}}, lda::rocblas_int,
@@ -5688,7 +5688,7 @@ end
 function rocblas_dsyr2k_batched(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                 ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsyr2k_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dsyr2k_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                              trans::rocblas_operation, n::rocblas_int,
                                              k::rocblas_int, alpha::Ptr{Cdouble},
                                              A::Ptr{Ptr{Cdouble}}, lda::rocblas_int,
@@ -5701,7 +5701,7 @@ end
 function rocblas_csyr2k_batched(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                 ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csyr2k_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_csyr2k_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                              trans::rocblas_operation, n::rocblas_int,
                                              k::rocblas_int,
                                              alpha::Ptr{rocblas_float_complex},
@@ -5718,7 +5718,7 @@ end
 function rocblas_zsyr2k_batched(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                 ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zsyr2k_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zsyr2k_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                              trans::rocblas_operation, n::rocblas_int,
                                              k::rocblas_int,
                                              alpha::Ptr{rocblas_double_complex},
@@ -5736,7 +5736,7 @@ function rocblas_ssyr2k_strided_batched(handle, uplo, trans, n, k, alpha, A, lda
                                         B, ldb, stride_B, beta, C, ldc, stride_C,
                                         batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssyr2k_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ssyr2k_strided_batched(handle::rocblas_handle,
                                                      uplo::rocblas_fill,
                                                      trans::rocblas_operation,
                                                      n::rocblas_int, k::rocblas_int,
@@ -5755,7 +5755,7 @@ function rocblas_dsyr2k_strided_batched(handle, uplo, trans, n, k, alpha, A, lda
                                         B, ldb, stride_B, beta, C, ldc, stride_C,
                                         batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsyr2k_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dsyr2k_strided_batched(handle::rocblas_handle,
                                                      uplo::rocblas_fill,
                                                      trans::rocblas_operation,
                                                      n::rocblas_int, k::rocblas_int,
@@ -5774,7 +5774,7 @@ function rocblas_csyr2k_strided_batched(handle, uplo, trans, n, k, alpha, A, lda
                                         B, ldb, stride_B, beta, C, ldc, stride_C,
                                         batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csyr2k_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_csyr2k_strided_batched(handle::rocblas_handle,
                                                      uplo::rocblas_fill,
                                                      trans::rocblas_operation,
                                                      n::rocblas_int, k::rocblas_int,
@@ -5796,7 +5796,7 @@ function rocblas_zsyr2k_strided_batched(handle, uplo, trans, n, k, alpha, A, lda
                                         B, ldb, stride_B, beta, C, ldc, stride_C,
                                         batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zsyr2k_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zsyr2k_strided_batched(handle::rocblas_handle,
                                                      uplo::rocblas_fill,
                                                      trans::rocblas_operation,
                                                      n::rocblas_int, k::rocblas_int,
@@ -5816,7 +5816,7 @@ end
 
 function rocblas_ssyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssyrkx(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ssyrkx(handle::rocblas_handle, uplo::rocblas_fill,
                                      trans::rocblas_operation, n::rocblas_int,
                                      k::rocblas_int, alpha::Ptr{Cfloat}, A::Ptr{Cfloat},
                                      lda::rocblas_int, B::Ptr{Cfloat}, ldb::rocblas_int,
@@ -5826,7 +5826,7 @@ end
 
 function rocblas_dsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsyrkx(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dsyrkx(handle::rocblas_handle, uplo::rocblas_fill,
                                      trans::rocblas_operation, n::rocblas_int,
                                      k::rocblas_int, alpha::Ptr{Cdouble}, A::Ptr{Cdouble},
                                      lda::rocblas_int, B::Ptr{Cdouble}, ldb::rocblas_int,
@@ -5836,7 +5836,7 @@ end
 
 function rocblas_csyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csyrkx(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_csyrkx(handle::rocblas_handle, uplo::rocblas_fill,
                                      trans::rocblas_operation, n::rocblas_int,
                                      k::rocblas_int, alpha::Ptr{rocblas_float_complex},
                                      A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -5848,7 +5848,7 @@ end
 
 function rocblas_zsyrkx(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zsyrkx(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zsyrkx(handle::rocblas_handle, uplo::rocblas_fill,
                                      trans::rocblas_operation, n::rocblas_int,
                                      k::rocblas_int, alpha::Ptr{rocblas_double_complex},
                                      A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -5861,7 +5861,7 @@ end
 function rocblas_ssyrkx_batched(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                 ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssyrkx_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ssyrkx_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                              trans::rocblas_operation, n::rocblas_int,
                                              k::rocblas_int, alpha::Ptr{Cfloat},
                                              A::Ptr{Ptr{Cfloat}}, lda::rocblas_int,
@@ -5874,7 +5874,7 @@ end
 function rocblas_dsyrkx_batched(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                 ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsyrkx_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dsyrkx_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                              trans::rocblas_operation, n::rocblas_int,
                                              k::rocblas_int, alpha::Ptr{Cdouble},
                                              A::Ptr{Ptr{Cdouble}}, lda::rocblas_int,
@@ -5887,7 +5887,7 @@ end
 function rocblas_csyrkx_batched(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                 ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csyrkx_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_csyrkx_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                              trans::rocblas_operation, n::rocblas_int,
                                              k::rocblas_int,
                                              alpha::Ptr{rocblas_float_complex},
@@ -5904,7 +5904,7 @@ end
 function rocblas_zsyrkx_batched(handle, uplo, trans, n, k, alpha, A, lda, B, ldb, beta, C,
                                 ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zsyrkx_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zsyrkx_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                              trans::rocblas_operation, n::rocblas_int,
                                              k::rocblas_int,
                                              alpha::Ptr{rocblas_double_complex},
@@ -5922,7 +5922,7 @@ function rocblas_ssyrkx_strided_batched(handle, uplo, trans, n, k, alpha, A, lda
                                         B, ldb, stride_B, beta, C, ldc, stride_C,
                                         batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ssyrkx_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ssyrkx_strided_batched(handle::rocblas_handle,
                                                      uplo::rocblas_fill,
                                                      trans::rocblas_operation,
                                                      n::rocblas_int, k::rocblas_int,
@@ -5941,7 +5941,7 @@ function rocblas_dsyrkx_strided_batched(handle, uplo, trans, n, k, alpha, A, lda
                                         B, ldb, stride_B, beta, C, ldc, stride_C,
                                         batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dsyrkx_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dsyrkx_strided_batched(handle::rocblas_handle,
                                                      uplo::rocblas_fill,
                                                      trans::rocblas_operation,
                                                      n::rocblas_int, k::rocblas_int,
@@ -5960,7 +5960,7 @@ function rocblas_csyrkx_strided_batched(handle, uplo, trans, n, k, alpha, A, lda
                                         B, ldb, stride_B, beta, C, ldc, stride_C,
                                         batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_csyrkx_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_csyrkx_strided_batched(handle::rocblas_handle,
                                                      uplo::rocblas_fill,
                                                      trans::rocblas_operation,
                                                      n::rocblas_int, k::rocblas_int,
@@ -5982,7 +5982,7 @@ function rocblas_zsyrkx_strided_batched(handle, uplo, trans, n, k, alpha, A, lda
                                         B, ldb, stride_B, beta, C, ldc, stride_C,
                                         batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zsyrkx_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zsyrkx_strided_batched(handle::rocblas_handle,
                                                      uplo::rocblas_fill,
                                                      trans::rocblas_operation,
                                                      n::rocblas_int, k::rocblas_int,
@@ -6003,7 +6003,7 @@ end
 function rocblas_strmm(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B, ldb, C,
                        ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_strmm(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_strmm(handle::rocblas_handle, side::rocblas_side,
                                     uplo::rocblas_fill, transA::rocblas_operation,
                                     diag::rocblas_diagonal, m::rocblas_int, n::rocblas_int,
                                     alpha::Ptr{Cfloat}, A::Ptr{Cfloat}, lda::rocblas_int,
@@ -6014,7 +6014,7 @@ end
 function rocblas_dtrmm(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B, ldb, C,
                        ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtrmm(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_dtrmm(handle::rocblas_handle, side::rocblas_side,
                                     uplo::rocblas_fill, transA::rocblas_operation,
                                     diag::rocblas_diagonal, m::rocblas_int, n::rocblas_int,
                                     alpha::Ptr{Cdouble}, A::Ptr{Cdouble}, lda::rocblas_int,
@@ -6025,7 +6025,7 @@ end
 function rocblas_ctrmm(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B, ldb, C,
                        ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctrmm(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_ctrmm(handle::rocblas_handle, side::rocblas_side,
                                     uplo::rocblas_fill, transA::rocblas_operation,
                                     diag::rocblas_diagonal, m::rocblas_int, n::rocblas_int,
                                     alpha::Ptr{rocblas_float_complex},
@@ -6038,7 +6038,7 @@ end
 function rocblas_ztrmm(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B, ldb, C,
                        ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztrmm(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_ztrmm(handle::rocblas_handle, side::rocblas_side,
                                     uplo::rocblas_fill, transA::rocblas_operation,
                                     diag::rocblas_diagonal, m::rocblas_int, n::rocblas_int,
                                     alpha::Ptr{rocblas_double_complex},
@@ -6051,7 +6051,7 @@ end
 function rocblas_strmm_batched(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B,
                                ldb, C, ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_strmm_batched(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_strmm_batched(handle::rocblas_handle, side::rocblas_side,
                                             uplo::rocblas_fill, transA::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             n::rocblas_int, alpha::Ptr{Cfloat},
@@ -6064,7 +6064,7 @@ end
 function rocblas_dtrmm_batched(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B,
                                ldb, C, ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtrmm_batched(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_dtrmm_batched(handle::rocblas_handle, side::rocblas_side,
                                             uplo::rocblas_fill, transA::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             n::rocblas_int, alpha::Ptr{Cdouble},
@@ -6077,7 +6077,7 @@ end
 function rocblas_ctrmm_batched(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B,
                                ldb, C, ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctrmm_batched(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_ctrmm_batched(handle::rocblas_handle, side::rocblas_side,
                                             uplo::rocblas_fill, transA::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             n::rocblas_int,
@@ -6094,7 +6094,7 @@ end
 function rocblas_ztrmm_batched(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B,
                                ldb, C, ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztrmm_batched(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_ztrmm_batched(handle::rocblas_handle, side::rocblas_side,
                                             uplo::rocblas_fill, transA::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             n::rocblas_int,
@@ -6112,7 +6112,7 @@ function rocblas_strmm_strided_batched(handle, side, uplo, transA, diag, m, n, a
                                        lda, stride_A, B, ldb, stride_B, C, ldc, stride_C,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_strmm_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_strmm_strided_batched(handle::rocblas_handle,
                                                     side::rocblas_side, uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -6130,7 +6130,7 @@ function rocblas_dtrmm_strided_batched(handle, side, uplo, transA, diag, m, n, a
                                        lda, stride_A, B, ldb, stride_B, C, ldc, stride_C,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtrmm_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dtrmm_strided_batched(handle::rocblas_handle,
                                                     side::rocblas_side, uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -6148,7 +6148,7 @@ function rocblas_ctrmm_strided_batched(handle, side, uplo, transA, diag, m, n, a
                                        lda, stride_A, B, ldb, stride_B, C, ldc, stride_C,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctrmm_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ctrmm_strided_batched(handle::rocblas_handle,
                                                     side::rocblas_side, uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -6170,7 +6170,7 @@ function rocblas_ztrmm_strided_batched(handle, side, uplo, transA, diag, m, n, a
                                        lda, stride_A, B, ldb, stride_B, C, ldc, stride_C,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztrmm_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ztrmm_strided_batched(handle::rocblas_handle,
                                                     side::rocblas_side, uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -6190,7 +6190,7 @@ end
 
 function rocblas_strtri(handle, uplo, diag, n, A, lda, invA, ldinvA)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_strtri(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_strtri(handle::rocblas_handle, uplo::rocblas_fill,
                                      diag::rocblas_diagonal, n::rocblas_int, A::Ptr{Cfloat},
                                      lda::rocblas_int, invA::Ptr{Cfloat},
                                      ldinvA::rocblas_int)::rocblas_status
@@ -6198,7 +6198,7 @@ end
 
 function rocblas_dtrtri(handle, uplo, diag, n, A, lda, invA, ldinvA)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtrtri(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dtrtri(handle::rocblas_handle, uplo::rocblas_fill,
                                      diag::rocblas_diagonal, n::rocblas_int,
                                      A::Ptr{Cdouble}, lda::rocblas_int, invA::Ptr{Cdouble},
                                      ldinvA::rocblas_int)::rocblas_status
@@ -6206,7 +6206,7 @@ end
 
 function rocblas_ctrtri(handle, uplo, diag, n, A, lda, invA, ldinvA)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctrtri(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ctrtri(handle::rocblas_handle, uplo::rocblas_fill,
                                      diag::rocblas_diagonal, n::rocblas_int,
                                      A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                      invA::Ptr{rocblas_float_complex},
@@ -6215,7 +6215,7 @@ end
 
 function rocblas_ztrtri(handle, uplo, diag, n, A, lda, invA, ldinvA)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztrtri(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ztrtri(handle::rocblas_handle, uplo::rocblas_fill,
                                      diag::rocblas_diagonal, n::rocblas_int,
                                      A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                      invA::Ptr{rocblas_double_complex},
@@ -6224,7 +6224,7 @@ end
 
 function rocblas_strtri_batched(handle, uplo, diag, n, A, lda, invA, ldinvA, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_strtri_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_strtri_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                              diag::rocblas_diagonal, n::rocblas_int,
                                              A::Ptr{Ptr{Cfloat}}, lda::rocblas_int,
                                              invA::Ptr{Ptr{Cfloat}}, ldinvA::rocblas_int,
@@ -6233,7 +6233,7 @@ end
 
 function rocblas_dtrtri_batched(handle, uplo, diag, n, A, lda, invA, ldinvA, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtrtri_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dtrtri_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                              diag::rocblas_diagonal, n::rocblas_int,
                                              A::Ptr{Ptr{Cdouble}}, lda::rocblas_int,
                                              invA::Ptr{Ptr{Cdouble}}, ldinvA::rocblas_int,
@@ -6242,7 +6242,7 @@ end
 
 function rocblas_ctrtri_batched(handle, uplo, diag, n, A, lda, invA, ldinvA, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctrtri_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ctrtri_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                              diag::rocblas_diagonal, n::rocblas_int,
                                              A::Ptr{Ptr{rocblas_float_complex}},
                                              lda::rocblas_int,
@@ -6253,7 +6253,7 @@ end
 
 function rocblas_ztrtri_batched(handle, uplo, diag, n, A, lda, invA, ldinvA, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztrtri_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_ztrtri_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                              diag::rocblas_diagonal, n::rocblas_int,
                                              A::Ptr{Ptr{rocblas_double_complex}},
                                              lda::rocblas_int,
@@ -6265,7 +6265,7 @@ end
 function rocblas_strtri_strided_batched(handle, uplo, diag, n, A, lda, stride_a, invA,
                                         ldinvA, stride_invA, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_strtri_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_strtri_strided_batched(handle::rocblas_handle,
                                                      uplo::rocblas_fill,
                                                      diag::rocblas_diagonal, n::rocblas_int,
                                                      A::Ptr{Cfloat}, lda::rocblas_int,
@@ -6278,7 +6278,7 @@ end
 function rocblas_dtrtri_strided_batched(handle, uplo, diag, n, A, lda, stride_a, invA,
                                         ldinvA, stride_invA, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtrtri_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dtrtri_strided_batched(handle::rocblas_handle,
                                                      uplo::rocblas_fill,
                                                      diag::rocblas_diagonal, n::rocblas_int,
                                                      A::Ptr{Cdouble}, lda::rocblas_int,
@@ -6292,7 +6292,7 @@ end
 function rocblas_ctrtri_strided_batched(handle, uplo, diag, n, A, lda, stride_a, invA,
                                         ldinvA, stride_invA, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctrtri_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ctrtri_strided_batched(handle::rocblas_handle,
                                                      uplo::rocblas_fill,
                                                      diag::rocblas_diagonal, n::rocblas_int,
                                                      A::Ptr{rocblas_float_complex},
@@ -6307,7 +6307,7 @@ end
 function rocblas_ztrtri_strided_batched(handle, uplo, diag, n, A, lda, stride_a, invA,
                                         ldinvA, stride_invA, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztrtri_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ztrtri_strided_batched(handle::rocblas_handle,
                                                      uplo::rocblas_fill,
                                                      diag::rocblas_diagonal, n::rocblas_int,
                                                      A::Ptr{rocblas_double_complex},
@@ -6321,7 +6321,7 @@ end
 
 function rocblas_strsm(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B, ldb)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_strsm(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_strsm(handle::rocblas_handle, side::rocblas_side,
                                     uplo::rocblas_fill, transA::rocblas_operation,
                                     diag::rocblas_diagonal, m::rocblas_int, n::rocblas_int,
                                     alpha::Ptr{Cfloat}, A::Ptr{Cfloat}, lda::rocblas_int,
@@ -6330,7 +6330,7 @@ end
 
 function rocblas_dtrsm(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B, ldb)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtrsm(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_dtrsm(handle::rocblas_handle, side::rocblas_side,
                                     uplo::rocblas_fill, transA::rocblas_operation,
                                     diag::rocblas_diagonal, m::rocblas_int, n::rocblas_int,
                                     alpha::Ptr{Cdouble}, A::Ptr{Cdouble}, lda::rocblas_int,
@@ -6339,7 +6339,7 @@ end
 
 function rocblas_ctrsm(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B, ldb)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctrsm(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_ctrsm(handle::rocblas_handle, side::rocblas_side,
                                     uplo::rocblas_fill, transA::rocblas_operation,
                                     diag::rocblas_diagonal, m::rocblas_int, n::rocblas_int,
                                     alpha::Ptr{rocblas_float_complex},
@@ -6350,7 +6350,7 @@ end
 
 function rocblas_ztrsm(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B, ldb)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztrsm(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_ztrsm(handle::rocblas_handle, side::rocblas_side,
                                     uplo::rocblas_fill, transA::rocblas_operation,
                                     diag::rocblas_diagonal, m::rocblas_int, n::rocblas_int,
                                     alpha::Ptr{rocblas_double_complex},
@@ -6362,7 +6362,7 @@ end
 function rocblas_strsm_batched(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B,
                                ldb, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_strsm_batched(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_strsm_batched(handle::rocblas_handle, side::rocblas_side,
                                             uplo::rocblas_fill, transA::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             n::rocblas_int, alpha::Ptr{Cfloat},
@@ -6374,7 +6374,7 @@ end
 function rocblas_dtrsm_batched(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B,
                                ldb, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtrsm_batched(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_dtrsm_batched(handle::rocblas_handle, side::rocblas_side,
                                             uplo::rocblas_fill, transA::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             n::rocblas_int, alpha::Ptr{Cdouble},
@@ -6386,7 +6386,7 @@ end
 function rocblas_ctrsm_batched(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B,
                                ldb, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctrsm_batched(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_ctrsm_batched(handle::rocblas_handle, side::rocblas_side,
                                             uplo::rocblas_fill, transA::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             n::rocblas_int,
@@ -6401,7 +6401,7 @@ end
 function rocblas_ztrsm_batched(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B,
                                ldb, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztrsm_batched(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_ztrsm_batched(handle::rocblas_handle, side::rocblas_side,
                                             uplo::rocblas_fill, transA::rocblas_operation,
                                             diag::rocblas_diagonal, m::rocblas_int,
                                             n::rocblas_int,
@@ -6416,7 +6416,7 @@ end
 function rocblas_strsm_strided_batched(handle, side, uplo, transA, diag, m, n, alpha, A,
                                        lda, stride_a, B, ldb, stride_b, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_strsm_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_strsm_strided_batched(handle::rocblas_handle,
                                                     side::rocblas_side, uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -6431,7 +6431,7 @@ end
 function rocblas_dtrsm_strided_batched(handle, side, uplo, transA, diag, m, n, alpha, A,
                                        lda, stride_a, B, ldb, stride_b, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dtrsm_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dtrsm_strided_batched(handle::rocblas_handle,
                                                     side::rocblas_side, uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -6446,7 +6446,7 @@ end
 function rocblas_ctrsm_strided_batched(handle, side, uplo, transA, diag, m, n, alpha, A,
                                        lda, stride_a, B, ldb, stride_b, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ctrsm_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ctrsm_strided_batched(handle::rocblas_handle,
                                                     side::rocblas_side, uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -6464,7 +6464,7 @@ end
 function rocblas_ztrsm_strided_batched(handle, side, uplo, transA, diag, m, n, alpha, A,
                                        lda, stride_a, B, ldb, stride_b, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ztrsm_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ztrsm_strided_batched(handle::rocblas_handle,
                                                     side::rocblas_side, uplo::rocblas_fill,
                                                     transA::rocblas_operation,
                                                     diag::rocblas_diagonal, m::rocblas_int,
@@ -6481,7 +6481,7 @@ end
 
 function rocblas_sgemm(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sgemm(handle::rocblas_handle, transA::rocblas_operation,
+    @check @ccall librocblas.rocblas_sgemm(handle::rocblas_handle, transA::rocblas_operation,
                                     transB::rocblas_operation, m::rocblas_int,
                                     n::rocblas_int, k::rocblas_int, alpha::Ptr{Cfloat},
                                     A::Ptr{Cfloat}, lda::rocblas_int, B::Ptr{Cfloat},
@@ -6491,7 +6491,7 @@ end
 
 function rocblas_dgemm(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dgemm(handle::rocblas_handle, transA::rocblas_operation,
+    @check @ccall librocblas.rocblas_dgemm(handle::rocblas_handle, transA::rocblas_operation,
                                     transB::rocblas_operation, m::rocblas_int,
                                     n::rocblas_int, k::rocblas_int, alpha::Ptr{Cdouble},
                                     A::Ptr{Cdouble}, lda::rocblas_int, B::Ptr{Cdouble},
@@ -6501,7 +6501,7 @@ end
 
 function rocblas_hgemm(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_hgemm(handle::rocblas_handle, transA::rocblas_operation,
+    @check @ccall librocblas.rocblas_hgemm(handle::rocblas_handle, transA::rocblas_operation,
                                     transB::rocblas_operation, m::rocblas_int,
                                     n::rocblas_int, k::rocblas_int,
                                     alpha::Ptr{rocblas_half}, A::Ptr{rocblas_half},
@@ -6512,7 +6512,7 @@ end
 
 function rocblas_cgemm(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cgemm(handle::rocblas_handle, transA::rocblas_operation,
+    @check @ccall librocblas.rocblas_cgemm(handle::rocblas_handle, transA::rocblas_operation,
                                     transB::rocblas_operation, m::rocblas_int,
                                     n::rocblas_int, k::rocblas_int,
                                     alpha::Ptr{rocblas_float_complex},
@@ -6525,7 +6525,7 @@ end
 
 function rocblas_zgemm(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zgemm(handle::rocblas_handle, transA::rocblas_operation,
+    @check @ccall librocblas.rocblas_zgemm(handle::rocblas_handle, transA::rocblas_operation,
                                     transB::rocblas_operation, m::rocblas_int,
                                     n::rocblas_int, k::rocblas_int,
                                     alpha::Ptr{rocblas_double_complex},
@@ -6539,7 +6539,7 @@ end
 function rocblas_sgemm_batched(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta,
                                C, ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sgemm_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_sgemm_batched(handle::rocblas_handle,
                                             transA::rocblas_operation,
                                             transB::rocblas_operation, m::rocblas_int,
                                             n::rocblas_int, k::rocblas_int,
@@ -6553,7 +6553,7 @@ end
 function rocblas_dgemm_batched(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta,
                                C, ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dgemm_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dgemm_batched(handle::rocblas_handle,
                                             transA::rocblas_operation,
                                             transB::rocblas_operation, m::rocblas_int,
                                             n::rocblas_int, k::rocblas_int,
@@ -6567,7 +6567,7 @@ end
 function rocblas_hgemm_batched(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta,
                                C, ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_hgemm_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_hgemm_batched(handle::rocblas_handle,
                                             transA::rocblas_operation,
                                             transB::rocblas_operation, m::rocblas_int,
                                             n::rocblas_int, k::rocblas_int,
@@ -6582,7 +6582,7 @@ end
 function rocblas_cgemm_batched(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta,
                                C, ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cgemm_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_cgemm_batched(handle::rocblas_handle,
                                             transA::rocblas_operation,
                                             transB::rocblas_operation, m::rocblas_int,
                                             n::rocblas_int, k::rocblas_int,
@@ -6600,7 +6600,7 @@ end
 function rocblas_zgemm_batched(handle, transA, transB, m, n, k, alpha, A, lda, B, ldb, beta,
                                C, ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zgemm_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zgemm_batched(handle::rocblas_handle,
                                             transA::rocblas_operation,
                                             transB::rocblas_operation, m::rocblas_int,
                                             n::rocblas_int, k::rocblas_int,
@@ -6619,7 +6619,7 @@ function rocblas_sgemm_strided_batched(handle, transA, transB, m, n, k, alpha, A
                                        stride_a, B, ldb, stride_b, beta, C, ldc, stride_c,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sgemm_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_sgemm_strided_batched(handle::rocblas_handle,
                                                     transA::rocblas_operation,
                                                     transB::rocblas_operation,
                                                     m::rocblas_int, n::rocblas_int,
@@ -6638,7 +6638,7 @@ function rocblas_dgemm_strided_batched(handle, transA, transB, m, n, k, alpha, A
                                        stride_a, B, ldb, stride_b, beta, C, ldc, stride_c,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dgemm_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dgemm_strided_batched(handle::rocblas_handle,
                                                     transA::rocblas_operation,
                                                     transB::rocblas_operation,
                                                     m::rocblas_int, n::rocblas_int,
@@ -6657,7 +6657,7 @@ function rocblas_hgemm_strided_batched(handle, transA, transB, m, n, k, alpha, A
                                        stride_a, B, ldb, stride_b, beta, C, ldc, stride_c,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_hgemm_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_hgemm_strided_batched(handle::rocblas_handle,
                                                     transA::rocblas_operation,
                                                     transB::rocblas_operation,
                                                     m::rocblas_int, n::rocblas_int,
@@ -6676,7 +6676,7 @@ end
 function rocblas_hgemm_kernel_name(handle, transA, transB, m, n, k, alpha, A, lda, stride_a,
                                    B, ldb, stride_b, beta, C, ldc, stride_c, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_hgemm_kernel_name(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_hgemm_kernel_name(handle::rocblas_handle,
                                                 transA::rocblas_operation,
                                                 transB::rocblas_operation, m::rocblas_int,
                                                 n::rocblas_int, k::rocblas_int,
@@ -6694,7 +6694,7 @@ end
 function rocblas_sgemm_kernel_name(handle, transA, transB, m, n, k, alpha, A, lda, stride_a,
                                    B, ldb, stride_b, beta, C, ldc, stride_c, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sgemm_kernel_name(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_sgemm_kernel_name(handle::rocblas_handle,
                                                 transA::rocblas_operation,
                                                 transB::rocblas_operation, m::rocblas_int,
                                                 n::rocblas_int, k::rocblas_int,
@@ -6710,7 +6710,7 @@ end
 function rocblas_dgemm_kernel_name(handle, transA, transB, m, n, k, alpha, A, lda, stride_a,
                                    B, ldb, stride_b, beta, C, ldc, stride_c, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dgemm_kernel_name(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dgemm_kernel_name(handle::rocblas_handle,
                                                 transA::rocblas_operation,
                                                 transB::rocblas_operation, m::rocblas_int,
                                                 n::rocblas_int, k::rocblas_int,
@@ -6727,7 +6727,7 @@ function rocblas_cgemm_strided_batched(handle, transA, transB, m, n, k, alpha, A
                                        stride_a, B, ldb, stride_b, beta, C, ldc, stride_c,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cgemm_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_cgemm_strided_batched(handle::rocblas_handle,
                                                     transA::rocblas_operation,
                                                     transB::rocblas_operation,
                                                     m::rocblas_int, n::rocblas_int,
@@ -6750,7 +6750,7 @@ function rocblas_zgemm_strided_batched(handle, transA, transB, m, n, k, alpha, A
                                        stride_a, B, ldb, stride_b, beta, C, ldc, stride_c,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zgemm_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zgemm_strided_batched(handle::rocblas_handle,
                                                     transA::rocblas_operation,
                                                     transB::rocblas_operation,
                                                     m::rocblas_int, n::rocblas_int,
@@ -6771,7 +6771,7 @@ end
 
 function rocblas_sdgmm(handle, side, m, n, A, lda, x, incx, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sdgmm(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_sdgmm(handle::rocblas_handle, side::rocblas_side,
                                     m::rocblas_int, n::rocblas_int, A::Ptr{Cfloat},
                                     lda::rocblas_int, x::Ptr{Cfloat}, incx::rocblas_int,
                                     C::Ptr{Cfloat}, ldc::rocblas_int)::rocblas_status
@@ -6779,7 +6779,7 @@ end
 
 function rocblas_ddgmm(handle, side, m, n, A, lda, x, incx, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ddgmm(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_ddgmm(handle::rocblas_handle, side::rocblas_side,
                                     m::rocblas_int, n::rocblas_int, A::Ptr{Cdouble},
                                     lda::rocblas_int, x::Ptr{Cdouble}, incx::rocblas_int,
                                     C::Ptr{Cdouble}, ldc::rocblas_int)::rocblas_status
@@ -6787,7 +6787,7 @@ end
 
 function rocblas_cdgmm(handle, side, m, n, A, lda, x, incx, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cdgmm(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_cdgmm(handle::rocblas_handle, side::rocblas_side,
                                     m::rocblas_int, n::rocblas_int,
                                     A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                     x::Ptr{rocblas_float_complex}, incx::rocblas_int,
@@ -6797,7 +6797,7 @@ end
 
 function rocblas_zdgmm(handle, side, m, n, A, lda, x, incx, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zdgmm(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_zdgmm(handle::rocblas_handle, side::rocblas_side,
                                     m::rocblas_int, n::rocblas_int,
                                     A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                     x::Ptr{rocblas_double_complex}, incx::rocblas_int,
@@ -6807,7 +6807,7 @@ end
 
 function rocblas_sdgmm_batched(handle, side, m, n, A, lda, x, incx, C, ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sdgmm_batched(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_sdgmm_batched(handle::rocblas_handle, side::rocblas_side,
                                             m::rocblas_int, n::rocblas_int,
                                             A::Ptr{Ptr{Cfloat}}, lda::rocblas_int,
                                             x::Ptr{Ptr{Cfloat}}, incx::rocblas_int,
@@ -6817,7 +6817,7 @@ end
 
 function rocblas_ddgmm_batched(handle, side, m, n, A, lda, x, incx, C, ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ddgmm_batched(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_ddgmm_batched(handle::rocblas_handle, side::rocblas_side,
                                             m::rocblas_int, n::rocblas_int,
                                             A::Ptr{Ptr{Cdouble}}, lda::rocblas_int,
                                             x::Ptr{Ptr{Cdouble}}, incx::rocblas_int,
@@ -6827,7 +6827,7 @@ end
 
 function rocblas_cdgmm_batched(handle, side, m, n, A, lda, x, incx, C, ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cdgmm_batched(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_cdgmm_batched(handle::rocblas_handle, side::rocblas_side,
                                             m::rocblas_int, n::rocblas_int,
                                             A::Ptr{Ptr{rocblas_float_complex}},
                                             lda::rocblas_int,
@@ -6840,7 +6840,7 @@ end
 
 function rocblas_zdgmm_batched(handle, side, m, n, A, lda, x, incx, C, ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zdgmm_batched(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_zdgmm_batched(handle::rocblas_handle, side::rocblas_side,
                                             m::rocblas_int, n::rocblas_int,
                                             A::Ptr{Ptr{rocblas_double_complex}},
                                             lda::rocblas_int,
@@ -6854,7 +6854,7 @@ end
 function rocblas_sdgmm_strided_batched(handle, side, m, n, A, lda, stride_A, x, incx,
                                        stride_x, C, ldc, stride_C, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sdgmm_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_sdgmm_strided_batched(handle::rocblas_handle,
                                                     side::rocblas_side, m::rocblas_int,
                                                     n::rocblas_int, A::Ptr{Cfloat},
                                                     lda::rocblas_int,
@@ -6869,7 +6869,7 @@ end
 function rocblas_ddgmm_strided_batched(handle, side, m, n, A, lda, stride_A, x, incx,
                                        stride_x, C, ldc, stride_C, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_ddgmm_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_ddgmm_strided_batched(handle::rocblas_handle,
                                                     side::rocblas_side, m::rocblas_int,
                                                     n::rocblas_int, A::Ptr{Cdouble},
                                                     lda::rocblas_int,
@@ -6884,7 +6884,7 @@ end
 function rocblas_cdgmm_strided_batched(handle, side, m, n, A, lda, stride_A, x, incx,
                                        stride_x, C, ldc, stride_C, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cdgmm_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_cdgmm_strided_batched(handle::rocblas_handle,
                                                     side::rocblas_side, m::rocblas_int,
                                                     n::rocblas_int,
                                                     A::Ptr{rocblas_float_complex},
@@ -6902,7 +6902,7 @@ end
 function rocblas_zdgmm_strided_batched(handle, side, m, n, A, lda, stride_A, x, incx,
                                        stride_x, C, ldc, stride_C, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zdgmm_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zdgmm_strided_batched(handle::rocblas_handle,
                                                     side::rocblas_side, m::rocblas_int,
                                                     n::rocblas_int,
                                                     A::Ptr{rocblas_double_complex},
@@ -6919,7 +6919,7 @@ end
 
 function rocblas_sgeam(handle, transA, transB, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sgeam(handle::rocblas_handle, transA::rocblas_operation,
+    @check @ccall librocblas.rocblas_sgeam(handle::rocblas_handle, transA::rocblas_operation,
                                     transB::rocblas_operation, m::rocblas_int,
                                     n::rocblas_int, alpha::Ptr{Cfloat}, A::Ptr{Cfloat},
                                     lda::rocblas_int, beta::Ptr{Cfloat}, B::Ptr{Cfloat},
@@ -6929,7 +6929,7 @@ end
 
 function rocblas_dgeam(handle, transA, transB, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dgeam(handle::rocblas_handle, transA::rocblas_operation,
+    @check @ccall librocblas.rocblas_dgeam(handle::rocblas_handle, transA::rocblas_operation,
                                     transB::rocblas_operation, m::rocblas_int,
                                     n::rocblas_int, alpha::Ptr{Cdouble}, A::Ptr{Cdouble},
                                     lda::rocblas_int, beta::Ptr{Cdouble}, B::Ptr{Cdouble},
@@ -6939,7 +6939,7 @@ end
 
 function rocblas_cgeam(handle, transA, transB, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cgeam(handle::rocblas_handle, transA::rocblas_operation,
+    @check @ccall librocblas.rocblas_cgeam(handle::rocblas_handle, transA::rocblas_operation,
                                     transB::rocblas_operation, m::rocblas_int,
                                     n::rocblas_int, alpha::Ptr{rocblas_float_complex},
                                     A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -6951,7 +6951,7 @@ end
 
 function rocblas_zgeam(handle, transA, transB, m, n, alpha, A, lda, beta, B, ldb, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zgeam(handle::rocblas_handle, transA::rocblas_operation,
+    @check @ccall librocblas.rocblas_zgeam(handle::rocblas_handle, transA::rocblas_operation,
                                     transB::rocblas_operation, m::rocblas_int,
                                     n::rocblas_int, alpha::Ptr{rocblas_double_complex},
                                     A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -6964,7 +6964,7 @@ end
 function rocblas_sgeam_batched(handle, transA, transB, m, n, alpha, A, lda, beta, B, ldb, C,
                                ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sgeam_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_sgeam_batched(handle::rocblas_handle,
                                             transA::rocblas_operation,
                                             transB::rocblas_operation, m::rocblas_int,
                                             n::rocblas_int, alpha::Ptr{Cfloat},
@@ -6978,7 +6978,7 @@ end
 function rocblas_dgeam_batched(handle, transA, transB, m, n, alpha, A, lda, beta, B, ldb, C,
                                ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dgeam_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dgeam_batched(handle::rocblas_handle,
                                             transA::rocblas_operation,
                                             transB::rocblas_operation, m::rocblas_int,
                                             n::rocblas_int, alpha::Ptr{Cdouble},
@@ -6992,7 +6992,7 @@ end
 function rocblas_cgeam_batched(handle, transA, transB, m, n, alpha, A, lda, beta, B, ldb, C,
                                ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cgeam_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_cgeam_batched(handle::rocblas_handle,
                                             transA::rocblas_operation,
                                             transB::rocblas_operation, m::rocblas_int,
                                             n::rocblas_int,
@@ -7010,7 +7010,7 @@ end
 function rocblas_zgeam_batched(handle, transA, transB, m, n, alpha, A, lda, beta, B, ldb, C,
                                ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zgeam_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zgeam_batched(handle::rocblas_handle,
                                             transA::rocblas_operation,
                                             transB::rocblas_operation, m::rocblas_int,
                                             n::rocblas_int,
@@ -7029,7 +7029,7 @@ function rocblas_sgeam_strided_batched(handle, transA, transB, m, n, alpha, A, l
                                        stride_A, beta, B, ldb, stride_B, C, ldc, stride_C,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sgeam_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_sgeam_strided_batched(handle::rocblas_handle,
                                                     transA::rocblas_operation,
                                                     transB::rocblas_operation,
                                                     m::rocblas_int, n::rocblas_int,
@@ -7048,7 +7048,7 @@ function rocblas_dgeam_strided_batched(handle, transA, transB, m, n, alpha, A, l
                                        stride_A, beta, B, ldb, stride_B, C, ldc, stride_C,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dgeam_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dgeam_strided_batched(handle::rocblas_handle,
                                                     transA::rocblas_operation,
                                                     transB::rocblas_operation,
                                                     m::rocblas_int, n::rocblas_int,
@@ -7067,7 +7067,7 @@ function rocblas_cgeam_strided_batched(handle, transA, transB, m, n, alpha, A, l
                                        stride_A, beta, B, ldb, stride_B, C, ldc, stride_C,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cgeam_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_cgeam_strided_batched(handle::rocblas_handle,
                                                     transA::rocblas_operation,
                                                     transB::rocblas_operation,
                                                     m::rocblas_int, n::rocblas_int,
@@ -7089,7 +7089,7 @@ function rocblas_zgeam_strided_batched(handle, transA, transB, m, n, alpha, A, l
                                        stride_A, beta, B, ldb, stride_B, C, ldc, stride_C,
                                        batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zgeam_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zgeam_strided_batched(handle::rocblas_handle,
                                                     transA::rocblas_operation,
                                                     transB::rocblas_operation,
                                                     m::rocblas_int, n::rocblas_int,
@@ -7111,7 +7111,7 @@ function rocblas_gemm_batched_ex(handle, transA, transB, m, n, k, alpha, a, a_ty
                                  b_type, ldb, beta, c, c_type, ldc, d, d_type, ldd,
                                  batch_count, compute_type, algo, solution_index, flags)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_gemm_batched_ex(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_gemm_batched_ex(handle::rocblas_handle,
                                               transA::rocblas_operation,
                                               transB::rocblas_operation, m::rocblas_int,
                                               n::rocblas_int, k::rocblas_int,
@@ -7132,7 +7132,7 @@ end
 function rocblas_sgemmt(handle, uplo, transA, transB, n, k, alpha, A, lda, B, ldb, beta, C,
                         ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sgemmt(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_sgemmt(handle::rocblas_handle, uplo::rocblas_fill,
                                      transA::rocblas_operation, transB::rocblas_operation,
                                      n::rocblas_int, k::rocblas_int, alpha::Ptr{Cfloat},
                                      A::Ptr{Cfloat}, lda::rocblas_int, B::Ptr{Cfloat},
@@ -7143,7 +7143,7 @@ end
 function rocblas_dgemmt(handle, uplo, transA, transB, n, k, alpha, A, lda, B, ldb, beta, C,
                         ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dgemmt(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dgemmt(handle::rocblas_handle, uplo::rocblas_fill,
                                      transA::rocblas_operation, transB::rocblas_operation,
                                      n::rocblas_int, k::rocblas_int, alpha::Ptr{Cdouble},
                                      A::Ptr{Cdouble}, lda::rocblas_int, B::Ptr{Cdouble},
@@ -7154,7 +7154,7 @@ end
 function rocblas_cgemmt(handle, uplo, transA, transB, n, k, alpha, A, lda, B, ldb, beta, C,
                         ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cgemmt(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_cgemmt(handle::rocblas_handle, uplo::rocblas_fill,
                                      transA::rocblas_operation, transB::rocblas_operation,
                                      n::rocblas_int, k::rocblas_int,
                                      alpha::Ptr{rocblas_float_complex},
@@ -7168,7 +7168,7 @@ end
 function rocblas_zgemmt(handle, uplo, transA, transB, n, k, alpha, A, lda, B, ldb, beta, C,
                         ldc)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zgemmt(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zgemmt(handle::rocblas_handle, uplo::rocblas_fill,
                                      transA::rocblas_operation, transB::rocblas_operation,
                                      n::rocblas_int, k::rocblas_int,
                                      alpha::Ptr{rocblas_double_complex},
@@ -7182,7 +7182,7 @@ end
 function rocblas_sgemmt_batched(handle, uplo, transA, transB, n, k, alpha, A, lda, B, ldb,
                                 beta, C, ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sgemmt_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_sgemmt_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                              transA::rocblas_operation,
                                              transB::rocblas_operation, n::rocblas_int,
                                              k::rocblas_int, alpha::Ptr{Cfloat},
@@ -7196,7 +7196,7 @@ end
 function rocblas_dgemmt_batched(handle, uplo, transA, transB, n, k, alpha, A, lda, B, ldb,
                                 beta, C, ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dgemmt_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_dgemmt_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                              transA::rocblas_operation,
                                              transB::rocblas_operation, n::rocblas_int,
                                              k::rocblas_int, alpha::Ptr{Cdouble},
@@ -7210,7 +7210,7 @@ end
 function rocblas_cgemmt_batched(handle, uplo, transA, transB, n, k, alpha, A, lda, B, ldb,
                                 beta, C, ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cgemmt_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_cgemmt_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                              transA::rocblas_operation,
                                              transB::rocblas_operation, n::rocblas_int,
                                              k::rocblas_int,
@@ -7228,7 +7228,7 @@ end
 function rocblas_zgemmt_batched(handle, uplo, transA, transB, n, k, alpha, A, lda, B, ldb,
                                 beta, C, ldc, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zgemmt_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocblas.rocblas_zgemmt_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                              transA::rocblas_operation,
                                              transB::rocblas_operation, n::rocblas_int,
                                              k::rocblas_int,
@@ -7247,7 +7247,7 @@ function rocblas_sgemmt_strided_batched(handle, uplo, transA, transB, n, k, alph
                                         stride_a, B, ldb, stride_b, beta, C, ldc, stride_c,
                                         batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_sgemmt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_sgemmt_strided_batched(handle::rocblas_handle,
                                                      uplo::rocblas_fill,
                                                      transA::rocblas_operation,
                                                      transB::rocblas_operation,
@@ -7267,7 +7267,7 @@ function rocblas_dgemmt_strided_batched(handle, uplo, transA, transB, n, k, alph
                                         stride_a, B, ldb, stride_b, beta, C, ldc, stride_c,
                                         batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dgemmt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dgemmt_strided_batched(handle::rocblas_handle,
                                                      uplo::rocblas_fill,
                                                      transA::rocblas_operation,
                                                      transB::rocblas_operation,
@@ -7287,7 +7287,7 @@ function rocblas_cgemmt_strided_batched(handle, uplo, transA, transB, n, k, alph
                                         stride_a, B, ldb, stride_b, beta, C, ldc, stride_c,
                                         batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_cgemmt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_cgemmt_strided_batched(handle::rocblas_handle,
                                                      uplo::rocblas_fill,
                                                      transA::rocblas_operation,
                                                      transB::rocblas_operation,
@@ -7310,7 +7310,7 @@ function rocblas_zgemmt_strided_batched(handle, uplo, transA, transB, n, k, alph
                                         stride_a, B, ldb, stride_b, beta, C, ldc, stride_c,
                                         batch_count)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_zgemmt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_zgemmt_strided_batched(handle::rocblas_handle,
                                                      uplo::rocblas_fill,
                                                      transA::rocblas_operation,
                                                      transB::rocblas_operation,
@@ -7333,7 +7333,7 @@ function rocblas_geam_ex(handle, transA, transB, m, n, k, alpha, A, a_type, lda,
                          ldb, beta, C, c_type, ldc, D, d_type, ldd, compute_type,
                          geam_ex_op)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_geam_ex(handle::rocblas_handle, transA::rocblas_operation,
+    @check @ccall librocblas.rocblas_geam_ex(handle::rocblas_handle, transA::rocblas_operation,
                                       transB::rocblas_operation, m::rocblas_int,
                                       n::rocblas_int, k::rocblas_int, alpha::Ptr{Cvoid},
                                       A::Ptr{Cvoid}, a_type::rocblas_datatype,
@@ -7349,7 +7349,7 @@ end
 function rocblas_trsm_batched_ex(handle, side, uplo, transA, diag, m, n, alpha, A, lda, B,
                                  ldb, batch_count, invA, invA_size, compute_type)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_trsm_batched_ex(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocblas.rocblas_trsm_batched_ex(handle::rocblas_handle, side::rocblas_side,
                                               uplo::rocblas_fill, transA::rocblas_operation,
                                               diag::rocblas_diagonal, m::rocblas_int,
                                               n::rocblas_int, alpha::Ptr{Cvoid},
@@ -7364,7 +7364,7 @@ function rocblas_trsm_strided_batched_ex(handle, side, uplo, transA, diag, m, n,
                                          lda, stride_A, B, ldb, stride_B, batch_count, invA,
                                          invA_size, stride_invA, compute_type)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_trsm_strided_batched_ex(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_trsm_strided_batched_ex(handle::rocblas_handle,
                                                       side::rocblas_side,
                                                       uplo::rocblas_fill,
                                                       transA::rocblas_operation,
@@ -7385,7 +7385,7 @@ end
 function rocblas_axpy_ex(handle, n, alpha, alpha_type, x, x_type, incx, y, y_type, incy,
                          execution_type)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_axpy_ex(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_axpy_ex(handle::rocblas_handle, n::rocblas_int,
                                       alpha::Ptr{Cvoid}, alpha_type::rocblas_datatype,
                                       x::Ptr{Cvoid}, x_type::rocblas_datatype,
                                       incx::rocblas_int, y::Ptr{Cvoid},
@@ -7396,7 +7396,7 @@ end
 function rocblas_axpy_batched_ex(handle, n, alpha, alpha_type, x, x_type, incx, y, y_type,
                                  incy, batch_count, execution_type)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_axpy_batched_ex(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_axpy_batched_ex(handle::rocblas_handle, n::rocblas_int,
                                               alpha::Ptr{Cvoid},
                                               alpha_type::rocblas_datatype, x::Ptr{Cvoid},
                                               x_type::rocblas_datatype, incx::rocblas_int,
@@ -7409,7 +7409,7 @@ function rocblas_axpy_strided_batched_ex(handle, n, alpha, alpha_type, x, x_type
                                          stridex, y, y_type, incy, stridey, batch_count,
                                          execution_type)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_axpy_strided_batched_ex(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_axpy_strided_batched_ex(handle::rocblas_handle,
                                                       n::rocblas_int, alpha::Ptr{Cvoid},
                                                       alpha_type::rocblas_datatype,
                                                       x::Ptr{Cvoid},
@@ -7427,7 +7427,7 @@ end
 function rocblas_dot_ex(handle, n, x, x_type, incx, y, y_type, incy, result, result_type,
                         execution_type)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dot_ex(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cvoid},
+    @check @ccall librocblas.rocblas_dot_ex(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cvoid},
                                      x_type::rocblas_datatype, incx::rocblas_int,
                                      y::Ptr{Cvoid}, y_type::rocblas_datatype,
                                      incy::rocblas_int, result::Ptr{Cvoid},
@@ -7438,7 +7438,7 @@ end
 function rocblas_dotc_ex(handle, n, x, x_type, incx, y, y_type, incy, result, result_type,
                          execution_type)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dotc_ex(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cvoid},
+    @check @ccall librocblas.rocblas_dotc_ex(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cvoid},
                                       x_type::rocblas_datatype, incx::rocblas_int,
                                       y::Ptr{Cvoid}, y_type::rocblas_datatype,
                                       incy::rocblas_int, result::Ptr{Cvoid},
@@ -7449,7 +7449,7 @@ end
 function rocblas_dot_batched_ex(handle, n, x, x_type, incx, y, y_type, incy, batch_count,
                                 result, result_type, execution_type)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dot_batched_ex(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_dot_batched_ex(handle::rocblas_handle, n::rocblas_int,
                                              x::Ptr{Cvoid}, x_type::rocblas_datatype,
                                              incx::rocblas_int, y::Ptr{Cvoid},
                                              y_type::rocblas_datatype, incy::rocblas_int,
@@ -7461,7 +7461,7 @@ end
 function rocblas_dotc_batched_ex(handle, n, x, x_type, incx, y, y_type, incy, batch_count,
                                  result, result_type, execution_type)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dotc_batched_ex(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_dotc_batched_ex(handle::rocblas_handle, n::rocblas_int,
                                               x::Ptr{Cvoid}, x_type::rocblas_datatype,
                                               incx::rocblas_int, y::Ptr{Cvoid},
                                               y_type::rocblas_datatype, incy::rocblas_int,
@@ -7474,7 +7474,7 @@ function rocblas_dot_strided_batched_ex(handle, n, x, x_type, incx, stride_x, y,
                                         incy, stride_y, batch_count, result, result_type,
                                         execution_type)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dot_strided_batched_ex(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_dot_strided_batched_ex(handle::rocblas_handle, n::rocblas_int,
                                                      x::Ptr{Cvoid},
                                                      x_type::rocblas_datatype,
                                                      incx::rocblas_int,
@@ -7493,7 +7493,7 @@ function rocblas_dotc_strided_batched_ex(handle, n, x, x_type, incx, stride_x, y
                                          incy, stride_y, batch_count, result, result_type,
                                          execution_type)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_dotc_strided_batched_ex(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_dotc_strided_batched_ex(handle::rocblas_handle,
                                                       n::rocblas_int, x::Ptr{Cvoid},
                                                       x_type::rocblas_datatype,
                                                       incx::rocblas_int,
@@ -7510,7 +7510,7 @@ end
 
 function rocblas_nrm2_ex(handle, n, x, x_type, incx, results, result_type, execution_type)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_nrm2_ex(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cvoid},
+    @check @ccall librocblas.rocblas_nrm2_ex(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cvoid},
                                       x_type::rocblas_datatype, incx::rocblas_int,
                                       results::Ptr{Cvoid}, result_type::rocblas_datatype,
                                       execution_type::rocblas_datatype)::rocblas_status
@@ -7519,7 +7519,7 @@ end
 function rocblas_nrm2_batched_ex(handle, n, x, x_type, incx, batch_count, results,
                                  result_type, execution_type)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_nrm2_batched_ex(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_nrm2_batched_ex(handle::rocblas_handle, n::rocblas_int,
                                               x::Ptr{Cvoid}, x_type::rocblas_datatype,
                                               incx::rocblas_int, batch_count::rocblas_int,
                                               results::Ptr{Cvoid},
@@ -7530,7 +7530,7 @@ end
 function rocblas_nrm2_strided_batched_ex(handle, n, x, x_type, incx, stride_x, batch_count,
                                          results, result_type, execution_type)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_nrm2_strided_batched_ex(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_nrm2_strided_batched_ex(handle::rocblas_handle,
                                                       n::rocblas_int, x::Ptr{Cvoid},
                                                       x_type::rocblas_datatype,
                                                       incx::rocblas_int,
@@ -7544,7 +7544,7 @@ end
 function rocblas_rot_ex(handle, n, x, x_type, incx, y, y_type, incy, c, s, cs_type,
                         execution_type)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_rot_ex(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cvoid},
+    @check @ccall librocblas.rocblas_rot_ex(handle::rocblas_handle, n::rocblas_int, x::Ptr{Cvoid},
                                      x_type::rocblas_datatype, incx::rocblas_int,
                                      y::Ptr{Cvoid}, y_type::rocblas_datatype,
                                      incy::rocblas_int, c::Ptr{Cvoid}, s::Ptr{Cvoid},
@@ -7555,7 +7555,7 @@ end
 function rocblas_rot_batched_ex(handle, n, x, x_type, incx, y, y_type, incy, c, s, cs_type,
                                 batch_count, execution_type)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_rot_batched_ex(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_rot_batched_ex(handle::rocblas_handle, n::rocblas_int,
                                              x::Ptr{Cvoid}, x_type::rocblas_datatype,
                                              incx::rocblas_int, y::Ptr{Cvoid},
                                              y_type::rocblas_datatype, incy::rocblas_int,
@@ -7569,7 +7569,7 @@ function rocblas_rot_strided_batched_ex(handle, n, x, x_type, incx, stride_x, y,
                                         incy, stride_y, c, s, cs_type, batch_count,
                                         execution_type)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_rot_strided_batched_ex(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_rot_strided_batched_ex(handle::rocblas_handle, n::rocblas_int,
                                                      x::Ptr{Cvoid},
                                                      x_type::rocblas_datatype,
                                                      incx::rocblas_int,
@@ -7586,7 +7586,7 @@ end
 
 function rocblas_scal_ex(handle, n, alpha, alpha_type, x, x_type, incx, execution_type)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_scal_ex(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_scal_ex(handle::rocblas_handle, n::rocblas_int,
                                       alpha::Ptr{Cvoid}, alpha_type::rocblas_datatype,
                                       x::Ptr{Cvoid}, x_type::rocblas_datatype,
                                       incx::rocblas_int,
@@ -7596,7 +7596,7 @@ end
 function rocblas_scal_batched_ex(handle, n, alpha, alpha_type, x, x_type, incx, batch_count,
                                  execution_type)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_scal_batched_ex(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocblas.rocblas_scal_batched_ex(handle::rocblas_handle, n::rocblas_int,
                                               alpha::Ptr{Cvoid},
                                               alpha_type::rocblas_datatype, x::Ptr{Cvoid},
                                               x_type::rocblas_datatype, incx::rocblas_int,
@@ -7607,7 +7607,7 @@ end
 function rocblas_scal_strided_batched_ex(handle, n, alpha, alpha_type, x, x_type, incx,
                                          stridex, batch_count, execution_type)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_scal_strided_batched_ex(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_scal_strided_batched_ex(handle::rocblas_handle,
                                                       n::rocblas_int, alpha::Ptr{Cvoid},
                                                       alpha_type::rocblas_datatype,
                                                       x::Ptr{Cvoid},
@@ -7619,99 +7619,96 @@ function rocblas_scal_strided_batched_ex(handle, n, alpha, alpha_type, x, x_type
 end
 
 function rocblas_status_to_string(status)
-    AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_status_to_string(status::rocblas_status)::Ptr{Cchar}
+    @check @ccall librocblas.rocblas_status_to_string(status::rocblas_status)::Ptr{Cchar}
 end
 
 function rocblas_initialize()
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_initialize()::Cvoid
+    @check @ccall librocblas.rocblas_initialize()::Cvoid
 end
 
 function rocblas_get_version_string(buf, len)
-    AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_get_version_string(buf::Ptr{Cchar},
+    @check @ccall librocblas.rocblas_get_version_string(buf::Ptr{Cchar},
                                                  len::Csize_t)::rocblas_status
 end
 
 function rocblas_get_version_string_size(len)
-    AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_get_version_string_size(len::Ptr{Csize_t})::rocblas_status
+    @check @ccall librocblas.rocblas_get_version_string_size(len::Ptr{Csize_t})::rocblas_status
 end
 
 function rocblas_start_device_memory_size_query(handle)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_start_device_memory_size_query(handle::rocblas_handle)::rocblas_status
+    @check @ccall librocblas.rocblas_start_device_memory_size_query(handle::rocblas_handle)::rocblas_status
 end
 
 function rocblas_stop_device_memory_size_query(handle, size)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_stop_device_memory_size_query(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_stop_device_memory_size_query(handle::rocblas_handle,
                                                             size::Ptr{Csize_t})::rocblas_status
 end
 
 function rocblas_is_device_memory_size_query(handle)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_is_device_memory_size_query(handle::rocblas_handle)::Bool
+    @check @ccall librocblas.rocblas_is_device_memory_size_query(handle::rocblas_handle)::Bool
 end
 
 function rocblas_device_malloc_success(ptr)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_device_malloc_success(ptr::Ptr{rocblas_device_malloc_base})::Bool
+    @check @ccall librocblas.rocblas_device_malloc_success(ptr::Ptr{rocblas_device_malloc_base})::Bool
 end
 
 function rocblas_device_malloc_ptr(ptr, res)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_device_malloc_ptr(ptr::Ptr{rocblas_device_malloc_base},
+    @check @ccall librocblas.rocblas_device_malloc_ptr(ptr::Ptr{rocblas_device_malloc_base},
                                                 res::Ptr{Ptr{Cvoid}})::rocblas_status
 end
 
 function rocblas_device_malloc_get(ptr, index, res)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_device_malloc_get(ptr::Ptr{rocblas_device_malloc_base},
+    @check @ccall librocblas.rocblas_device_malloc_get(ptr::Ptr{rocblas_device_malloc_base},
                                                 index::Csize_t,
                                                 res::Ptr{Ptr{Cvoid}})::rocblas_status
 end
 
 function rocblas_device_malloc_free(ptr)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_device_malloc_free(ptr::Ptr{rocblas_device_malloc_base})::rocblas_status
+    @check @ccall librocblas.rocblas_device_malloc_free(ptr::Ptr{rocblas_device_malloc_base})::rocblas_status
 end
 
 function rocblas_device_malloc_set_default_memory_size(size)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_device_malloc_set_default_memory_size(size::Csize_t)::Cvoid
+    @check @ccall librocblas.rocblas_device_malloc_set_default_memory_size(size::Csize_t)::Cvoid
 end
 
 function rocblas_get_device_memory_size(handle, size)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_get_device_memory_size(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_get_device_memory_size(handle::rocblas_handle,
                                                      size::Ptr{Csize_t})::rocblas_status
 end
 
 function rocblas_set_device_memory_size(handle, size)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_set_device_memory_size(handle::rocblas_handle,
+    @check @ccall librocblas.rocblas_set_device_memory_size(handle::rocblas_handle,
                                                      size::Csize_t)::rocblas_status
 end
 
 function rocblas_set_workspace(handle, addr, size)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_set_workspace(handle::rocblas_handle, addr::Ptr{Cvoid},
+    @check @ccall librocblas.rocblas_set_workspace(handle::rocblas_handle, addr::Ptr{Cvoid},
                                             size::Csize_t)::rocblas_status
 end
 
 function rocblas_is_managing_device_memory(handle)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_is_managing_device_memory(handle::rocblas_handle)::Bool
+    @check @ccall librocblas.rocblas_is_managing_device_memory(handle::rocblas_handle)::Bool
 end
 
 function rocblas_is_user_managing_device_memory(handle)
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_is_user_managing_device_memory(handle::rocblas_handle)::Bool
+    @check @ccall librocblas.rocblas_is_user_managing_device_memory(handle::rocblas_handle)::Bool
 end
 
 function rocblas_abort()
     AMDGPU.prepare_state()
-    @ccall librocblas.rocblas_abort()::Cvoid
+    @check @ccall librocblas.rocblas_abort()::Cvoid
 end

--- a/src/discovery/discovery.jl
+++ b/src/discovery/discovery.jl
@@ -91,12 +91,13 @@ function __init__()
         global libhip = get_library(
             Sys.islinux() ? "libamdhip64" : "amdhip64"; rocm_path)
 
-        # Detect HIP version, which will influence what device libraries to use.
-        hip_version = Base.thisminor(_hip_runtime_version())
         # Check if opaque pointers are enabled and turn off artifacts.
         llvm_args = get(ENV, "JULIA_LLVM_ARGS", "")
         enabled_opaque_pointers = occursin("-opaque-pointers", llvm_args)
-        from_artifact = hip_version > v"5.4" && !enabled_opaque_pointers
+        from_artifact = (
+            # Detect HIP version, which will influence what device libraries to use.
+            (isempty(libhip) || Base.thisminor(_hip_runtime_version()) > v"5.4")
+            && !enabled_opaque_pointers)
 
         # If ROCm 5.5+ - use artifact device libraries.
         global libdevice_libs = get_device_libs(from_artifact; rocm_path)

--- a/src/dnn/libMIOpen.jl
+++ b/src/dnn/libMIOpen.jl
@@ -26,7 +26,6 @@ const miopenAllocatorFunction = Ptr{Cvoid}
 const miopenDeallocatorFunction = Ptr{Cvoid}
 
 function miopenGetVersion(major, minor, patch)
-    AMDGPU.prepare_state()
     @check ccall((:miopenGetVersion, libMIOpen_path), miopenStatus_t, (Ptr{Csize_t}, Ptr{Csize_t}, Ptr{Csize_t}), major, minor, patch)
 end
 

--- a/src/solver/librocsolver.jl
+++ b/src/solver/librocsolver.jl
@@ -44,29 +44,29 @@ const rocsolver_storev = rocblas_storev
 
 function rocsolver_create_handle(handle)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_create_handle(handle::Ptr{rocsolver_handle})::rocsolver_status
+    @check @ccall librocsolver.rocsolver_create_handle(handle::Ptr{rocsolver_handle})::rocsolver_status
 end
 
 function rocsolver_destroy_handle(handle)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_destroy_handle(handle::rocsolver_handle)::rocsolver_status
+    @check @ccall librocsolver.rocsolver_destroy_handle(handle::rocsolver_handle)::rocsolver_status
 end
 
 function rocsolver_set_stream(handle, stream)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_set_stream(handle::rocsolver_handle,
+    @check @ccall librocsolver.rocsolver_set_stream(handle::rocsolver_handle,
                                              stream::hipStream_t)::rocsolver_status
 end
 
 function rocsolver_get_stream(handle, stream)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_get_stream(handle::rocsolver_handle,
+    @check @ccall librocsolver.rocsolver_get_stream(handle::rocsolver_handle,
                                              stream::Ptr{hipStream_t})::rocsolver_status
 end
 
 function rocsolver_set_vector(n, elem_size, x, incx, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_set_vector(n::rocsolver_int, elem_size::rocsolver_int,
+    @check @ccall librocsolver.rocsolver_set_vector(n::rocsolver_int, elem_size::rocsolver_int,
                                              x::Ptr{Cvoid}, incx::rocsolver_int,
                                              y::Ptr{Cvoid},
                                              incy::rocsolver_int)::rocsolver_status
@@ -74,7 +74,7 @@ end
 
 function rocsolver_get_vector(n, elem_size, x, incx, y, incy)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_get_vector(n::rocsolver_int, elem_size::rocsolver_int,
+    @check @ccall librocsolver.rocsolver_get_vector(n::rocsolver_int, elem_size::rocsolver_int,
                                              x::Ptr{Cvoid}, incx::rocsolver_int,
                                              y::Ptr{Cvoid},
                                              incy::rocsolver_int)::rocsolver_status
@@ -82,7 +82,7 @@ end
 
 function rocsolver_set_matrix(rows, cols, elem_size, a, lda, b, ldb)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_set_matrix(rows::rocsolver_int, cols::rocsolver_int,
+    @check @ccall librocsolver.rocsolver_set_matrix(rows::rocsolver_int, cols::rocsolver_int,
                                              elem_size::rocsolver_int, a::Ptr{Cvoid},
                                              lda::rocsolver_int, b::Ptr{Cvoid},
                                              ldb::rocsolver_int)::rocsolver_status
@@ -90,7 +90,7 @@ end
 
 function rocsolver_get_matrix(rows, cols, elem_size, a, lda, b, ldb)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_get_matrix(rows::rocsolver_int, cols::rocsolver_int,
+    @check @ccall librocsolver.rocsolver_get_matrix(rows::rocsolver_int, cols::rocsolver_int,
                                              elem_size::rocsolver_int, a::Ptr{Cvoid},
                                              lda::rocsolver_int, b::Ptr{Cvoid},
                                              ldb::rocsolver_int)::rocsolver_status
@@ -178,68 +178,66 @@ end
 const rocsolver_rfinfo_mode = rocsolver_rfinfo_mode_
 
 function rocsolver_get_version_string(buf, len)
-    AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_get_version_string(buf::Ptr{Cchar},
+    @check @ccall librocsolver.rocsolver_get_version_string(buf::Ptr{Cchar},
                                                      len::Csize_t)::rocblas_status
 end
 
 function rocsolver_get_version_string_size(len)
-    AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_get_version_string_size(len::Ptr{Csize_t})::rocblas_status
+    @check @ccall librocsolver.rocsolver_get_version_string_size(len::Ptr{Csize_t})::rocblas_status
 end
 
 function rocsolver_log_begin()
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_log_begin()::rocblas_status
+    @check @ccall librocsolver.rocsolver_log_begin()::rocblas_status
 end
 
 function rocsolver_log_end()
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_log_end()::rocblas_status
+    @check @ccall librocsolver.rocsolver_log_end()::rocblas_status
 end
 
 function rocsolver_log_set_layer_mode(layer_mode)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_log_set_layer_mode(layer_mode::rocblas_layer_mode_flags)::rocblas_status
+    @check @ccall librocsolver.rocsolver_log_set_layer_mode(layer_mode::rocblas_layer_mode_flags)::rocblas_status
 end
 
 function rocsolver_log_set_max_levels(max_levels)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_log_set_max_levels(max_levels::rocblas_int)::rocblas_status
+    @check @ccall librocsolver.rocsolver_log_set_max_levels(max_levels::rocblas_int)::rocblas_status
 end
 
 function rocsolver_log_restore_defaults()
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_log_restore_defaults()::rocblas_status
+    @check @ccall librocsolver.rocsolver_log_restore_defaults()::rocblas_status
 end
 
 function rocsolver_log_write_profile()
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_log_write_profile()::rocblas_status
+    @check @ccall librocsolver.rocsolver_log_write_profile()::rocblas_status
 end
 
 function rocsolver_log_flush_profile()
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_log_flush_profile()::rocblas_status
+    @check @ccall librocsolver.rocsolver_log_flush_profile()::rocblas_status
 end
 
 function rocsolver_clacgv(handle, n, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_clacgv(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_clacgv(handle::rocblas_handle, n::rocblas_int,
                                          x::Ptr{rocblas_float_complex},
                                          incx::rocblas_int)::rocblas_status
 end
 
 function rocsolver_zlacgv(handle, n, x, incx)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zlacgv(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zlacgv(handle::rocblas_handle, n::rocblas_int,
                                          x::Ptr{rocblas_double_complex},
                                          incx::rocblas_int)::rocblas_status
 end
 
 function rocsolver_slaswp(handle, n, A, lda, k1, k2, ipiv, incx)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_slaswp(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_slaswp(handle::rocblas_handle, n::rocblas_int,
                                          A::Ptr{Cfloat}, lda::rocblas_int, k1::rocblas_int,
                                          k2::rocblas_int, ipiv::Ptr{rocblas_int},
                                          incx::rocblas_int)::rocblas_status
@@ -247,7 +245,7 @@ end
 
 function rocsolver_dlaswp(handle, n, A, lda, k1, k2, ipiv, incx)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dlaswp(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dlaswp(handle::rocblas_handle, n::rocblas_int,
                                          A::Ptr{Cdouble}, lda::rocblas_int, k1::rocblas_int,
                                          k2::rocblas_int, ipiv::Ptr{rocblas_int},
                                          incx::rocblas_int)::rocblas_status
@@ -255,7 +253,7 @@ end
 
 function rocsolver_claswp(handle, n, A, lda, k1, k2, ipiv, incx)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_claswp(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_claswp(handle::rocblas_handle, n::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                          k1::rocblas_int, k2::rocblas_int,
                                          ipiv::Ptr{rocblas_int},
@@ -264,7 +262,7 @@ end
 
 function rocsolver_zlaswp(handle, n, A, lda, k1, k2, ipiv, incx)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zlaswp(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zlaswp(handle::rocblas_handle, n::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                          k1::rocblas_int, k2::rocblas_int,
                                          ipiv::Ptr{rocblas_int},
@@ -273,7 +271,7 @@ end
 
 function rocsolver_slarfg(handle, n, alpha, x, incx, tau)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_slarfg(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_slarfg(handle::rocblas_handle, n::rocblas_int,
                                          alpha::Ptr{Cfloat}, x::Ptr{Cfloat},
                                          incx::rocblas_int,
                                          tau::Ptr{Cfloat})::rocblas_status
@@ -281,7 +279,7 @@ end
 
 function rocsolver_dlarfg(handle, n, alpha, x, incx, tau)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dlarfg(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dlarfg(handle::rocblas_handle, n::rocblas_int,
                                          alpha::Ptr{Cdouble}, x::Ptr{Cdouble},
                                          incx::rocblas_int,
                                          tau::Ptr{Cdouble})::rocblas_status
@@ -289,7 +287,7 @@ end
 
 function rocsolver_clarfg(handle, n, alpha, x, incx, tau)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_clarfg(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_clarfg(handle::rocblas_handle, n::rocblas_int,
                                          alpha::Ptr{rocblas_float_complex},
                                          x::Ptr{rocblas_float_complex}, incx::rocblas_int,
                                          tau::Ptr{rocblas_float_complex})::rocblas_status
@@ -297,7 +295,7 @@ end
 
 function rocsolver_zlarfg(handle, n, alpha, x, incx, tau)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zlarfg(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zlarfg(handle::rocblas_handle, n::rocblas_int,
                                          alpha::Ptr{rocblas_double_complex},
                                          x::Ptr{rocblas_double_complex}, incx::rocblas_int,
                                          tau::Ptr{rocblas_double_complex})::rocblas_status
@@ -305,7 +303,7 @@ end
 
 function rocsolver_slarft(handle, direct, storev, n, k, V, ldv, tau, T, ldt)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_slarft(handle::rocblas_handle, direct::rocblas_direct,
+    @check @ccall librocsolver.rocsolver_slarft(handle::rocblas_handle, direct::rocblas_direct,
                                          storev::rocblas_storev, n::rocblas_int,
                                          k::rocblas_int, V::Ptr{Cfloat}, ldv::rocblas_int,
                                          tau::Ptr{Cfloat}, T::Ptr{Cfloat},
@@ -314,7 +312,7 @@ end
 
 function rocsolver_dlarft(handle, direct, storev, n, k, V, ldv, tau, T, ldt)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dlarft(handle::rocblas_handle, direct::rocblas_direct,
+    @check @ccall librocsolver.rocsolver_dlarft(handle::rocblas_handle, direct::rocblas_direct,
                                          storev::rocblas_storev, n::rocblas_int,
                                          k::rocblas_int, V::Ptr{Cdouble}, ldv::rocblas_int,
                                          tau::Ptr{Cdouble}, T::Ptr{Cdouble},
@@ -323,7 +321,7 @@ end
 
 function rocsolver_clarft(handle, direct, storev, n, k, V, ldv, tau, T, ldt)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_clarft(handle::rocblas_handle, direct::rocblas_direct,
+    @check @ccall librocsolver.rocsolver_clarft(handle::rocblas_handle, direct::rocblas_direct,
                                          storev::rocblas_storev, n::rocblas_int,
                                          k::rocblas_int, V::Ptr{rocblas_float_complex},
                                          ldv::rocblas_int, tau::Ptr{rocblas_float_complex},
@@ -333,7 +331,7 @@ end
 
 function rocsolver_zlarft(handle, direct, storev, n, k, V, ldv, tau, T, ldt)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zlarft(handle::rocblas_handle, direct::rocblas_direct,
+    @check @ccall librocsolver.rocsolver_zlarft(handle::rocblas_handle, direct::rocblas_direct,
                                          storev::rocblas_storev, n::rocblas_int,
                                          k::rocblas_int, V::Ptr{rocblas_double_complex},
                                          ldv::rocblas_int, tau::Ptr{rocblas_double_complex},
@@ -343,7 +341,7 @@ end
 
 function rocsolver_slarf(handle, side, m, n, x, incx, alpha, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_slarf(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_slarf(handle::rocblas_handle, side::rocblas_side,
                                         m::rocblas_int, n::rocblas_int, x::Ptr{Cfloat},
                                         incx::rocblas_int, alpha::Ptr{Cfloat},
                                         A::Ptr{Cfloat}, lda::rocblas_int)::rocblas_status
@@ -351,7 +349,7 @@ end
 
 function rocsolver_dlarf(handle, side, m, n, x, incx, alpha, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dlarf(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_dlarf(handle::rocblas_handle, side::rocblas_side,
                                         m::rocblas_int, n::rocblas_int, x::Ptr{Cdouble},
                                         incx::rocblas_int, alpha::Ptr{Cdouble},
                                         A::Ptr{Cdouble}, lda::rocblas_int)::rocblas_status
@@ -359,7 +357,7 @@ end
 
 function rocsolver_clarf(handle, side, m, n, x, incx, alpha, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_clarf(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_clarf(handle::rocblas_handle, side::rocblas_side,
                                         m::rocblas_int, n::rocblas_int,
                                         x::Ptr{rocblas_float_complex}, incx::rocblas_int,
                                         alpha::Ptr{rocblas_float_complex},
@@ -369,7 +367,7 @@ end
 
 function rocsolver_zlarf(handle, side, m, n, x, incx, alpha, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zlarf(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_zlarf(handle::rocblas_handle, side::rocblas_side,
                                         m::rocblas_int, n::rocblas_int,
                                         x::Ptr{rocblas_double_complex}, incx::rocblas_int,
                                         alpha::Ptr{rocblas_double_complex},
@@ -380,7 +378,7 @@ end
 function rocsolver_slarfb(handle, side, trans, direct, storev, m, n, k, V, ldv, T, ldt, A,
                           lda)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_slarfb(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_slarfb(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, direct::rocblas_direct,
                                          storev::rocblas_storev, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, V::Ptr{Cfloat},
@@ -391,7 +389,7 @@ end
 function rocsolver_dlarfb(handle, side, trans, direct, storev, m, n, k, V, ldv, T, ldt, A,
                           lda)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dlarfb(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_dlarfb(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, direct::rocblas_direct,
                                          storev::rocblas_storev, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, V::Ptr{Cdouble},
@@ -403,7 +401,7 @@ end
 function rocsolver_clarfb(handle, side, trans, direct, storev, m, n, k, V, ldv, T, ldt, A,
                           lda)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_clarfb(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_clarfb(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, direct::rocblas_direct,
                                          storev::rocblas_storev, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
@@ -416,7 +414,7 @@ end
 function rocsolver_zlarfb(handle, side, trans, direct, storev, m, n, k, V, ldv, T, ldt, A,
                           lda)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zlarfb(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_zlarfb(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, direct::rocblas_direct,
                                          storev::rocblas_storev, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
@@ -428,7 +426,7 @@ end
 
 function rocsolver_slabrd(handle, m, n, k, A, lda, D, E, tauq, taup, X, ldx, Y, ldy)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_slabrd(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_slabrd(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cfloat},
                                          lda::rocblas_int, D::Ptr{Cfloat}, E::Ptr{Cfloat},
                                          tauq::Ptr{Cfloat}, taup::Ptr{Cfloat},
@@ -438,7 +436,7 @@ end
 
 function rocsolver_dlabrd(handle, m, n, k, A, lda, D, E, tauq, taup, X, ldx, Y, ldy)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dlabrd(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dlabrd(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cdouble},
                                          lda::rocblas_int, D::Ptr{Cdouble}, E::Ptr{Cdouble},
                                          tauq::Ptr{Cdouble}, taup::Ptr{Cdouble},
@@ -448,7 +446,7 @@ end
 
 function rocsolver_clabrd(handle, m, n, k, A, lda, D, E, tauq, taup, X, ldx, Y, ldy)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_clabrd(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_clabrd(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                          D::Ptr{Cfloat}, E::Ptr{Cfloat},
@@ -461,7 +459,7 @@ end
 
 function rocsolver_zlabrd(handle, m, n, k, A, lda, D, E, tauq, taup, X, ldx, Y, ldy)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zlabrd(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zlabrd(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                          D::Ptr{Cdouble}, E::Ptr{Cdouble},
@@ -474,7 +472,7 @@ end
 
 function rocsolver_slatrd(handle, uplo, n, k, A, lda, E, tau, W, ldw)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_slatrd(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_slatrd(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cfloat},
                                          lda::rocblas_int, E::Ptr{Cfloat}, tau::Ptr{Cfloat},
                                          W::Ptr{Cfloat}, ldw::rocblas_int)::rocblas_status
@@ -482,7 +480,7 @@ end
 
 function rocsolver_dlatrd(handle, uplo, n, k, A, lda, E, tau, W, ldw)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dlatrd(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dlatrd(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cdouble},
                                          lda::rocblas_int, E::Ptr{Cdouble},
                                          tau::Ptr{Cdouble}, W::Ptr{Cdouble},
@@ -491,7 +489,7 @@ end
 
 function rocsolver_clatrd(handle, uplo, n, k, A, lda, E, tau, W, ldw)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_clatrd(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_clatrd(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                          E::Ptr{Cfloat}, tau::Ptr{rocblas_float_complex},
@@ -501,7 +499,7 @@ end
 
 function rocsolver_zlatrd(handle, uplo, n, k, A, lda, E, tau, W, ldw)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zlatrd(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_zlatrd(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                          E::Ptr{Cdouble}, tau::Ptr{rocblas_double_complex},
@@ -511,7 +509,7 @@ end
 
 function rocsolver_slasyf(handle, uplo, n, nb, kb, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_slasyf(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_slasyf(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, nb::rocblas_int,
                                          kb::Ptr{rocblas_int}, A::Ptr{Cfloat},
                                          lda::rocblas_int, ipiv::Ptr{rocblas_int},
@@ -520,7 +518,7 @@ end
 
 function rocsolver_dlasyf(handle, uplo, n, nb, kb, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dlasyf(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dlasyf(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, nb::rocblas_int,
                                          kb::Ptr{rocblas_int}, A::Ptr{Cdouble},
                                          lda::rocblas_int, ipiv::Ptr{rocblas_int},
@@ -529,7 +527,7 @@ end
 
 function rocsolver_clasyf(handle, uplo, n, nb, kb, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_clasyf(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_clasyf(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, nb::rocblas_int,
                                          kb::Ptr{rocblas_int},
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -539,7 +537,7 @@ end
 
 function rocsolver_zlasyf(handle, uplo, n, nb, kb, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zlasyf(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_zlasyf(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, nb::rocblas_int,
                                          kb::Ptr{rocblas_int},
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -549,35 +547,35 @@ end
 
 function rocsolver_slauum(handle, uplo, n, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_slauum(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_slauum(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cfloat},
                                          lda::rocblas_int)::rocblas_status
 end
 
 function rocsolver_dlauum(handle, uplo, n, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dlauum(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dlauum(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cdouble},
                                          lda::rocblas_int)::rocblas_status
 end
 
 function rocsolver_clauum(handle, uplo, n, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_clauum(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_clauum(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int)::rocblas_status
 end
 
 function rocsolver_zlauum(handle, uplo, n, A, lda)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zlauum(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_zlauum(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int)::rocblas_status
 end
 
 function rocsolver_sorg2r(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sorg2r(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sorg2r(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cfloat},
                                          lda::rocblas_int,
                                          ipiv::Ptr{Cfloat})::rocblas_status
@@ -585,7 +583,7 @@ end
 
 function rocsolver_dorg2r(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dorg2r(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dorg2r(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cdouble},
                                          lda::rocblas_int,
                                          ipiv::Ptr{Cdouble})::rocblas_status
@@ -593,7 +591,7 @@ end
 
 function rocsolver_cung2r(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cung2r(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cung2r(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_float_complex})::rocblas_status
@@ -601,7 +599,7 @@ end
 
 function rocsolver_zung2r(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zung2r(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zung2r(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_double_complex})::rocblas_status
@@ -609,7 +607,7 @@ end
 
 function rocsolver_sorgqr(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sorgqr(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sorgqr(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cfloat},
                                          lda::rocblas_int,
                                          ipiv::Ptr{Cfloat})::rocblas_status
@@ -617,7 +615,7 @@ end
 
 function rocsolver_dorgqr(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dorgqr(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dorgqr(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cdouble},
                                          lda::rocblas_int,
                                          ipiv::Ptr{Cdouble})::rocblas_status
@@ -625,7 +623,7 @@ end
 
 function rocsolver_cungqr(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cungqr(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cungqr(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_float_complex})::rocblas_status
@@ -633,7 +631,7 @@ end
 
 function rocsolver_zungqr(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zungqr(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zungqr(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_double_complex})::rocblas_status
@@ -641,7 +639,7 @@ end
 
 function rocsolver_sorgl2(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sorgl2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sorgl2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cfloat},
                                          lda::rocblas_int,
                                          ipiv::Ptr{Cfloat})::rocblas_status
@@ -649,7 +647,7 @@ end
 
 function rocsolver_dorgl2(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dorgl2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dorgl2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cdouble},
                                          lda::rocblas_int,
                                          ipiv::Ptr{Cdouble})::rocblas_status
@@ -657,7 +655,7 @@ end
 
 function rocsolver_cungl2(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cungl2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cungl2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_float_complex})::rocblas_status
@@ -665,7 +663,7 @@ end
 
 function rocsolver_zungl2(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zungl2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zungl2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_double_complex})::rocblas_status
@@ -673,7 +671,7 @@ end
 
 function rocsolver_sorglq(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sorglq(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sorglq(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cfloat},
                                          lda::rocblas_int,
                                          ipiv::Ptr{Cfloat})::rocblas_status
@@ -681,7 +679,7 @@ end
 
 function rocsolver_dorglq(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dorglq(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dorglq(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cdouble},
                                          lda::rocblas_int,
                                          ipiv::Ptr{Cdouble})::rocblas_status
@@ -689,7 +687,7 @@ end
 
 function rocsolver_cunglq(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cunglq(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cunglq(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_float_complex})::rocblas_status
@@ -697,7 +695,7 @@ end
 
 function rocsolver_zunglq(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zunglq(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zunglq(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_double_complex})::rocblas_status
@@ -705,7 +703,7 @@ end
 
 function rocsolver_sorg2l(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sorg2l(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sorg2l(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cfloat},
                                          lda::rocblas_int,
                                          ipiv::Ptr{Cfloat})::rocblas_status
@@ -713,7 +711,7 @@ end
 
 function rocsolver_dorg2l(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dorg2l(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dorg2l(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cdouble},
                                          lda::rocblas_int,
                                          ipiv::Ptr{Cdouble})::rocblas_status
@@ -721,7 +719,7 @@ end
 
 function rocsolver_cung2l(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cung2l(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cung2l(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_float_complex})::rocblas_status
@@ -729,7 +727,7 @@ end
 
 function rocsolver_zung2l(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zung2l(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zung2l(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_double_complex})::rocblas_status
@@ -737,7 +735,7 @@ end
 
 function rocsolver_sorgql(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sorgql(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sorgql(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cfloat},
                                          lda::rocblas_int,
                                          ipiv::Ptr{Cfloat})::rocblas_status
@@ -745,7 +743,7 @@ end
 
 function rocsolver_dorgql(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dorgql(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dorgql(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cdouble},
                                          lda::rocblas_int,
                                          ipiv::Ptr{Cdouble})::rocblas_status
@@ -753,7 +751,7 @@ end
 
 function rocsolver_cungql(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cungql(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cungql(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_float_complex})::rocblas_status
@@ -761,7 +759,7 @@ end
 
 function rocsolver_zungql(handle, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zungql(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zungql(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_double_complex})::rocblas_status
@@ -769,7 +767,7 @@ end
 
 function rocsolver_sorgbr(handle, storev, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sorgbr(handle::rocblas_handle, storev::rocblas_storev,
+    @check @ccall librocsolver.rocsolver_sorgbr(handle::rocblas_handle, storev::rocblas_storev,
                                          m::rocblas_int, n::rocblas_int, k::rocblas_int,
                                          A::Ptr{Cfloat}, lda::rocblas_int,
                                          ipiv::Ptr{Cfloat})::rocblas_status
@@ -777,7 +775,7 @@ end
 
 function rocsolver_dorgbr(handle, storev, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dorgbr(handle::rocblas_handle, storev::rocblas_storev,
+    @check @ccall librocsolver.rocsolver_dorgbr(handle::rocblas_handle, storev::rocblas_storev,
                                          m::rocblas_int, n::rocblas_int, k::rocblas_int,
                                          A::Ptr{Cdouble}, lda::rocblas_int,
                                          ipiv::Ptr{Cdouble})::rocblas_status
@@ -785,7 +783,7 @@ end
 
 function rocsolver_cungbr(handle, storev, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cungbr(handle::rocblas_handle, storev::rocblas_storev,
+    @check @ccall librocsolver.rocsolver_cungbr(handle::rocblas_handle, storev::rocblas_storev,
                                          m::rocblas_int, n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_float_complex})::rocblas_status
@@ -793,7 +791,7 @@ end
 
 function rocsolver_zungbr(handle, storev, m, n, k, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zungbr(handle::rocblas_handle, storev::rocblas_storev,
+    @check @ccall librocsolver.rocsolver_zungbr(handle::rocblas_handle, storev::rocblas_storev,
                                          m::rocblas_int, n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_double_complex})::rocblas_status
@@ -801,21 +799,21 @@ end
 
 function rocsolver_sorgtr(handle, uplo, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sorgtr(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_sorgtr(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          ipiv::Ptr{Cfloat})::rocblas_status
 end
 
 function rocsolver_dorgtr(handle, uplo, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dorgtr(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dorgtr(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          ipiv::Ptr{Cdouble})::rocblas_status
 end
 
 function rocsolver_cungtr(handle, uplo, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cungtr(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_cungtr(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int,
                                          ipiv::Ptr{rocblas_float_complex})::rocblas_status
@@ -823,7 +821,7 @@ end
 
 function rocsolver_zungtr(handle, uplo, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zungtr(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_zungtr(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int,
                                          ipiv::Ptr{rocblas_double_complex})::rocblas_status
@@ -831,7 +829,7 @@ end
 
 function rocsolver_sorm2r(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sorm2r(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_sorm2r(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cfloat},
                                          lda::rocblas_int, ipiv::Ptr{Cfloat},
@@ -840,7 +838,7 @@ end
 
 function rocsolver_dorm2r(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dorm2r(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_dorm2r(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cdouble},
                                          lda::rocblas_int, ipiv::Ptr{Cdouble},
@@ -849,7 +847,7 @@ end
 
 function rocsolver_cunm2r(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cunm2r(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_cunm2r(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -860,7 +858,7 @@ end
 
 function rocsolver_zunm2r(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zunm2r(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_zunm2r(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -871,7 +869,7 @@ end
 
 function rocsolver_sormqr(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sormqr(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_sormqr(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cfloat},
                                          lda::rocblas_int, ipiv::Ptr{Cfloat},
@@ -880,7 +878,7 @@ end
 
 function rocsolver_dormqr(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dormqr(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_dormqr(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cdouble},
                                          lda::rocblas_int, ipiv::Ptr{Cdouble},
@@ -889,7 +887,7 @@ end
 
 function rocsolver_cunmqr(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cunmqr(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_cunmqr(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -900,7 +898,7 @@ end
 
 function rocsolver_zunmqr(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zunmqr(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_zunmqr(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -911,7 +909,7 @@ end
 
 function rocsolver_sorml2(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sorml2(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_sorml2(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cfloat},
                                          lda::rocblas_int, ipiv::Ptr{Cfloat},
@@ -920,7 +918,7 @@ end
 
 function rocsolver_dorml2(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dorml2(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_dorml2(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cdouble},
                                          lda::rocblas_int, ipiv::Ptr{Cdouble},
@@ -929,7 +927,7 @@ end
 
 function rocsolver_cunml2(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cunml2(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_cunml2(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -940,7 +938,7 @@ end
 
 function rocsolver_zunml2(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zunml2(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_zunml2(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -951,7 +949,7 @@ end
 
 function rocsolver_sormlq(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sormlq(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_sormlq(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cfloat},
                                          lda::rocblas_int, ipiv::Ptr{Cfloat},
@@ -960,7 +958,7 @@ end
 
 function rocsolver_dormlq(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dormlq(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_dormlq(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cdouble},
                                          lda::rocblas_int, ipiv::Ptr{Cdouble},
@@ -969,7 +967,7 @@ end
 
 function rocsolver_cunmlq(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cunmlq(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_cunmlq(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -980,7 +978,7 @@ end
 
 function rocsolver_zunmlq(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zunmlq(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_zunmlq(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -991,7 +989,7 @@ end
 
 function rocsolver_sorm2l(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sorm2l(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_sorm2l(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cfloat},
                                          lda::rocblas_int, ipiv::Ptr{Cfloat},
@@ -1000,7 +998,7 @@ end
 
 function rocsolver_dorm2l(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dorm2l(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_dorm2l(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cdouble},
                                          lda::rocblas_int, ipiv::Ptr{Cdouble},
@@ -1009,7 +1007,7 @@ end
 
 function rocsolver_cunm2l(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cunm2l(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_cunm2l(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -1020,7 +1018,7 @@ end
 
 function rocsolver_zunm2l(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zunm2l(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_zunm2l(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -1031,7 +1029,7 @@ end
 
 function rocsolver_sormql(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sormql(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_sormql(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cfloat},
                                          lda::rocblas_int, ipiv::Ptr{Cfloat},
@@ -1040,7 +1038,7 @@ end
 
 function rocsolver_dormql(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dormql(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_dormql(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int, A::Ptr{Cdouble},
                                          lda::rocblas_int, ipiv::Ptr{Cdouble},
@@ -1049,7 +1047,7 @@ end
 
 function rocsolver_cunmql(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cunmql(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_cunmql(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -1060,7 +1058,7 @@ end
 
 function rocsolver_zunmql(handle, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zunmql(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_zunmql(handle::rocblas_handle, side::rocblas_side,
                                          trans::rocblas_operation, m::rocblas_int,
                                          n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -1071,7 +1069,7 @@ end
 
 function rocsolver_sormbr(handle, storev, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sormbr(handle::rocblas_handle, storev::rocblas_storev,
+    @check @ccall librocsolver.rocsolver_sormbr(handle::rocblas_handle, storev::rocblas_storev,
                                          side::rocblas_side, trans::rocblas_operation,
                                          m::rocblas_int, n::rocblas_int, k::rocblas_int,
                                          A::Ptr{Cfloat}, lda::rocblas_int,
@@ -1081,7 +1079,7 @@ end
 
 function rocsolver_dormbr(handle, storev, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dormbr(handle::rocblas_handle, storev::rocblas_storev,
+    @check @ccall librocsolver.rocsolver_dormbr(handle::rocblas_handle, storev::rocblas_storev,
                                          side::rocblas_side, trans::rocblas_operation,
                                          m::rocblas_int, n::rocblas_int, k::rocblas_int,
                                          A::Ptr{Cdouble}, lda::rocblas_int,
@@ -1091,7 +1089,7 @@ end
 
 function rocsolver_cunmbr(handle, storev, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cunmbr(handle::rocblas_handle, storev::rocblas_storev,
+    @check @ccall librocsolver.rocsolver_cunmbr(handle::rocblas_handle, storev::rocblas_storev,
                                          side::rocblas_side, trans::rocblas_operation,
                                          m::rocblas_int, n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -1102,7 +1100,7 @@ end
 
 function rocsolver_zunmbr(handle, storev, side, trans, m, n, k, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zunmbr(handle::rocblas_handle, storev::rocblas_storev,
+    @check @ccall librocsolver.rocsolver_zunmbr(handle::rocblas_handle, storev::rocblas_storev,
                                          side::rocblas_side, trans::rocblas_operation,
                                          m::rocblas_int, n::rocblas_int, k::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -1113,7 +1111,7 @@ end
 
 function rocsolver_sormtr(handle, side, uplo, trans, m, n, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sormtr(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_sormtr(handle::rocblas_handle, side::rocblas_side,
                                          uplo::rocblas_fill, trans::rocblas_operation,
                                          m::rocblas_int, n::rocblas_int, A::Ptr{Cfloat},
                                          lda::rocblas_int, ipiv::Ptr{Cfloat},
@@ -1122,7 +1120,7 @@ end
 
 function rocsolver_dormtr(handle, side, uplo, trans, m, n, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dormtr(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_dormtr(handle::rocblas_handle, side::rocblas_side,
                                          uplo::rocblas_fill, trans::rocblas_operation,
                                          m::rocblas_int, n::rocblas_int, A::Ptr{Cdouble},
                                          lda::rocblas_int, ipiv::Ptr{Cdouble},
@@ -1131,7 +1129,7 @@ end
 
 function rocsolver_cunmtr(handle, side, uplo, trans, m, n, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cunmtr(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_cunmtr(handle::rocblas_handle, side::rocblas_side,
                                          uplo::rocblas_fill, trans::rocblas_operation,
                                          m::rocblas_int, n::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -1142,7 +1140,7 @@ end
 
 function rocsolver_zunmtr(handle, side, uplo, trans, m, n, A, lda, ipiv, C, ldc)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zunmtr(handle::rocblas_handle, side::rocblas_side,
+    @check @ccall librocsolver.rocsolver_zunmtr(handle::rocblas_handle, side::rocblas_side,
                                          uplo::rocblas_fill, trans::rocblas_operation,
                                          m::rocblas_int, n::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -1153,7 +1151,7 @@ end
 
 function rocsolver_sbdsqr(handle, uplo, n, nv, nu, nc, D, E, V, ldv, U, ldu, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sbdsqr(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_sbdsqr(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, nv::rocblas_int, nu::rocblas_int,
                                          nc::rocblas_int, D::Ptr{Cfloat}, E::Ptr{Cfloat},
                                          V::Ptr{Cfloat}, ldv::rocblas_int, U::Ptr{Cfloat},
@@ -1163,7 +1161,7 @@ end
 
 function rocsolver_dbdsqr(handle, uplo, n, nv, nu, nc, D, E, V, ldv, U, ldu, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dbdsqr(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dbdsqr(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, nv::rocblas_int, nu::rocblas_int,
                                          nc::rocblas_int, D::Ptr{Cdouble}, E::Ptr{Cdouble},
                                          V::Ptr{Cdouble}, ldv::rocblas_int, U::Ptr{Cdouble},
@@ -1174,7 +1172,7 @@ end
 
 function rocsolver_cbdsqr(handle, uplo, n, nv, nu, nc, D, E, V, ldv, U, ldu, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cbdsqr(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_cbdsqr(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, nv::rocblas_int, nu::rocblas_int,
                                          nc::rocblas_int, D::Ptr{Cfloat}, E::Ptr{Cfloat},
                                          V::Ptr{rocblas_float_complex}, ldv::rocblas_int,
@@ -1185,7 +1183,7 @@ end
 
 function rocsolver_zbdsqr(handle, uplo, n, nv, nu, nc, D, E, V, ldv, U, ldu, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zbdsqr(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_zbdsqr(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, nv::rocblas_int, nu::rocblas_int,
                                          nc::rocblas_int, D::Ptr{Cdouble}, E::Ptr{Cdouble},
                                          V::Ptr{rocblas_double_complex}, ldv::rocblas_int,
@@ -1196,21 +1194,21 @@ end
 
 function rocsolver_ssterf(handle, n, D, E, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssterf(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_ssterf(handle::rocblas_handle, n::rocblas_int,
                                          D::Ptr{Cfloat}, E::Ptr{Cfloat},
                                          info::Ptr{rocblas_int})::rocblas_status
 end
 
 function rocsolver_dsterf(handle, n, D, E, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsterf(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dsterf(handle::rocblas_handle, n::rocblas_int,
                                          D::Ptr{Cdouble}, E::Ptr{Cdouble},
                                          info::Ptr{rocblas_int})::rocblas_status
 end
 
 function rocsolver_ssteqr(handle, evect, n, D, E, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssteqr(handle::rocblas_handle, evect::rocblas_evect,
+    @check @ccall librocsolver.rocsolver_ssteqr(handle::rocblas_handle, evect::rocblas_evect,
                                          n::rocblas_int, D::Ptr{Cfloat}, E::Ptr{Cfloat},
                                          C::Ptr{Cfloat}, ldc::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -1218,7 +1216,7 @@ end
 
 function rocsolver_dsteqr(handle, evect, n, D, E, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsteqr(handle::rocblas_handle, evect::rocblas_evect,
+    @check @ccall librocsolver.rocsolver_dsteqr(handle::rocblas_handle, evect::rocblas_evect,
                                          n::rocblas_int, D::Ptr{Cdouble}, E::Ptr{Cdouble},
                                          C::Ptr{Cdouble}, ldc::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -1226,7 +1224,7 @@ end
 
 function rocsolver_csteqr(handle, evect, n, D, E, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_csteqr(handle::rocblas_handle, evect::rocblas_evect,
+    @check @ccall librocsolver.rocsolver_csteqr(handle::rocblas_handle, evect::rocblas_evect,
                                          n::rocblas_int, D::Ptr{Cfloat}, E::Ptr{Cfloat},
                                          C::Ptr{rocblas_float_complex}, ldc::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -1234,7 +1232,7 @@ end
 
 function rocsolver_zsteqr(handle, evect, n, D, E, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zsteqr(handle::rocblas_handle, evect::rocblas_evect,
+    @check @ccall librocsolver.rocsolver_zsteqr(handle::rocblas_handle, evect::rocblas_evect,
                                          n::rocblas_int, D::Ptr{Cdouble}, E::Ptr{Cdouble},
                                          C::Ptr{rocblas_double_complex}, ldc::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -1242,7 +1240,7 @@ end
 
 function rocsolver_sstedc(handle, evect, n, D, E, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sstedc(handle::rocblas_handle, evect::rocblas_evect,
+    @check @ccall librocsolver.rocsolver_sstedc(handle::rocblas_handle, evect::rocblas_evect,
                                          n::rocblas_int, D::Ptr{Cfloat}, E::Ptr{Cfloat},
                                          C::Ptr{Cfloat}, ldc::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -1250,7 +1248,7 @@ end
 
 function rocsolver_dstedc(handle, evect, n, D, E, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dstedc(handle::rocblas_handle, evect::rocblas_evect,
+    @check @ccall librocsolver.rocsolver_dstedc(handle::rocblas_handle, evect::rocblas_evect,
                                          n::rocblas_int, D::Ptr{Cdouble}, E::Ptr{Cdouble},
                                          C::Ptr{Cdouble}, ldc::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -1258,7 +1256,7 @@ end
 
 function rocsolver_cstedc(handle, evect, n, D, E, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cstedc(handle::rocblas_handle, evect::rocblas_evect,
+    @check @ccall librocsolver.rocsolver_cstedc(handle::rocblas_handle, evect::rocblas_evect,
                                          n::rocblas_int, D::Ptr{Cfloat}, E::Ptr{Cfloat},
                                          C::Ptr{rocblas_float_complex}, ldc::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -1266,7 +1264,7 @@ end
 
 function rocsolver_zstedc(handle, evect, n, D, E, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zstedc(handle::rocblas_handle, evect::rocblas_evect,
+    @check @ccall librocsolver.rocsolver_zstedc(handle::rocblas_handle, evect::rocblas_evect,
                                          n::rocblas_int, D::Ptr{Cdouble}, E::Ptr{Cdouble},
                                          C::Ptr{rocblas_double_complex}, ldc::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -1275,7 +1273,7 @@ end
 function rocsolver_sstebz(handle, erange, eorder, n, vl, vu, il, iu, abstol, D, E, nev,
                           nsplit, W, iblock, isplit, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sstebz(handle::rocblas_handle, erange::rocblas_erange,
+    @check @ccall librocsolver.rocsolver_sstebz(handle::rocblas_handle, erange::rocblas_erange,
                                          eorder::rocblas_eorder, n::rocblas_int, vl::Cfloat,
                                          vu::Cfloat, il::rocblas_int, iu::rocblas_int,
                                          abstol::Cfloat, D::Ptr{Cfloat}, E::Ptr{Cfloat},
@@ -1288,7 +1286,7 @@ end
 function rocsolver_dstebz(handle, erange, eorder, n, vl, vu, il, iu, abstol, D, E, nev,
                           nsplit, W, iblock, isplit, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dstebz(handle::rocblas_handle, erange::rocblas_erange,
+    @check @ccall librocsolver.rocsolver_dstebz(handle::rocblas_handle, erange::rocblas_erange,
                                          eorder::rocblas_eorder, n::rocblas_int,
                                          vl::Cdouble, vu::Cdouble, il::rocblas_int,
                                          iu::rocblas_int, abstol::Cdouble, D::Ptr{Cdouble},
@@ -1300,7 +1298,7 @@ end
 
 function rocsolver_sstein(handle, n, D, E, nev, W, iblock, isplit, Z, ldz, ifail, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sstein(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sstein(handle::rocblas_handle, n::rocblas_int,
                                          D::Ptr{Cfloat}, E::Ptr{Cfloat},
                                          nev::Ptr{rocblas_int}, W::Ptr{Cfloat},
                                          iblock::Ptr{rocblas_int}, isplit::Ptr{rocblas_int},
@@ -1311,7 +1309,7 @@ end
 
 function rocsolver_dstein(handle, n, D, E, nev, W, iblock, isplit, Z, ldz, ifail, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dstein(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dstein(handle::rocblas_handle, n::rocblas_int,
                                          D::Ptr{Cdouble}, E::Ptr{Cdouble},
                                          nev::Ptr{rocblas_int}, W::Ptr{Cdouble},
                                          iblock::Ptr{rocblas_int}, isplit::Ptr{rocblas_int},
@@ -1322,7 +1320,7 @@ end
 
 function rocsolver_cstein(handle, n, D, E, nev, W, iblock, isplit, Z, ldz, ifail, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cstein(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cstein(handle::rocblas_handle, n::rocblas_int,
                                          D::Ptr{Cfloat}, E::Ptr{Cfloat},
                                          nev::Ptr{rocblas_int}, W::Ptr{Cfloat},
                                          iblock::Ptr{rocblas_int}, isplit::Ptr{rocblas_int},
@@ -1333,7 +1331,7 @@ end
 
 function rocsolver_zstein(handle, n, D, E, nev, W, iblock, isplit, Z, ldz, ifail, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zstein(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zstein(handle::rocblas_handle, n::rocblas_int,
                                          D::Ptr{Cdouble}, E::Ptr{Cdouble},
                                          nev::Ptr{rocblas_int}, W::Ptr{Cdouble},
                                          iblock::Ptr{rocblas_int}, isplit::Ptr{rocblas_int},
@@ -1345,7 +1343,7 @@ end
 function rocsolver_sbdsvdx(handle, uplo, svect, srange, n, D, E, vl, vu, il, iu, nsv, S, Z,
                            ldz, ifail, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sbdsvdx(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_sbdsvdx(handle::rocblas_handle, uplo::rocblas_fill,
                                           svect::rocblas_svect, srange::rocblas_srange,
                                           n::rocblas_int, D::Ptr{Cfloat}, E::Ptr{Cfloat},
                                           vl::Cfloat, vu::Cfloat, il::rocblas_int,
@@ -1358,7 +1356,7 @@ end
 function rocsolver_dbdsvdx(handle, uplo, svect, srange, n, D, E, vl, vu, il, iu, nsv, S, Z,
                            ldz, ifail, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dbdsvdx(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dbdsvdx(handle::rocblas_handle, uplo::rocblas_fill,
                                           svect::rocblas_svect, srange::rocblas_srange,
                                           n::rocblas_int, D::Ptr{Cdouble}, E::Ptr{Cdouble},
                                           vl::Cdouble, vu::Cdouble, il::rocblas_int,
@@ -1370,7 +1368,7 @@ end
 
 function rocsolver_sgetf2_npvt(handle, m, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetf2_npvt(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgetf2_npvt(handle::rocblas_handle, m::rocblas_int,
                                               n::rocblas_int, A::Ptr{Cfloat},
                                               lda::rocblas_int,
                                               info::Ptr{rocblas_int})::rocblas_status
@@ -1378,7 +1376,7 @@ end
 
 function rocsolver_dgetf2_npvt(handle, m, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetf2_npvt(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgetf2_npvt(handle::rocblas_handle, m::rocblas_int,
                                               n::rocblas_int, A::Ptr{Cdouble},
                                               lda::rocblas_int,
                                               info::Ptr{rocblas_int})::rocblas_status
@@ -1386,7 +1384,7 @@ end
 
 function rocsolver_cgetf2_npvt(handle, m, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetf2_npvt(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgetf2_npvt(handle::rocblas_handle, m::rocblas_int,
                                               n::rocblas_int, A::Ptr{rocblas_float_complex},
                                               lda::rocblas_int,
                                               info::Ptr{rocblas_int})::rocblas_status
@@ -1394,7 +1392,7 @@ end
 
 function rocsolver_zgetf2_npvt(handle, m, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetf2_npvt(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgetf2_npvt(handle::rocblas_handle, m::rocblas_int,
                                               n::rocblas_int,
                                               A::Ptr{rocblas_double_complex},
                                               lda::rocblas_int,
@@ -1403,7 +1401,7 @@ end
 
 function rocsolver_sgetf2_npvt_batched(handle, m, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetf2_npvt_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgetf2_npvt_batched(handle::rocblas_handle,
                                                       m::rocblas_int, n::rocblas_int,
                                                       A::Ptr{Ptr{Cfloat}}, lda::rocblas_int,
                                                       info::Ptr{rocblas_int},
@@ -1412,7 +1410,7 @@ end
 
 function rocsolver_dgetf2_npvt_batched(handle, m, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetf2_npvt_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgetf2_npvt_batched(handle::rocblas_handle,
                                                       m::rocblas_int, n::rocblas_int,
                                                       A::Ptr{Ptr{Cdouble}},
                                                       lda::rocblas_int,
@@ -1422,7 +1420,7 @@ end
 
 function rocsolver_cgetf2_npvt_batched(handle, m, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetf2_npvt_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgetf2_npvt_batched(handle::rocblas_handle,
                                                       m::rocblas_int, n::rocblas_int,
                                                       A::Ptr{Ptr{rocblas_float_complex}},
                                                       lda::rocblas_int,
@@ -1432,7 +1430,7 @@ end
 
 function rocsolver_zgetf2_npvt_batched(handle, m, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetf2_npvt_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgetf2_npvt_batched(handle::rocblas_handle,
                                                       m::rocblas_int, n::rocblas_int,
                                                       A::Ptr{Ptr{rocblas_double_complex}},
                                                       lda::rocblas_int,
@@ -1443,7 +1441,7 @@ end
 function rocsolver_sgetf2_npvt_strided_batched(handle, m, n, A, lda, strideA, info,
                                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetf2_npvt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgetf2_npvt_strided_batched(handle::rocblas_handle,
                                                               m::rocblas_int,
                                                               n::rocblas_int,
                                                               A::Ptr{Cfloat},
@@ -1456,7 +1454,7 @@ end
 function rocsolver_dgetf2_npvt_strided_batched(handle, m, n, A, lda, strideA, info,
                                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetf2_npvt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgetf2_npvt_strided_batched(handle::rocblas_handle,
                                                               m::rocblas_int,
                                                               n::rocblas_int,
                                                               A::Ptr{Cdouble},
@@ -1469,7 +1467,7 @@ end
 function rocsolver_cgetf2_npvt_strided_batched(handle, m, n, A, lda, strideA, info,
                                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetf2_npvt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgetf2_npvt_strided_batched(handle::rocblas_handle,
                                                               m::rocblas_int,
                                                               n::rocblas_int,
                                                               A::Ptr{rocblas_float_complex},
@@ -1482,7 +1480,7 @@ end
 function rocsolver_zgetf2_npvt_strided_batched(handle, m, n, A, lda, strideA, info,
                                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetf2_npvt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgetf2_npvt_strided_batched(handle::rocblas_handle,
                                                               m::rocblas_int,
                                                               n::rocblas_int,
                                                               A::Ptr{rocblas_double_complex},
@@ -1494,7 +1492,7 @@ end
 
 function rocsolver_sgetrf_npvt(handle, m, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetrf_npvt(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgetrf_npvt(handle::rocblas_handle, m::rocblas_int,
                                               n::rocblas_int, A::Ptr{Cfloat},
                                               lda::rocblas_int,
                                               info::Ptr{rocblas_int})::rocblas_status
@@ -1502,7 +1500,7 @@ end
 
 function rocsolver_dgetrf_npvt(handle, m, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetrf_npvt(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgetrf_npvt(handle::rocblas_handle, m::rocblas_int,
                                               n::rocblas_int, A::Ptr{Cdouble},
                                               lda::rocblas_int,
                                               info::Ptr{rocblas_int})::rocblas_status
@@ -1510,7 +1508,7 @@ end
 
 function rocsolver_cgetrf_npvt(handle, m, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetrf_npvt(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgetrf_npvt(handle::rocblas_handle, m::rocblas_int,
                                               n::rocblas_int, A::Ptr{rocblas_float_complex},
                                               lda::rocblas_int,
                                               info::Ptr{rocblas_int})::rocblas_status
@@ -1518,7 +1516,7 @@ end
 
 function rocsolver_zgetrf_npvt(handle, m, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetrf_npvt(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgetrf_npvt(handle::rocblas_handle, m::rocblas_int,
                                               n::rocblas_int,
                                               A::Ptr{rocblas_double_complex},
                                               lda::rocblas_int,
@@ -1527,7 +1525,7 @@ end
 
 function rocsolver_sgetrf_npvt_batched(handle, m, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetrf_npvt_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgetrf_npvt_batched(handle::rocblas_handle,
                                                       m::rocblas_int, n::rocblas_int,
                                                       A::Ptr{Ptr{Cfloat}}, lda::rocblas_int,
                                                       info::Ptr{rocblas_int},
@@ -1536,7 +1534,7 @@ end
 
 function rocsolver_dgetrf_npvt_batched(handle, m, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetrf_npvt_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgetrf_npvt_batched(handle::rocblas_handle,
                                                       m::rocblas_int, n::rocblas_int,
                                                       A::Ptr{Ptr{Cdouble}},
                                                       lda::rocblas_int,
@@ -1546,7 +1544,7 @@ end
 
 function rocsolver_cgetrf_npvt_batched(handle, m, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetrf_npvt_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgetrf_npvt_batched(handle::rocblas_handle,
                                                       m::rocblas_int, n::rocblas_int,
                                                       A::Ptr{Ptr{rocblas_float_complex}},
                                                       lda::rocblas_int,
@@ -1556,7 +1554,7 @@ end
 
 function rocsolver_zgetrf_npvt_batched(handle, m, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetrf_npvt_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgetrf_npvt_batched(handle::rocblas_handle,
                                                       m::rocblas_int, n::rocblas_int,
                                                       A::Ptr{Ptr{rocblas_double_complex}},
                                                       lda::rocblas_int,
@@ -1567,7 +1565,7 @@ end
 function rocsolver_sgetrf_npvt_strided_batched(handle, m, n, A, lda, strideA, info,
                                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetrf_npvt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgetrf_npvt_strided_batched(handle::rocblas_handle,
                                                               m::rocblas_int,
                                                               n::rocblas_int,
                                                               A::Ptr{Cfloat},
@@ -1580,7 +1578,7 @@ end
 function rocsolver_dgetrf_npvt_strided_batched(handle, m, n, A, lda, strideA, info,
                                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetrf_npvt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgetrf_npvt_strided_batched(handle::rocblas_handle,
                                                               m::rocblas_int,
                                                               n::rocblas_int,
                                                               A::Ptr{Cdouble},
@@ -1593,7 +1591,7 @@ end
 function rocsolver_cgetrf_npvt_strided_batched(handle, m, n, A, lda, strideA, info,
                                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetrf_npvt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgetrf_npvt_strided_batched(handle::rocblas_handle,
                                                               m::rocblas_int,
                                                               n::rocblas_int,
                                                               A::Ptr{rocblas_float_complex},
@@ -1606,7 +1604,7 @@ end
 function rocsolver_zgetrf_npvt_strided_batched(handle, m, n, A, lda, strideA, info,
                                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetrf_npvt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgetrf_npvt_strided_batched(handle::rocblas_handle,
                                                               m::rocblas_int,
                                                               n::rocblas_int,
                                                               A::Ptr{rocblas_double_complex},
@@ -1618,7 +1616,7 @@ end
 
 function rocsolver_sgetf2(handle, m, n, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetf2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgetf2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_int},
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -1626,7 +1624,7 @@ end
 
 function rocsolver_dgetf2(handle, m, n, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetf2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgetf2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_int},
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -1634,7 +1632,7 @@ end
 
 function rocsolver_cgetf2(handle, m, n, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetf2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgetf2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -1642,7 +1640,7 @@ end
 
 function rocsolver_zgetf2(handle, m, n, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetf2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgetf2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -1650,7 +1648,7 @@ end
 
 function rocsolver_sgetf2_batched(handle, m, n, A, lda, ipiv, strideP, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetf2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgetf2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                  lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                                  strideP::rocblas_stride,
@@ -1660,7 +1658,7 @@ end
 
 function rocsolver_dgetf2_batched(handle, m, n, A, lda, ipiv, strideP, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetf2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgetf2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                  lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                                  strideP::rocblas_stride,
@@ -1670,7 +1668,7 @@ end
 
 function rocsolver_cgetf2_batched(handle, m, n, A, lda, ipiv, strideP, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetf2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgetf2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
                                                  lda::rocblas_int, ipiv::Ptr{rocblas_int},
@@ -1681,7 +1679,7 @@ end
 
 function rocsolver_zgetf2_batched(handle, m, n, A, lda, ipiv, strideP, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetf2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgetf2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
                                                  lda::rocblas_int, ipiv::Ptr{rocblas_int},
@@ -1693,7 +1691,7 @@ end
 function rocsolver_sgetf2_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetf2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgetf2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cfloat}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -1706,7 +1704,7 @@ end
 function rocsolver_dgetf2_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetf2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgetf2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cdouble}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -1719,7 +1717,7 @@ end
 function rocsolver_cgetf2_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetf2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgetf2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
                                                          lda::rocblas_int,
@@ -1733,7 +1731,7 @@ end
 function rocsolver_zgetf2_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetf2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgetf2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
                                                          lda::rocblas_int,
@@ -1746,7 +1744,7 @@ end
 
 function rocsolver_sgetrf(handle, m, n, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetrf(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgetrf(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_int},
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -1754,7 +1752,7 @@ end
 
 function rocsolver_dgetrf(handle, m, n, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetrf(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgetrf(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_int},
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -1762,7 +1760,7 @@ end
 
 function rocsolver_cgetrf(handle, m, n, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetrf(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgetrf(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -1770,7 +1768,7 @@ end
 
 function rocsolver_zgetrf(handle, m, n, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetrf(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgetrf(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -1778,7 +1776,7 @@ end
 
 function rocsolver_sgetrf_batched(handle, m, n, A, lda, ipiv, strideP, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetrf_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgetrf_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                  lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                                  strideP::rocblas_stride,
@@ -1788,7 +1786,7 @@ end
 
 function rocsolver_dgetrf_batched(handle, m, n, A, lda, ipiv, strideP, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetrf_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgetrf_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                  lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                                  strideP::rocblas_stride,
@@ -1798,7 +1796,7 @@ end
 
 function rocsolver_cgetrf_batched(handle, m, n, A, lda, ipiv, strideP, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetrf_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgetrf_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
                                                  lda::rocblas_int, ipiv::Ptr{rocblas_int},
@@ -1809,7 +1807,7 @@ end
 
 function rocsolver_zgetrf_batched(handle, m, n, A, lda, ipiv, strideP, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetrf_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgetrf_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
                                                  lda::rocblas_int, ipiv::Ptr{rocblas_int},
@@ -1821,7 +1819,7 @@ end
 function rocsolver_sgetrf_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetrf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgetrf_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cfloat}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -1834,7 +1832,7 @@ end
 function rocsolver_dgetrf_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetrf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgetrf_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cdouble}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -1847,7 +1845,7 @@ end
 function rocsolver_cgetrf_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetrf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgetrf_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
                                                          lda::rocblas_int,
@@ -1861,7 +1859,7 @@ end
 function rocsolver_zgetrf_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetrf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgetrf_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
                                                          lda::rocblas_int,
@@ -1874,21 +1872,21 @@ end
 
 function rocsolver_sgeqr2(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgeqr2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgeqr2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          ipiv::Ptr{Cfloat})::rocblas_status
 end
 
 function rocsolver_dgeqr2(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgeqr2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgeqr2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          ipiv::Ptr{Cdouble})::rocblas_status
 end
 
 function rocsolver_cgeqr2(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgeqr2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgeqr2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int,
                                          ipiv::Ptr{rocblas_float_complex})::rocblas_status
@@ -1896,7 +1894,7 @@ end
 
 function rocsolver_zgeqr2(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgeqr2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgeqr2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int,
                                          ipiv::Ptr{rocblas_double_complex})::rocblas_status
@@ -1904,7 +1902,7 @@ end
 
 function rocsolver_sgeqr2_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgeqr2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgeqr2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                  lda::rocblas_int, ipiv::Ptr{Cfloat},
                                                  strideP::rocblas_stride,
@@ -1913,7 +1911,7 @@ end
 
 function rocsolver_dgeqr2_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgeqr2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgeqr2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                  lda::rocblas_int, ipiv::Ptr{Cdouble},
                                                  strideP::rocblas_stride,
@@ -1922,7 +1920,7 @@ end
 
 function rocsolver_cgeqr2_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgeqr2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgeqr2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
                                                  lda::rocblas_int,
@@ -1933,7 +1931,7 @@ end
 
 function rocsolver_zgeqr2_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgeqr2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgeqr2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
                                                  lda::rocblas_int,
@@ -1945,7 +1943,7 @@ end
 function rocsolver_sgeqr2_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgeqr2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgeqr2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cfloat}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -1957,7 +1955,7 @@ end
 function rocsolver_dgeqr2_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgeqr2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgeqr2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cdouble}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -1969,7 +1967,7 @@ end
 function rocsolver_cgeqr2_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgeqr2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgeqr2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
                                                          lda::rocblas_int,
@@ -1982,7 +1980,7 @@ end
 function rocsolver_zgeqr2_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgeqr2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgeqr2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
                                                          lda::rocblas_int,
@@ -1994,21 +1992,21 @@ end
 
 function rocsolver_sgerq2(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgerq2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgerq2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          ipiv::Ptr{Cfloat})::rocblas_status
 end
 
 function rocsolver_dgerq2(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgerq2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgerq2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          ipiv::Ptr{Cdouble})::rocblas_status
 end
 
 function rocsolver_cgerq2(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgerq2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgerq2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int,
                                          ipiv::Ptr{rocblas_float_complex})::rocblas_status
@@ -2016,7 +2014,7 @@ end
 
 function rocsolver_zgerq2(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgerq2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgerq2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int,
                                          ipiv::Ptr{rocblas_double_complex})::rocblas_status
@@ -2024,7 +2022,7 @@ end
 
 function rocsolver_sgerq2_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgerq2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgerq2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                  lda::rocblas_int, ipiv::Ptr{Cfloat},
                                                  strideP::rocblas_stride,
@@ -2033,7 +2031,7 @@ end
 
 function rocsolver_dgerq2_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgerq2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgerq2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                  lda::rocblas_int, ipiv::Ptr{Cdouble},
                                                  strideP::rocblas_stride,
@@ -2042,7 +2040,7 @@ end
 
 function rocsolver_cgerq2_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgerq2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgerq2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
                                                  lda::rocblas_int,
@@ -2053,7 +2051,7 @@ end
 
 function rocsolver_zgerq2_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgerq2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgerq2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
                                                  lda::rocblas_int,
@@ -2065,7 +2063,7 @@ end
 function rocsolver_sgerq2_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgerq2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgerq2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cfloat}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -2077,7 +2075,7 @@ end
 function rocsolver_dgerq2_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgerq2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgerq2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cdouble}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -2089,7 +2087,7 @@ end
 function rocsolver_cgerq2_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgerq2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgerq2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
                                                          lda::rocblas_int,
@@ -2102,7 +2100,7 @@ end
 function rocsolver_zgerq2_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgerq2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgerq2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
                                                          lda::rocblas_int,
@@ -2114,21 +2112,21 @@ end
 
 function rocsolver_sgeql2(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgeql2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgeql2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          ipiv::Ptr{Cfloat})::rocblas_status
 end
 
 function rocsolver_dgeql2(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgeql2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgeql2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          ipiv::Ptr{Cdouble})::rocblas_status
 end
 
 function rocsolver_cgeql2(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgeql2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgeql2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int,
                                          ipiv::Ptr{rocblas_float_complex})::rocblas_status
@@ -2136,7 +2134,7 @@ end
 
 function rocsolver_zgeql2(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgeql2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgeql2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int,
                                          ipiv::Ptr{rocblas_double_complex})::rocblas_status
@@ -2144,7 +2142,7 @@ end
 
 function rocsolver_sgeql2_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgeql2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgeql2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                  lda::rocblas_int, ipiv::Ptr{Cfloat},
                                                  strideP::rocblas_stride,
@@ -2153,7 +2151,7 @@ end
 
 function rocsolver_dgeql2_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgeql2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgeql2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                  lda::rocblas_int, ipiv::Ptr{Cdouble},
                                                  strideP::rocblas_stride,
@@ -2162,7 +2160,7 @@ end
 
 function rocsolver_cgeql2_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgeql2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgeql2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
                                                  lda::rocblas_int,
@@ -2173,7 +2171,7 @@ end
 
 function rocsolver_zgeql2_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgeql2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgeql2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
                                                  lda::rocblas_int,
@@ -2185,7 +2183,7 @@ end
 function rocsolver_sgeql2_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgeql2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgeql2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cfloat}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -2197,7 +2195,7 @@ end
 function rocsolver_dgeql2_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgeql2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgeql2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cdouble}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -2209,7 +2207,7 @@ end
 function rocsolver_cgeql2_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgeql2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgeql2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
                                                          lda::rocblas_int,
@@ -2222,7 +2220,7 @@ end
 function rocsolver_zgeql2_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgeql2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgeql2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
                                                          lda::rocblas_int,
@@ -2234,21 +2232,21 @@ end
 
 function rocsolver_sgelq2(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgelq2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgelq2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          ipiv::Ptr{Cfloat})::rocblas_status
 end
 
 function rocsolver_dgelq2(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgelq2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgelq2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          ipiv::Ptr{Cdouble})::rocblas_status
 end
 
 function rocsolver_cgelq2(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgelq2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgelq2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int,
                                          ipiv::Ptr{rocblas_float_complex})::rocblas_status
@@ -2256,7 +2254,7 @@ end
 
 function rocsolver_zgelq2(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgelq2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgelq2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int,
                                          ipiv::Ptr{rocblas_double_complex})::rocblas_status
@@ -2264,7 +2262,7 @@ end
 
 function rocsolver_sgelq2_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgelq2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgelq2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                  lda::rocblas_int, ipiv::Ptr{Cfloat},
                                                  strideP::rocblas_stride,
@@ -2273,7 +2271,7 @@ end
 
 function rocsolver_dgelq2_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgelq2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgelq2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                  lda::rocblas_int, ipiv::Ptr{Cdouble},
                                                  strideP::rocblas_stride,
@@ -2282,7 +2280,7 @@ end
 
 function rocsolver_cgelq2_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgelq2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgelq2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
                                                  lda::rocblas_int,
@@ -2293,7 +2291,7 @@ end
 
 function rocsolver_zgelq2_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgelq2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgelq2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
                                                  lda::rocblas_int,
@@ -2305,7 +2303,7 @@ end
 function rocsolver_sgelq2_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgelq2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgelq2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cfloat}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -2317,7 +2315,7 @@ end
 function rocsolver_dgelq2_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgelq2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgelq2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cdouble}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -2329,7 +2327,7 @@ end
 function rocsolver_cgelq2_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgelq2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgelq2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
                                                          lda::rocblas_int,
@@ -2342,7 +2340,7 @@ end
 function rocsolver_zgelq2_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgelq2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgelq2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
                                                          lda::rocblas_int,
@@ -2354,21 +2352,21 @@ end
 
 function rocsolver_sgeqrf(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgeqrf(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgeqrf(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          ipiv::Ptr{Cfloat})::rocblas_status
 end
 
 function rocsolver_dgeqrf(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgeqrf(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgeqrf(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          ipiv::Ptr{Cdouble})::rocblas_status
 end
 
 function rocsolver_cgeqrf(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgeqrf(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgeqrf(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int,
                                          ipiv::Ptr{rocblas_float_complex})::rocblas_status
@@ -2376,7 +2374,7 @@ end
 
 function rocsolver_zgeqrf(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgeqrf(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgeqrf(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int,
                                          ipiv::Ptr{rocblas_double_complex})::rocblas_status
@@ -2384,7 +2382,7 @@ end
 
 function rocsolver_sgeqrf_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgeqrf_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgeqrf_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                  lda::rocblas_int, ipiv::Ptr{Cfloat},
                                                  strideP::rocblas_stride,
@@ -2393,7 +2391,7 @@ end
 
 function rocsolver_dgeqrf_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgeqrf_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgeqrf_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                  lda::rocblas_int, ipiv::Ptr{Cdouble},
                                                  strideP::rocblas_stride,
@@ -2402,7 +2400,7 @@ end
 
 function rocsolver_cgeqrf_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgeqrf_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgeqrf_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
                                                  lda::rocblas_int,
@@ -2413,7 +2411,7 @@ end
 
 function rocsolver_zgeqrf_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgeqrf_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgeqrf_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
                                                  lda::rocblas_int,
@@ -2425,7 +2423,7 @@ end
 function rocsolver_sgeqrf_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgeqrf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgeqrf_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cfloat}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -2437,7 +2435,7 @@ end
 function rocsolver_dgeqrf_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgeqrf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgeqrf_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cdouble}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -2449,7 +2447,7 @@ end
 function rocsolver_cgeqrf_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgeqrf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgeqrf_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
                                                          lda::rocblas_int,
@@ -2462,7 +2460,7 @@ end
 function rocsolver_zgeqrf_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgeqrf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgeqrf_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
                                                          lda::rocblas_int,
@@ -2474,21 +2472,21 @@ end
 
 function rocsolver_sgerqf(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgerqf(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgerqf(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          ipiv::Ptr{Cfloat})::rocblas_status
 end
 
 function rocsolver_dgerqf(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgerqf(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgerqf(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          ipiv::Ptr{Cdouble})::rocblas_status
 end
 
 function rocsolver_cgerqf(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgerqf(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgerqf(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int,
                                          ipiv::Ptr{rocblas_float_complex})::rocblas_status
@@ -2496,7 +2494,7 @@ end
 
 function rocsolver_zgerqf(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgerqf(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgerqf(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int,
                                          ipiv::Ptr{rocblas_double_complex})::rocblas_status
@@ -2504,7 +2502,7 @@ end
 
 function rocsolver_sgerqf_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgerqf_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgerqf_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                  lda::rocblas_int, ipiv::Ptr{Cfloat},
                                                  strideP::rocblas_stride,
@@ -2513,7 +2511,7 @@ end
 
 function rocsolver_dgerqf_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgerqf_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgerqf_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                  lda::rocblas_int, ipiv::Ptr{Cdouble},
                                                  strideP::rocblas_stride,
@@ -2522,7 +2520,7 @@ end
 
 function rocsolver_cgerqf_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgerqf_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgerqf_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
                                                  lda::rocblas_int,
@@ -2533,7 +2531,7 @@ end
 
 function rocsolver_zgerqf_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgerqf_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgerqf_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
                                                  lda::rocblas_int,
@@ -2545,7 +2543,7 @@ end
 function rocsolver_sgerqf_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgerqf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgerqf_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cfloat}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -2557,7 +2555,7 @@ end
 function rocsolver_dgerqf_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgerqf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgerqf_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cdouble}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -2569,7 +2567,7 @@ end
 function rocsolver_cgerqf_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgerqf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgerqf_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
                                                          lda::rocblas_int,
@@ -2582,7 +2580,7 @@ end
 function rocsolver_zgerqf_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgerqf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgerqf_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
                                                          lda::rocblas_int,
@@ -2594,21 +2592,21 @@ end
 
 function rocsolver_sgeqlf(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgeqlf(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgeqlf(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          ipiv::Ptr{Cfloat})::rocblas_status
 end
 
 function rocsolver_dgeqlf(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgeqlf(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgeqlf(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          ipiv::Ptr{Cdouble})::rocblas_status
 end
 
 function rocsolver_cgeqlf(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgeqlf(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgeqlf(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int,
                                          ipiv::Ptr{rocblas_float_complex})::rocblas_status
@@ -2616,7 +2614,7 @@ end
 
 function rocsolver_zgeqlf(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgeqlf(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgeqlf(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int,
                                          ipiv::Ptr{rocblas_double_complex})::rocblas_status
@@ -2624,7 +2622,7 @@ end
 
 function rocsolver_sgeqlf_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgeqlf_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgeqlf_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                  lda::rocblas_int, ipiv::Ptr{Cfloat},
                                                  strideP::rocblas_stride,
@@ -2633,7 +2631,7 @@ end
 
 function rocsolver_dgeqlf_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgeqlf_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgeqlf_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                  lda::rocblas_int, ipiv::Ptr{Cdouble},
                                                  strideP::rocblas_stride,
@@ -2642,7 +2640,7 @@ end
 
 function rocsolver_cgeqlf_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgeqlf_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgeqlf_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
                                                  lda::rocblas_int,
@@ -2653,7 +2651,7 @@ end
 
 function rocsolver_zgeqlf_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgeqlf_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgeqlf_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
                                                  lda::rocblas_int,
@@ -2665,7 +2663,7 @@ end
 function rocsolver_sgeqlf_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgeqlf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgeqlf_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cfloat}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -2677,7 +2675,7 @@ end
 function rocsolver_dgeqlf_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgeqlf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgeqlf_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cdouble}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -2689,7 +2687,7 @@ end
 function rocsolver_cgeqlf_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgeqlf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgeqlf_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
                                                          lda::rocblas_int,
@@ -2702,7 +2700,7 @@ end
 function rocsolver_zgeqlf_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgeqlf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgeqlf_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
                                                          lda::rocblas_int,
@@ -2714,21 +2712,21 @@ end
 
 function rocsolver_sgelqf(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgelqf(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgelqf(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          ipiv::Ptr{Cfloat})::rocblas_status
 end
 
 function rocsolver_dgelqf(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgelqf(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgelqf(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          ipiv::Ptr{Cdouble})::rocblas_status
 end
 
 function rocsolver_cgelqf(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgelqf(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgelqf(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int,
                                          ipiv::Ptr{rocblas_float_complex})::rocblas_status
@@ -2736,7 +2734,7 @@ end
 
 function rocsolver_zgelqf(handle, m, n, A, lda, ipiv)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgelqf(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgelqf(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int,
                                          ipiv::Ptr{rocblas_double_complex})::rocblas_status
@@ -2744,7 +2742,7 @@ end
 
 function rocsolver_sgelqf_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgelqf_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgelqf_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                  lda::rocblas_int, ipiv::Ptr{Cfloat},
                                                  strideP::rocblas_stride,
@@ -2753,7 +2751,7 @@ end
 
 function rocsolver_dgelqf_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgelqf_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgelqf_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                  lda::rocblas_int, ipiv::Ptr{Cdouble},
                                                  strideP::rocblas_stride,
@@ -2762,7 +2760,7 @@ end
 
 function rocsolver_cgelqf_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgelqf_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgelqf_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
                                                  lda::rocblas_int,
@@ -2773,7 +2771,7 @@ end
 
 function rocsolver_zgelqf_batched(handle, m, n, A, lda, ipiv, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgelqf_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgelqf_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
                                                  lda::rocblas_int,
@@ -2785,7 +2783,7 @@ end
 function rocsolver_sgelqf_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgelqf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgelqf_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cfloat}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -2797,7 +2795,7 @@ end
 function rocsolver_dgelqf_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgelqf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgelqf_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cdouble}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -2809,7 +2807,7 @@ end
 function rocsolver_cgelqf_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgelqf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgelqf_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
                                                          lda::rocblas_int,
@@ -2822,7 +2820,7 @@ end
 function rocsolver_zgelqf_strided_batched(handle, m, n, A, lda, strideA, ipiv, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgelqf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgelqf_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
                                                          lda::rocblas_int,
@@ -2834,7 +2832,7 @@ end
 
 function rocsolver_sgebd2(handle, m, n, A, lda, D, E, tauq, taup)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgebd2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgebd2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          D::Ptr{Cfloat}, E::Ptr{Cfloat}, tauq::Ptr{Cfloat},
                                          taup::Ptr{Cfloat})::rocblas_status
@@ -2842,7 +2840,7 @@ end
 
 function rocsolver_dgebd2(handle, m, n, A, lda, D, E, tauq, taup)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgebd2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgebd2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          D::Ptr{Cdouble}, E::Ptr{Cdouble},
                                          tauq::Ptr{Cdouble},
@@ -2851,7 +2849,7 @@ end
 
 function rocsolver_cgebd2(handle, m, n, A, lda, D, E, tauq, taup)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgebd2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgebd2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int, D::Ptr{Cfloat}, E::Ptr{Cfloat},
                                          tauq::Ptr{rocblas_float_complex},
@@ -2860,7 +2858,7 @@ end
 
 function rocsolver_zgebd2(handle, m, n, A, lda, D, E, tauq, taup)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgebd2(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgebd2(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int, D::Ptr{Cdouble}, E::Ptr{Cdouble},
                                          tauq::Ptr{rocblas_double_complex},
@@ -2870,7 +2868,7 @@ end
 function rocsolver_sgebd2_batched(handle, m, n, A, lda, D, strideD, E, strideE, tauq,
                                   strideQ, taup, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgebd2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgebd2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                  lda::rocblas_int, D::Ptr{Cfloat},
                                                  strideD::rocblas_stride, E::Ptr{Cfloat},
@@ -2883,7 +2881,7 @@ end
 function rocsolver_dgebd2_batched(handle, m, n, A, lda, D, strideD, E, strideE, tauq,
                                   strideQ, taup, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgebd2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgebd2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                  lda::rocblas_int, D::Ptr{Cdouble},
                                                  strideD::rocblas_stride, E::Ptr{Cdouble},
@@ -2898,7 +2896,7 @@ end
 function rocsolver_cgebd2_batched(handle, m, n, A, lda, D, strideD, E, strideE, tauq,
                                   strideQ, taup, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgebd2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgebd2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
                                                  lda::rocblas_int, D::Ptr{Cfloat},
@@ -2914,7 +2912,7 @@ end
 function rocsolver_zgebd2_batched(handle, m, n, A, lda, D, strideD, E, strideE, tauq,
                                   strideQ, taup, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgebd2_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgebd2_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
                                                  lda::rocblas_int, D::Ptr{Cdouble},
@@ -2931,7 +2929,7 @@ function rocsolver_sgebd2_strided_batched(handle, m, n, A, lda, strideA, D, stri
                                           strideE, tauq, strideQ, taup, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgebd2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgebd2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cfloat}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -2950,7 +2948,7 @@ function rocsolver_dgebd2_strided_batched(handle, m, n, A, lda, strideA, D, stri
                                           strideE, tauq, strideQ, taup, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgebd2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgebd2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cdouble}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -2969,7 +2967,7 @@ function rocsolver_cgebd2_strided_batched(handle, m, n, A, lda, strideA, D, stri
                                           strideE, tauq, strideQ, taup, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgebd2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgebd2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
                                                          lda::rocblas_int,
@@ -2989,7 +2987,7 @@ function rocsolver_zgebd2_strided_batched(handle, m, n, A, lda, strideA, D, stri
                                           strideE, tauq, strideQ, taup, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgebd2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgebd2_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
                                                          lda::rocblas_int,
@@ -3007,7 +3005,7 @@ end
 
 function rocsolver_sgebrd(handle, m, n, A, lda, D, E, tauq, taup)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgebrd(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgebrd(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          D::Ptr{Cfloat}, E::Ptr{Cfloat}, tauq::Ptr{Cfloat},
                                          taup::Ptr{Cfloat})::rocblas_status
@@ -3015,7 +3013,7 @@ end
 
 function rocsolver_dgebrd(handle, m, n, A, lda, D, E, tauq, taup)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgebrd(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgebrd(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          D::Ptr{Cdouble}, E::Ptr{Cdouble},
                                          tauq::Ptr{Cdouble},
@@ -3024,7 +3022,7 @@ end
 
 function rocsolver_cgebrd(handle, m, n, A, lda, D, E, tauq, taup)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgebrd(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgebrd(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int, D::Ptr{Cfloat}, E::Ptr{Cfloat},
                                          tauq::Ptr{rocblas_float_complex},
@@ -3033,7 +3031,7 @@ end
 
 function rocsolver_zgebrd(handle, m, n, A, lda, D, E, tauq, taup)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgebrd(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgebrd(handle::rocblas_handle, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int, D::Ptr{Cdouble}, E::Ptr{Cdouble},
                                          tauq::Ptr{rocblas_double_complex},
@@ -3043,7 +3041,7 @@ end
 function rocsolver_sgebrd_batched(handle, m, n, A, lda, D, strideD, E, strideE, tauq,
                                   strideQ, taup, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgebrd_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgebrd_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                  lda::rocblas_int, D::Ptr{Cfloat},
                                                  strideD::rocblas_stride, E::Ptr{Cfloat},
@@ -3056,7 +3054,7 @@ end
 function rocsolver_dgebrd_batched(handle, m, n, A, lda, D, strideD, E, strideE, tauq,
                                   strideQ, taup, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgebrd_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgebrd_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                  lda::rocblas_int, D::Ptr{Cdouble},
                                                  strideD::rocblas_stride, E::Ptr{Cdouble},
@@ -3071,7 +3069,7 @@ end
 function rocsolver_cgebrd_batched(handle, m, n, A, lda, D, strideD, E, strideE, tauq,
                                   strideQ, taup, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgebrd_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgebrd_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
                                                  lda::rocblas_int, D::Ptr{Cfloat},
@@ -3087,7 +3085,7 @@ end
 function rocsolver_zgebrd_batched(handle, m, n, A, lda, D, strideD, E, strideE, tauq,
                                   strideQ, taup, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgebrd_batched(handle::rocblas_handle, m::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgebrd_batched(handle::rocblas_handle, m::rocblas_int,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
                                                  lda::rocblas_int, D::Ptr{Cdouble},
@@ -3104,7 +3102,7 @@ function rocsolver_sgebrd_strided_batched(handle, m, n, A, lda, strideA, D, stri
                                           strideE, tauq, strideQ, taup, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgebrd_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgebrd_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cfloat}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -3123,7 +3121,7 @@ function rocsolver_dgebrd_strided_batched(handle, m, n, A, lda, strideA, D, stri
                                           strideE, tauq, strideQ, taup, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgebrd_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgebrd_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{Cdouble}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -3142,7 +3140,7 @@ function rocsolver_cgebrd_strided_batched(handle, m, n, A, lda, strideA, D, stri
                                           strideE, tauq, strideQ, taup, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgebrd_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgebrd_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
                                                          lda::rocblas_int,
@@ -3162,7 +3160,7 @@ function rocsolver_zgebrd_strided_batched(handle, m, n, A, lda, strideA, D, stri
                                           strideE, tauq, strideQ, taup, strideP,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgebrd_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgebrd_strided_batched(handle::rocblas_handle,
                                                          m::rocblas_int, n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
                                                          lda::rocblas_int,
@@ -3180,7 +3178,7 @@ end
 
 function rocsolver_sgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetrs(handle::rocblas_handle, trans::rocblas_operation,
+    @check @ccall librocsolver.rocsolver_sgetrs(handle::rocblas_handle, trans::rocblas_operation,
                                          n::rocblas_int, nrhs::rocblas_int, A::Ptr{Cfloat},
                                          lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                          B::Ptr{Cfloat}, ldb::rocblas_int)::rocblas_status
@@ -3188,7 +3186,7 @@ end
 
 function rocsolver_dgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetrs(handle::rocblas_handle, trans::rocblas_operation,
+    @check @ccall librocsolver.rocsolver_dgetrs(handle::rocblas_handle, trans::rocblas_operation,
                                          n::rocblas_int, nrhs::rocblas_int, A::Ptr{Cdouble},
                                          lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                          B::Ptr{Cdouble}, ldb::rocblas_int)::rocblas_status
@@ -3196,7 +3194,7 @@ end
 
 function rocsolver_cgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetrs(handle::rocblas_handle, trans::rocblas_operation,
+    @check @ccall librocsolver.rocsolver_cgetrs(handle::rocblas_handle, trans::rocblas_operation,
                                          n::rocblas_int, nrhs::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_int},
@@ -3206,7 +3204,7 @@ end
 
 function rocsolver_zgetrs(handle, trans, n, nrhs, A, lda, ipiv, B, ldb)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetrs(handle::rocblas_handle, trans::rocblas_operation,
+    @check @ccall librocsolver.rocsolver_zgetrs(handle::rocblas_handle, trans::rocblas_operation,
                                          n::rocblas_int, nrhs::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_int},
@@ -3217,7 +3215,7 @@ end
 function rocsolver_sgetrs_batched(handle, trans, n, nrhs, A, lda, ipiv, strideP, B, ldb,
                                   batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetrs_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgetrs_batched(handle::rocblas_handle,
                                                  trans::rocblas_operation, n::rocblas_int,
                                                  nrhs::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                  lda::rocblas_int, ipiv::Ptr{rocblas_int},
@@ -3229,7 +3227,7 @@ end
 function rocsolver_dgetrs_batched(handle, trans, n, nrhs, A, lda, ipiv, strideP, B, ldb,
                                   batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetrs_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgetrs_batched(handle::rocblas_handle,
                                                  trans::rocblas_operation, n::rocblas_int,
                                                  nrhs::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                  lda::rocblas_int, ipiv::Ptr{rocblas_int},
@@ -3241,7 +3239,7 @@ end
 function rocsolver_cgetrs_batched(handle, trans, n, nrhs, A, lda, ipiv, strideP, B, ldb,
                                   batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetrs_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgetrs_batched(handle::rocblas_handle,
                                                  trans::rocblas_operation, n::rocblas_int,
                                                  nrhs::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
@@ -3255,7 +3253,7 @@ end
 function rocsolver_zgetrs_batched(handle, trans, n, nrhs, A, lda, ipiv, strideP, B, ldb,
                                   batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetrs_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgetrs_batched(handle::rocblas_handle,
                                                  trans::rocblas_operation, n::rocblas_int,
                                                  nrhs::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
@@ -3269,7 +3267,7 @@ end
 function rocsolver_sgetrs_strided_batched(handle, trans, n, nrhs, A, lda, strideA, ipiv,
                                           strideP, B, ldb, strideB, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetrs_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgetrs_strided_batched(handle::rocblas_handle,
                                                          trans::rocblas_operation,
                                                          n::rocblas_int, nrhs::rocblas_int,
                                                          A::Ptr{Cfloat}, lda::rocblas_int,
@@ -3284,7 +3282,7 @@ end
 function rocsolver_dgetrs_strided_batched(handle, trans, n, nrhs, A, lda, strideA, ipiv,
                                           strideP, B, ldb, strideB, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetrs_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgetrs_strided_batched(handle::rocblas_handle,
                                                          trans::rocblas_operation,
                                                          n::rocblas_int, nrhs::rocblas_int,
                                                          A::Ptr{Cdouble}, lda::rocblas_int,
@@ -3299,7 +3297,7 @@ end
 function rocsolver_cgetrs_strided_batched(handle, trans, n, nrhs, A, lda, strideA, ipiv,
                                           strideP, B, ldb, strideB, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetrs_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgetrs_strided_batched(handle::rocblas_handle,
                                                          trans::rocblas_operation,
                                                          n::rocblas_int, nrhs::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
@@ -3316,7 +3314,7 @@ end
 function rocsolver_zgetrs_strided_batched(handle, trans, n, nrhs, A, lda, strideA, ipiv,
                                           strideP, B, ldb, strideB, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetrs_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgetrs_strided_batched(handle::rocblas_handle,
                                                          trans::rocblas_operation,
                                                          n::rocblas_int, nrhs::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
@@ -3332,7 +3330,7 @@ end
 
 function rocsolver_sgesv(handle, n, nrhs, A, lda, ipiv, B, ldb, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgesv(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgesv(handle::rocblas_handle, n::rocblas_int,
                                         nrhs::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                         ipiv::Ptr{rocblas_int}, B::Ptr{Cfloat},
                                         ldb::rocblas_int,
@@ -3341,7 +3339,7 @@ end
 
 function rocsolver_dgesv(handle, n, nrhs, A, lda, ipiv, B, ldb, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgesv(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgesv(handle::rocblas_handle, n::rocblas_int,
                                         nrhs::rocblas_int, A::Ptr{Cdouble},
                                         lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                         B::Ptr{Cdouble}, ldb::rocblas_int,
@@ -3350,7 +3348,7 @@ end
 
 function rocsolver_cgesv(handle, n, nrhs, A, lda, ipiv, B, ldb, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgesv(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgesv(handle::rocblas_handle, n::rocblas_int,
                                         nrhs::rocblas_int, A::Ptr{rocblas_float_complex},
                                         lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                         B::Ptr{rocblas_float_complex}, ldb::rocblas_int,
@@ -3359,7 +3357,7 @@ end
 
 function rocsolver_zgesv(handle, n, nrhs, A, lda, ipiv, B, ldb, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgesv(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgesv(handle::rocblas_handle, n::rocblas_int,
                                         nrhs::rocblas_int, A::Ptr{rocblas_double_complex},
                                         lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                         B::Ptr{rocblas_double_complex}, ldb::rocblas_int,
@@ -3369,7 +3367,7 @@ end
 function rocsolver_sgesv_batched(handle, n, nrhs, A, lda, ipiv, strideP, B, ldb, info,
                                  batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgesv_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgesv_batched(handle::rocblas_handle, n::rocblas_int,
                                                 nrhs::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                 lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                                 strideP::rocblas_stride,
@@ -3381,7 +3379,7 @@ end
 function rocsolver_dgesv_batched(handle, n, nrhs, A, lda, ipiv, strideP, B, ldb, info,
                                  batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgesv_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgesv_batched(handle::rocblas_handle, n::rocblas_int,
                                                 nrhs::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                 lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                                 strideP::rocblas_stride,
@@ -3393,7 +3391,7 @@ end
 function rocsolver_cgesv_batched(handle, n, nrhs, A, lda, ipiv, strideP, B, ldb, info,
                                  batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgesv_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgesv_batched(handle::rocblas_handle, n::rocblas_int,
                                                 nrhs::rocblas_int,
                                                 A::Ptr{Ptr{rocblas_float_complex}},
                                                 lda::rocblas_int, ipiv::Ptr{rocblas_int},
@@ -3406,7 +3404,7 @@ end
 function rocsolver_zgesv_batched(handle, n, nrhs, A, lda, ipiv, strideP, B, ldb, info,
                                  batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgesv_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgesv_batched(handle::rocblas_handle, n::rocblas_int,
                                                 nrhs::rocblas_int,
                                                 A::Ptr{Ptr{rocblas_double_complex}},
                                                 lda::rocblas_int, ipiv::Ptr{rocblas_int},
@@ -3419,7 +3417,7 @@ end
 function rocsolver_sgesv_strided_batched(handle, n, nrhs, A, lda, strideA, ipiv, strideP, B,
                                          ldb, strideB, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgesv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgesv_strided_batched(handle::rocblas_handle,
                                                         n::rocblas_int, nrhs::rocblas_int,
                                                         A::Ptr{Cfloat}, lda::rocblas_int,
                                                         strideA::rocblas_stride,
@@ -3434,7 +3432,7 @@ end
 function rocsolver_dgesv_strided_batched(handle, n, nrhs, A, lda, strideA, ipiv, strideP, B,
                                          ldb, strideB, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgesv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgesv_strided_batched(handle::rocblas_handle,
                                                         n::rocblas_int, nrhs::rocblas_int,
                                                         A::Ptr{Cdouble}, lda::rocblas_int,
                                                         strideA::rocblas_stride,
@@ -3449,7 +3447,7 @@ end
 function rocsolver_cgesv_strided_batched(handle, n, nrhs, A, lda, strideA, ipiv, strideP, B,
                                          ldb, strideB, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgesv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgesv_strided_batched(handle::rocblas_handle,
                                                         n::rocblas_int, nrhs::rocblas_int,
                                                         A::Ptr{rocblas_float_complex},
                                                         lda::rocblas_int,
@@ -3466,7 +3464,7 @@ end
 function rocsolver_zgesv_strided_batched(handle, n, nrhs, A, lda, strideA, ipiv, strideP, B,
                                          ldb, strideB, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgesv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgesv_strided_batched(handle::rocblas_handle,
                                                         n::rocblas_int, nrhs::rocblas_int,
                                                         A::Ptr{rocblas_double_complex},
                                                         lda::rocblas_int,
@@ -3482,7 +3480,7 @@ end
 
 function rocsolver_sgetri(handle, n, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetri(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgetri(handle::rocblas_handle, n::rocblas_int,
                                          A::Ptr{Cfloat}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_int},
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -3490,7 +3488,7 @@ end
 
 function rocsolver_dgetri(handle, n, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetri(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgetri(handle::rocblas_handle, n::rocblas_int,
                                          A::Ptr{Cdouble}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_int},
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -3498,7 +3496,7 @@ end
 
 function rocsolver_cgetri(handle, n, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetri(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgetri(handle::rocblas_handle, n::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_int},
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -3506,7 +3504,7 @@ end
 
 function rocsolver_zgetri(handle, n, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetri(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgetri(handle::rocblas_handle, n::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_int},
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -3514,7 +3512,7 @@ end
 
 function rocsolver_sgetri_batched(handle, n, A, lda, ipiv, strideP, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetri_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgetri_batched(handle::rocblas_handle, n::rocblas_int,
                                                  A::Ptr{Ptr{Cfloat}}, lda::rocblas_int,
                                                  ipiv::Ptr{rocblas_int},
                                                  strideP::rocblas_stride,
@@ -3524,7 +3522,7 @@ end
 
 function rocsolver_dgetri_batched(handle, n, A, lda, ipiv, strideP, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetri_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgetri_batched(handle::rocblas_handle, n::rocblas_int,
                                                  A::Ptr{Ptr{Cdouble}}, lda::rocblas_int,
                                                  ipiv::Ptr{rocblas_int},
                                                  strideP::rocblas_stride,
@@ -3534,7 +3532,7 @@ end
 
 function rocsolver_cgetri_batched(handle, n, A, lda, ipiv, strideP, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetri_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgetri_batched(handle::rocblas_handle, n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
                                                  lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                                  strideP::rocblas_stride,
@@ -3544,7 +3542,7 @@ end
 
 function rocsolver_zgetri_batched(handle, n, A, lda, ipiv, strideP, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetri_batched(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgetri_batched(handle::rocblas_handle, n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
                                                  lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                                  strideP::rocblas_stride,
@@ -3555,7 +3553,7 @@ end
 function rocsolver_sgetri_strided_batched(handle, n, A, lda, strideA, ipiv, strideP, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetri_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgetri_strided_batched(handle::rocblas_handle,
                                                          n::rocblas_int, A::Ptr{Cfloat},
                                                          lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -3568,7 +3566,7 @@ end
 function rocsolver_dgetri_strided_batched(handle, n, A, lda, strideA, ipiv, strideP, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetri_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgetri_strided_batched(handle::rocblas_handle,
                                                          n::rocblas_int, A::Ptr{Cdouble},
                                                          lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -3581,7 +3579,7 @@ end
 function rocsolver_cgetri_strided_batched(handle, n, A, lda, strideA, ipiv, strideP, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetri_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgetri_strided_batched(handle::rocblas_handle,
                                                          n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
                                                          lda::rocblas_int,
@@ -3595,7 +3593,7 @@ end
 function rocsolver_zgetri_strided_batched(handle, n, A, lda, strideA, ipiv, strideP, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetri_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgetri_strided_batched(handle::rocblas_handle,
                                                          n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
                                                          lda::rocblas_int,
@@ -3608,21 +3606,21 @@ end
 
 function rocsolver_sgetri_npvt(handle, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetri_npvt(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgetri_npvt(handle::rocblas_handle, n::rocblas_int,
                                               A::Ptr{Cfloat}, lda::rocblas_int,
                                               info::Ptr{rocblas_int})::rocblas_status
 end
 
 function rocsolver_dgetri_npvt(handle, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetri_npvt(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgetri_npvt(handle::rocblas_handle, n::rocblas_int,
                                               A::Ptr{Cdouble}, lda::rocblas_int,
                                               info::Ptr{rocblas_int})::rocblas_status
 end
 
 function rocsolver_cgetri_npvt(handle, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetri_npvt(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgetri_npvt(handle::rocblas_handle, n::rocblas_int,
                                               A::Ptr{rocblas_float_complex},
                                               lda::rocblas_int,
                                               info::Ptr{rocblas_int})::rocblas_status
@@ -3630,7 +3628,7 @@ end
 
 function rocsolver_zgetri_npvt(handle, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetri_npvt(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgetri_npvt(handle::rocblas_handle, n::rocblas_int,
                                               A::Ptr{rocblas_double_complex},
                                               lda::rocblas_int,
                                               info::Ptr{rocblas_int})::rocblas_status
@@ -3638,7 +3636,7 @@ end
 
 function rocsolver_sgetri_npvt_batched(handle, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetri_npvt_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgetri_npvt_batched(handle::rocblas_handle,
                                                       n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                       lda::rocblas_int,
                                                       info::Ptr{rocblas_int},
@@ -3647,7 +3645,7 @@ end
 
 function rocsolver_dgetri_npvt_batched(handle, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetri_npvt_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgetri_npvt_batched(handle::rocblas_handle,
                                                       n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                       lda::rocblas_int,
                                                       info::Ptr{rocblas_int},
@@ -3656,7 +3654,7 @@ end
 
 function rocsolver_cgetri_npvt_batched(handle, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetri_npvt_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgetri_npvt_batched(handle::rocblas_handle,
                                                       n::rocblas_int,
                                                       A::Ptr{Ptr{rocblas_float_complex}},
                                                       lda::rocblas_int,
@@ -3666,7 +3664,7 @@ end
 
 function rocsolver_zgetri_npvt_batched(handle, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetri_npvt_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgetri_npvt_batched(handle::rocblas_handle,
                                                       n::rocblas_int,
                                                       A::Ptr{Ptr{rocblas_double_complex}},
                                                       lda::rocblas_int,
@@ -3677,7 +3675,7 @@ end
 function rocsolver_sgetri_npvt_strided_batched(handle, n, A, lda, strideA, info,
                                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetri_npvt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgetri_npvt_strided_batched(handle::rocblas_handle,
                                                               n::rocblas_int,
                                                               A::Ptr{Cfloat},
                                                               lda::rocblas_int,
@@ -3689,7 +3687,7 @@ end
 function rocsolver_dgetri_npvt_strided_batched(handle, n, A, lda, strideA, info,
                                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetri_npvt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgetri_npvt_strided_batched(handle::rocblas_handle,
                                                               n::rocblas_int,
                                                               A::Ptr{Cdouble},
                                                               lda::rocblas_int,
@@ -3701,7 +3699,7 @@ end
 function rocsolver_cgetri_npvt_strided_batched(handle, n, A, lda, strideA, info,
                                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetri_npvt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgetri_npvt_strided_batched(handle::rocblas_handle,
                                                               n::rocblas_int,
                                                               A::Ptr{rocblas_float_complex},
                                                               lda::rocblas_int,
@@ -3713,7 +3711,7 @@ end
 function rocsolver_zgetri_npvt_strided_batched(handle, n, A, lda, strideA, info,
                                                batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetri_npvt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgetri_npvt_strided_batched(handle::rocblas_handle,
                                                               n::rocblas_int,
                                                               A::Ptr{rocblas_double_complex},
                                                               lda::rocblas_int,
@@ -3724,7 +3722,7 @@ end
 
 function rocsolver_sgels(handle, trans, m, n, nrhs, A, lda, B, ldb, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgels(handle::rocblas_handle, trans::rocblas_operation,
+    @check @ccall librocsolver.rocsolver_sgels(handle::rocblas_handle, trans::rocblas_operation,
                                         m::rocblas_int, n::rocblas_int, nrhs::rocblas_int,
                                         A::Ptr{Cfloat}, lda::rocblas_int, B::Ptr{Cfloat},
                                         ldb::rocblas_int,
@@ -3733,7 +3731,7 @@ end
 
 function rocsolver_dgels(handle, trans, m, n, nrhs, A, lda, B, ldb, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgels(handle::rocblas_handle, trans::rocblas_operation,
+    @check @ccall librocsolver.rocsolver_dgels(handle::rocblas_handle, trans::rocblas_operation,
                                         m::rocblas_int, n::rocblas_int, nrhs::rocblas_int,
                                         A::Ptr{Cdouble}, lda::rocblas_int, B::Ptr{Cdouble},
                                         ldb::rocblas_int,
@@ -3742,7 +3740,7 @@ end
 
 function rocsolver_cgels(handle, trans, m, n, nrhs, A, lda, B, ldb, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgels(handle::rocblas_handle, trans::rocblas_operation,
+    @check @ccall librocsolver.rocsolver_cgels(handle::rocblas_handle, trans::rocblas_operation,
                                         m::rocblas_int, n::rocblas_int, nrhs::rocblas_int,
                                         A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                         B::Ptr{rocblas_float_complex}, ldb::rocblas_int,
@@ -3751,7 +3749,7 @@ end
 
 function rocsolver_zgels(handle, trans, m, n, nrhs, A, lda, B, ldb, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgels(handle::rocblas_handle, trans::rocblas_operation,
+    @check @ccall librocsolver.rocsolver_zgels(handle::rocblas_handle, trans::rocblas_operation,
                                         m::rocblas_int, n::rocblas_int, nrhs::rocblas_int,
                                         A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                         B::Ptr{rocblas_double_complex}, ldb::rocblas_int,
@@ -3761,7 +3759,7 @@ end
 function rocsolver_sgels_batched(handle, trans, m, n, nrhs, A, lda, B, ldb, info,
                                  batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgels_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgels_batched(handle::rocblas_handle,
                                                 trans::rocblas_operation, m::rocblas_int,
                                                 n::rocblas_int, nrhs::rocblas_int,
                                                 A::Ptr{Ptr{Cfloat}}, lda::rocblas_int,
@@ -3773,7 +3771,7 @@ end
 function rocsolver_dgels_batched(handle, trans, m, n, nrhs, A, lda, B, ldb, info,
                                  batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgels_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgels_batched(handle::rocblas_handle,
                                                 trans::rocblas_operation, m::rocblas_int,
                                                 n::rocblas_int, nrhs::rocblas_int,
                                                 A::Ptr{Ptr{Cdouble}}, lda::rocblas_int,
@@ -3785,7 +3783,7 @@ end
 function rocsolver_cgels_batched(handle, trans, m, n, nrhs, A, lda, B, ldb, info,
                                  batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgels_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgels_batched(handle::rocblas_handle,
                                                 trans::rocblas_operation, m::rocblas_int,
                                                 n::rocblas_int, nrhs::rocblas_int,
                                                 A::Ptr{Ptr{rocblas_float_complex}},
@@ -3798,7 +3796,7 @@ end
 function rocsolver_zgels_batched(handle, trans, m, n, nrhs, A, lda, B, ldb, info,
                                  batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgels_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgels_batched(handle::rocblas_handle,
                                                 trans::rocblas_operation, m::rocblas_int,
                                                 n::rocblas_int, nrhs::rocblas_int,
                                                 A::Ptr{Ptr{rocblas_double_complex}},
@@ -3811,7 +3809,7 @@ end
 function rocsolver_sgels_strided_batched(handle, trans, m, n, nrhs, A, lda, strideA, B, ldb,
                                          strideB, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgels_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgels_strided_batched(handle::rocblas_handle,
                                                         trans::rocblas_operation,
                                                         m::rocblas_int, n::rocblas_int,
                                                         nrhs::rocblas_int, A::Ptr{Cfloat},
@@ -3826,7 +3824,7 @@ end
 function rocsolver_dgels_strided_batched(handle, trans, m, n, nrhs, A, lda, strideA, B, ldb,
                                          strideB, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgels_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgels_strided_batched(handle::rocblas_handle,
                                                         trans::rocblas_operation,
                                                         m::rocblas_int, n::rocblas_int,
                                                         nrhs::rocblas_int, A::Ptr{Cdouble},
@@ -3841,7 +3839,7 @@ end
 function rocsolver_cgels_strided_batched(handle, trans, m, n, nrhs, A, lda, strideA, B, ldb,
                                          strideB, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgels_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgels_strided_batched(handle::rocblas_handle,
                                                         trans::rocblas_operation,
                                                         m::rocblas_int, n::rocblas_int,
                                                         nrhs::rocblas_int,
@@ -3858,7 +3856,7 @@ end
 function rocsolver_zgels_strided_batched(handle, trans, m, n, nrhs, A, lda, strideA, B, ldb,
                                          strideB, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgels_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgels_strided_batched(handle::rocblas_handle,
                                                         trans::rocblas_operation,
                                                         m::rocblas_int, n::rocblas_int,
                                                         nrhs::rocblas_int,
@@ -3874,21 +3872,21 @@ end
 
 function rocsolver_spotf2(handle, uplo, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_spotf2(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_spotf2(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
 end
 
 function rocsolver_dpotf2(handle, uplo, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dpotf2(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dpotf2(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
 end
 
 function rocsolver_cpotf2(handle, uplo, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cpotf2(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_cpotf2(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -3896,7 +3894,7 @@ end
 
 function rocsolver_zpotf2(handle, uplo, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zpotf2(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_zpotf2(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -3904,7 +3902,7 @@ end
 
 function rocsolver_spotf2_batched(handle, uplo, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_spotf2_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_spotf2_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                  lda::rocblas_int, info::Ptr{rocblas_int},
                                                  batch_count::rocblas_int)::rocblas_status
@@ -3912,7 +3910,7 @@ end
 
 function rocsolver_dpotf2_batched(handle, uplo, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dpotf2_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dpotf2_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                  lda::rocblas_int, info::Ptr{rocblas_int},
                                                  batch_count::rocblas_int)::rocblas_status
@@ -3920,7 +3918,7 @@ end
 
 function rocsolver_cpotf2_batched(handle, uplo, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cpotf2_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_cpotf2_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
                                                  lda::rocblas_int, info::Ptr{rocblas_int},
@@ -3929,7 +3927,7 @@ end
 
 function rocsolver_zpotf2_batched(handle, uplo, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zpotf2_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_zpotf2_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
                                                  lda::rocblas_int, info::Ptr{rocblas_int},
@@ -3939,7 +3937,7 @@ end
 function rocsolver_spotf2_strided_batched(handle, uplo, n, A, lda, strideA, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_spotf2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_spotf2_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{Cfloat}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -3950,7 +3948,7 @@ end
 function rocsolver_dpotf2_strided_batched(handle, uplo, n, A, lda, strideA, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dpotf2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dpotf2_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{Cdouble}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -3961,7 +3959,7 @@ end
 function rocsolver_cpotf2_strided_batched(handle, uplo, n, A, lda, strideA, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cpotf2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cpotf2_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
                                                          lda::rocblas_int,
@@ -3973,7 +3971,7 @@ end
 function rocsolver_zpotf2_strided_batched(handle, uplo, n, A, lda, strideA, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zpotf2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zpotf2_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
                                                          lda::rocblas_int,
@@ -3984,21 +3982,21 @@ end
 
 function rocsolver_spotrf(handle, uplo, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_spotrf(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_spotrf(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
 end
 
 function rocsolver_dpotrf(handle, uplo, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dpotrf(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dpotrf(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
 end
 
 function rocsolver_cpotrf(handle, uplo, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cpotrf(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_cpotrf(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -4006,7 +4004,7 @@ end
 
 function rocsolver_zpotrf(handle, uplo, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zpotrf(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_zpotrf(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -4014,7 +4012,7 @@ end
 
 function rocsolver_spotrf_batched(handle, uplo, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_spotrf_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_spotrf_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                  lda::rocblas_int, info::Ptr{rocblas_int},
                                                  batch_count::rocblas_int)::rocblas_status
@@ -4022,7 +4020,7 @@ end
 
 function rocsolver_dpotrf_batched(handle, uplo, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dpotrf_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dpotrf_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                  lda::rocblas_int, info::Ptr{rocblas_int},
                                                  batch_count::rocblas_int)::rocblas_status
@@ -4030,7 +4028,7 @@ end
 
 function rocsolver_cpotrf_batched(handle, uplo, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cpotrf_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_cpotrf_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
                                                  lda::rocblas_int, info::Ptr{rocblas_int},
@@ -4039,7 +4037,7 @@ end
 
 function rocsolver_zpotrf_batched(handle, uplo, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zpotrf_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_zpotrf_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
                                                  lda::rocblas_int, info::Ptr{rocblas_int},
@@ -4049,7 +4047,7 @@ end
 function rocsolver_spotrf_strided_batched(handle, uplo, n, A, lda, strideA, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_spotrf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_spotrf_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{Cfloat}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -4060,7 +4058,7 @@ end
 function rocsolver_dpotrf_strided_batched(handle, uplo, n, A, lda, strideA, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dpotrf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dpotrf_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{Cdouble}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -4071,7 +4069,7 @@ end
 function rocsolver_cpotrf_strided_batched(handle, uplo, n, A, lda, strideA, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cpotrf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cpotrf_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
                                                          lda::rocblas_int,
@@ -4083,7 +4081,7 @@ end
 function rocsolver_zpotrf_strided_batched(handle, uplo, n, A, lda, strideA, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zpotrf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zpotrf_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
                                                          lda::rocblas_int,
@@ -4094,7 +4092,7 @@ end
 
 function rocsolver_spotrs(handle, uplo, n, nrhs, A, lda, B, ldb)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_spotrs(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_spotrs(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, nrhs::rocblas_int, A::Ptr{Cfloat},
                                          lda::rocblas_int, B::Ptr{Cfloat},
                                          ldb::rocblas_int)::rocblas_status
@@ -4102,7 +4100,7 @@ end
 
 function rocsolver_dpotrs(handle, uplo, n, nrhs, A, lda, B, ldb)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dpotrs(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dpotrs(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, nrhs::rocblas_int, A::Ptr{Cdouble},
                                          lda::rocblas_int, B::Ptr{Cdouble},
                                          ldb::rocblas_int)::rocblas_status
@@ -4110,7 +4108,7 @@ end
 
 function rocsolver_cpotrs(handle, uplo, n, nrhs, A, lda, B, ldb)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cpotrs(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_cpotrs(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, nrhs::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                          B::Ptr{rocblas_float_complex},
@@ -4119,7 +4117,7 @@ end
 
 function rocsolver_zpotrs(handle, uplo, n, nrhs, A, lda, B, ldb)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zpotrs(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_zpotrs(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, nrhs::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                          B::Ptr{rocblas_double_complex},
@@ -4128,7 +4126,7 @@ end
 
 function rocsolver_spotrs_batched(handle, uplo, n, nrhs, A, lda, B, ldb, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_spotrs_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_spotrs_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int, nrhs::rocblas_int,
                                                  A::Ptr{Ptr{Cfloat}}, lda::rocblas_int,
                                                  B::Ptr{Ptr{Cfloat}}, ldb::rocblas_int,
@@ -4137,7 +4135,7 @@ end
 
 function rocsolver_dpotrs_batched(handle, uplo, n, nrhs, A, lda, B, ldb, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dpotrs_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dpotrs_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int, nrhs::rocblas_int,
                                                  A::Ptr{Ptr{Cdouble}}, lda::rocblas_int,
                                                  B::Ptr{Ptr{Cdouble}}, ldb::rocblas_int,
@@ -4146,7 +4144,7 @@ end
 
 function rocsolver_cpotrs_batched(handle, uplo, n, nrhs, A, lda, B, ldb, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cpotrs_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_cpotrs_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int, nrhs::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
                                                  lda::rocblas_int,
@@ -4157,7 +4155,7 @@ end
 
 function rocsolver_zpotrs_batched(handle, uplo, n, nrhs, A, lda, B, ldb, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zpotrs_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_zpotrs_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int, nrhs::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
                                                  lda::rocblas_int,
@@ -4169,7 +4167,7 @@ end
 function rocsolver_spotrs_strided_batched(handle, uplo, n, nrhs, A, lda, strideA, B, ldb,
                                           strideB, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_spotrs_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_spotrs_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          nrhs::rocblas_int, A::Ptr{Cfloat},
                                                          lda::rocblas_int,
@@ -4182,7 +4180,7 @@ end
 function rocsolver_dpotrs_strided_batched(handle, uplo, n, nrhs, A, lda, strideA, B, ldb,
                                           strideB, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dpotrs_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dpotrs_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          nrhs::rocblas_int, A::Ptr{Cdouble},
                                                          lda::rocblas_int,
@@ -4195,7 +4193,7 @@ end
 function rocsolver_cpotrs_strided_batched(handle, uplo, n, nrhs, A, lda, strideA, B, ldb,
                                           strideB, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cpotrs_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cpotrs_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          nrhs::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
@@ -4210,7 +4208,7 @@ end
 function rocsolver_zpotrs_strided_batched(handle, uplo, n, nrhs, A, lda, strideA, B, ldb,
                                           strideB, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zpotrs_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zpotrs_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          nrhs::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
@@ -4224,7 +4222,7 @@ end
 
 function rocsolver_sposv(handle, uplo, n, nrhs, A, lda, B, ldb, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sposv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_sposv(handle::rocblas_handle, uplo::rocblas_fill,
                                         n::rocblas_int, nrhs::rocblas_int, A::Ptr{Cfloat},
                                         lda::rocblas_int, B::Ptr{Cfloat}, ldb::rocblas_int,
                                         info::Ptr{rocblas_int})::rocblas_status
@@ -4232,7 +4230,7 @@ end
 
 function rocsolver_dposv(handle, uplo, n, nrhs, A, lda, B, ldb, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dposv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dposv(handle::rocblas_handle, uplo::rocblas_fill,
                                         n::rocblas_int, nrhs::rocblas_int, A::Ptr{Cdouble},
                                         lda::rocblas_int, B::Ptr{Cdouble}, ldb::rocblas_int,
                                         info::Ptr{rocblas_int})::rocblas_status
@@ -4240,7 +4238,7 @@ end
 
 function rocsolver_cposv(handle, uplo, n, nrhs, A, lda, B, ldb, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cposv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_cposv(handle::rocblas_handle, uplo::rocblas_fill,
                                         n::rocblas_int, nrhs::rocblas_int,
                                         A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                         B::Ptr{rocblas_float_complex}, ldb::rocblas_int,
@@ -4249,7 +4247,7 @@ end
 
 function rocsolver_zposv(handle, uplo, n, nrhs, A, lda, B, ldb, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zposv(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_zposv(handle::rocblas_handle, uplo::rocblas_fill,
                                         n::rocblas_int, nrhs::rocblas_int,
                                         A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                         B::Ptr{rocblas_double_complex}, ldb::rocblas_int,
@@ -4258,7 +4256,7 @@ end
 
 function rocsolver_sposv_batched(handle, uplo, n, nrhs, A, lda, B, ldb, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sposv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_sposv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                 n::rocblas_int, nrhs::rocblas_int,
                                                 A::Ptr{Ptr{Cfloat}}, lda::rocblas_int,
                                                 B::Ptr{Ptr{Cfloat}}, ldb::rocblas_int,
@@ -4268,7 +4266,7 @@ end
 
 function rocsolver_dposv_batched(handle, uplo, n, nrhs, A, lda, B, ldb, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dposv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dposv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                 n::rocblas_int, nrhs::rocblas_int,
                                                 A::Ptr{Ptr{Cdouble}}, lda::rocblas_int,
                                                 B::Ptr{Ptr{Cdouble}}, ldb::rocblas_int,
@@ -4278,7 +4276,7 @@ end
 
 function rocsolver_cposv_batched(handle, uplo, n, nrhs, A, lda, B, ldb, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cposv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_cposv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                 n::rocblas_int, nrhs::rocblas_int,
                                                 A::Ptr{Ptr{rocblas_float_complex}},
                                                 lda::rocblas_int,
@@ -4289,7 +4287,7 @@ end
 
 function rocsolver_zposv_batched(handle, uplo, n, nrhs, A, lda, B, ldb, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zposv_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_zposv_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                 n::rocblas_int, nrhs::rocblas_int,
                                                 A::Ptr{Ptr{rocblas_double_complex}},
                                                 lda::rocblas_int,
@@ -4301,7 +4299,7 @@ end
 function rocsolver_sposv_strided_batched(handle, uplo, n, nrhs, A, lda, strideA, B, ldb,
                                          strideB, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sposv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sposv_strided_batched(handle::rocblas_handle,
                                                         uplo::rocblas_fill, n::rocblas_int,
                                                         nrhs::rocblas_int, A::Ptr{Cfloat},
                                                         lda::rocblas_int,
@@ -4315,7 +4313,7 @@ end
 function rocsolver_dposv_strided_batched(handle, uplo, n, nrhs, A, lda, strideA, B, ldb,
                                          strideB, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dposv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dposv_strided_batched(handle::rocblas_handle,
                                                         uplo::rocblas_fill, n::rocblas_int,
                                                         nrhs::rocblas_int, A::Ptr{Cdouble},
                                                         lda::rocblas_int,
@@ -4329,7 +4327,7 @@ end
 function rocsolver_cposv_strided_batched(handle, uplo, n, nrhs, A, lda, strideA, B, ldb,
                                          strideB, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cposv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cposv_strided_batched(handle::rocblas_handle,
                                                         uplo::rocblas_fill, n::rocblas_int,
                                                         nrhs::rocblas_int,
                                                         A::Ptr{rocblas_float_complex},
@@ -4345,7 +4343,7 @@ end
 function rocsolver_zposv_strided_batched(handle, uplo, n, nrhs, A, lda, strideA, B, ldb,
                                          strideB, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zposv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zposv_strided_batched(handle::rocblas_handle,
                                                         uplo::rocblas_fill, n::rocblas_int,
                                                         nrhs::rocblas_int,
                                                         A::Ptr{rocblas_double_complex},
@@ -4360,21 +4358,21 @@ end
 
 function rocsolver_spotri(handle, uplo, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_spotri(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_spotri(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
 end
 
 function rocsolver_dpotri(handle, uplo, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dpotri(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dpotri(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
 end
 
 function rocsolver_cpotri(handle, uplo, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cpotri(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_cpotri(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -4382,7 +4380,7 @@ end
 
 function rocsolver_zpotri(handle, uplo, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zpotri(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_zpotri(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -4390,7 +4388,7 @@ end
 
 function rocsolver_spotri_batched(handle, uplo, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_spotri_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_spotri_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                  lda::rocblas_int, info::Ptr{rocblas_int},
                                                  batch_count::rocblas_int)::rocblas_status
@@ -4398,7 +4396,7 @@ end
 
 function rocsolver_dpotri_batched(handle, uplo, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dpotri_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dpotri_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                  lda::rocblas_int, info::Ptr{rocblas_int},
                                                  batch_count::rocblas_int)::rocblas_status
@@ -4406,7 +4404,7 @@ end
 
 function rocsolver_cpotri_batched(handle, uplo, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cpotri_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_cpotri_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
                                                  lda::rocblas_int, info::Ptr{rocblas_int},
@@ -4415,7 +4413,7 @@ end
 
 function rocsolver_zpotri_batched(handle, uplo, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zpotri_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_zpotri_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
                                                  lda::rocblas_int, info::Ptr{rocblas_int},
@@ -4425,7 +4423,7 @@ end
 function rocsolver_spotri_strided_batched(handle, uplo, n, A, lda, strideA, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_spotri_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_spotri_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{Cfloat}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -4436,7 +4434,7 @@ end
 function rocsolver_dpotri_strided_batched(handle, uplo, n, A, lda, strideA, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dpotri_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dpotri_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{Cdouble}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -4447,7 +4445,7 @@ end
 function rocsolver_cpotri_strided_batched(handle, uplo, n, A, lda, strideA, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cpotri_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cpotri_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
                                                          lda::rocblas_int,
@@ -4459,7 +4457,7 @@ end
 function rocsolver_zpotri_strided_batched(handle, uplo, n, A, lda, strideA, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zpotri_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zpotri_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
                                                          lda::rocblas_int,
@@ -4471,7 +4469,7 @@ end
 function rocsolver_sgesvd(handle, left_svect, right_svect, m, n, A, lda, S, U, ldu, V, ldv,
                           E, fast_alg, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgesvd(handle::rocblas_handle, left_svect::rocblas_svect,
+    @check @ccall librocsolver.rocsolver_sgesvd(handle::rocblas_handle, left_svect::rocblas_svect,
                                          right_svect::rocblas_svect, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          S::Ptr{Cfloat}, U::Ptr{Cfloat}, ldu::rocblas_int,
@@ -4483,7 +4481,7 @@ end
 function rocsolver_dgesvd(handle, left_svect, right_svect, m, n, A, lda, S, U, ldu, V, ldv,
                           E, fast_alg, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgesvd(handle::rocblas_handle, left_svect::rocblas_svect,
+    @check @ccall librocsolver.rocsolver_dgesvd(handle::rocblas_handle, left_svect::rocblas_svect,
                                          right_svect::rocblas_svect, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          S::Ptr{Cdouble}, U::Ptr{Cdouble}, ldu::rocblas_int,
@@ -4495,7 +4493,7 @@ end
 function rocsolver_cgesvd(handle, left_svect, right_svect, m, n, A, lda, S, U, ldu, V, ldv,
                           E, fast_alg, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgesvd(handle::rocblas_handle, left_svect::rocblas_svect,
+    @check @ccall librocsolver.rocsolver_cgesvd(handle::rocblas_handle, left_svect::rocblas_svect,
                                          right_svect::rocblas_svect, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int, S::Ptr{Cfloat},
@@ -4508,7 +4506,7 @@ end
 function rocsolver_zgesvd(handle, left_svect, right_svect, m, n, A, lda, S, U, ldu, V, ldv,
                           E, fast_alg, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgesvd(handle::rocblas_handle, left_svect::rocblas_svect,
+    @check @ccall librocsolver.rocsolver_zgesvd(handle::rocblas_handle, left_svect::rocblas_svect,
                                          right_svect::rocblas_svect, m::rocblas_int,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int, S::Ptr{Cdouble},
@@ -4522,7 +4520,7 @@ function rocsolver_sgesvd_batched(handle, left_svect, right_svect, m, n, A, lda,
                                   U, ldu, strideU, V, ldv, strideV, E, strideE, fast_alg,
                                   info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgesvd_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgesvd_batched(handle::rocblas_handle,
                                                  left_svect::rocblas_svect,
                                                  right_svect::rocblas_svect, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
@@ -4541,7 +4539,7 @@ function rocsolver_dgesvd_batched(handle, left_svect, right_svect, m, n, A, lda,
                                   U, ldu, strideU, V, ldv, strideV, E, strideE, fast_alg,
                                   info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgesvd_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgesvd_batched(handle::rocblas_handle,
                                                  left_svect::rocblas_svect,
                                                  right_svect::rocblas_svect, m::rocblas_int,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
@@ -4560,7 +4558,7 @@ function rocsolver_cgesvd_batched(handle, left_svect, right_svect, m, n, A, lda,
                                   U, ldu, strideU, V, ldv, strideV, E, strideE, fast_alg,
                                   info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgesvd_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgesvd_batched(handle::rocblas_handle,
                                                  left_svect::rocblas_svect,
                                                  right_svect::rocblas_svect, m::rocblas_int,
                                                  n::rocblas_int,
@@ -4581,7 +4579,7 @@ function rocsolver_zgesvd_batched(handle, left_svect, right_svect, m, n, A, lda,
                                   U, ldu, strideU, V, ldv, strideV, E, strideE, fast_alg,
                                   info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgesvd_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgesvd_batched(handle::rocblas_handle,
                                                  left_svect::rocblas_svect,
                                                  right_svect::rocblas_svect, m::rocblas_int,
                                                  n::rocblas_int,
@@ -4602,7 +4600,7 @@ function rocsolver_sgesvd_strided_batched(handle, left_svect, right_svect, m, n,
                                           strideA, S, strideS, U, ldu, strideU, V, ldv,
                                           strideV, E, strideE, fast_alg, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgesvd_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgesvd_strided_batched(handle::rocblas_handle,
                                                          left_svect::rocblas_svect,
                                                          right_svect::rocblas_svect,
                                                          m::rocblas_int, n::rocblas_int,
@@ -4625,7 +4623,7 @@ function rocsolver_dgesvd_strided_batched(handle, left_svect, right_svect, m, n,
                                           strideA, S, strideS, U, ldu, strideU, V, ldv,
                                           strideV, E, strideE, fast_alg, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgesvd_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgesvd_strided_batched(handle::rocblas_handle,
                                                          left_svect::rocblas_svect,
                                                          right_svect::rocblas_svect,
                                                          m::rocblas_int, n::rocblas_int,
@@ -4648,7 +4646,7 @@ function rocsolver_cgesvd_strided_batched(handle, left_svect, right_svect, m, n,
                                           strideA, S, strideS, U, ldu, strideU, V, ldv,
                                           strideV, E, strideE, fast_alg, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgesvd_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgesvd_strided_batched(handle::rocblas_handle,
                                                          left_svect::rocblas_svect,
                                                          right_svect::rocblas_svect,
                                                          m::rocblas_int, n::rocblas_int,
@@ -4674,7 +4672,7 @@ function rocsolver_zgesvd_strided_batched(handle, left_svect, right_svect, m, n,
                                           strideA, S, strideS, U, ldu, strideU, V, ldv,
                                           strideV, E, strideE, fast_alg, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgesvd_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgesvd_strided_batched(handle::rocblas_handle,
                                                          left_svect::rocblas_svect,
                                                          right_svect::rocblas_svect,
                                                          m::rocblas_int, n::rocblas_int,
@@ -4699,7 +4697,7 @@ end
 function rocsolver_sgesvdj(handle, left_svect, right_svect, m, n, A, lda, abstol, residual,
                            max_sweeps, n_sweeps, S, U, ldu, V, ldv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgesvdj(handle::rocblas_handle, left_svect::rocblas_svect,
+    @check @ccall librocsolver.rocsolver_sgesvdj(handle::rocblas_handle, left_svect::rocblas_svect,
                                           right_svect::rocblas_svect, m::rocblas_int,
                                           n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                           abstol::Cfloat, residual::Ptr{Cfloat},
@@ -4713,7 +4711,7 @@ end
 function rocsolver_dgesvdj(handle, left_svect, right_svect, m, n, A, lda, abstol, residual,
                            max_sweeps, n_sweeps, S, U, ldu, V, ldv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgesvdj(handle::rocblas_handle, left_svect::rocblas_svect,
+    @check @ccall librocsolver.rocsolver_dgesvdj(handle::rocblas_handle, left_svect::rocblas_svect,
                                           right_svect::rocblas_svect, m::rocblas_int,
                                           n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                           abstol::Cdouble, residual::Ptr{Cdouble},
@@ -4727,7 +4725,7 @@ end
 function rocsolver_cgesvdj(handle, left_svect, right_svect, m, n, A, lda, abstol, residual,
                            max_sweeps, n_sweeps, S, U, ldu, V, ldv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgesvdj(handle::rocblas_handle, left_svect::rocblas_svect,
+    @check @ccall librocsolver.rocsolver_cgesvdj(handle::rocblas_handle, left_svect::rocblas_svect,
                                           right_svect::rocblas_svect, m::rocblas_int,
                                           n::rocblas_int, A::Ptr{rocblas_float_complex},
                                           lda::rocblas_int, abstol::Cfloat,
@@ -4741,7 +4739,7 @@ end
 function rocsolver_zgesvdj(handle, left_svect, right_svect, m, n, A, lda, abstol, residual,
                            max_sweeps, n_sweeps, S, U, ldu, V, ldv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgesvdj(handle::rocblas_handle, left_svect::rocblas_svect,
+    @check @ccall librocsolver.rocsolver_zgesvdj(handle::rocblas_handle, left_svect::rocblas_svect,
                                           right_svect::rocblas_svect, m::rocblas_int,
                                           n::rocblas_int, A::Ptr{rocblas_double_complex},
                                           lda::rocblas_int, abstol::Cdouble,
@@ -4756,7 +4754,7 @@ function rocsolver_sgesvdj_batched(handle, left_svect, right_svect, m, n, A, lda
                                    residual, max_sweeps, n_sweeps, S, strideS, U, ldu,
                                    strideU, V, ldv, strideV, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgesvdj_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgesvdj_batched(handle::rocblas_handle,
                                                   left_svect::rocblas_svect,
                                                   right_svect::rocblas_svect,
                                                   m::rocblas_int, n::rocblas_int,
@@ -4776,7 +4774,7 @@ function rocsolver_dgesvdj_batched(handle, left_svect, right_svect, m, n, A, lda
                                    residual, max_sweeps, n_sweeps, S, strideS, U, ldu,
                                    strideU, V, ldv, strideV, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgesvdj_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgesvdj_batched(handle::rocblas_handle,
                                                   left_svect::rocblas_svect,
                                                   right_svect::rocblas_svect,
                                                   m::rocblas_int, n::rocblas_int,
@@ -4796,7 +4794,7 @@ function rocsolver_cgesvdj_batched(handle, left_svect, right_svect, m, n, A, lda
                                    residual, max_sweeps, n_sweeps, S, strideS, U, ldu,
                                    strideU, V, ldv, strideV, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgesvdj_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgesvdj_batched(handle::rocblas_handle,
                                                   left_svect::rocblas_svect,
                                                   right_svect::rocblas_svect,
                                                   m::rocblas_int, n::rocblas_int,
@@ -4818,7 +4816,7 @@ function rocsolver_zgesvdj_batched(handle, left_svect, right_svect, m, n, A, lda
                                    residual, max_sweeps, n_sweeps, S, strideS, U, ldu,
                                    strideU, V, ldv, strideV, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgesvdj_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgesvdj_batched(handle::rocblas_handle,
                                                   left_svect::rocblas_svect,
                                                   right_svect::rocblas_svect,
                                                   m::rocblas_int, n::rocblas_int,
@@ -4841,7 +4839,7 @@ function rocsolver_sgesvdj_strided_batched(handle, left_svect, right_svect, m, n
                                            S, strideS, U, ldu, strideU, V, ldv, strideV,
                                            info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgesvdj_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgesvdj_strided_batched(handle::rocblas_handle,
                                                           left_svect::rocblas_svect,
                                                           right_svect::rocblas_svect,
                                                           m::rocblas_int, n::rocblas_int,
@@ -4866,7 +4864,7 @@ function rocsolver_dgesvdj_strided_batched(handle, left_svect, right_svect, m, n
                                            S, strideS, U, ldu, strideU, V, ldv, strideV,
                                            info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgesvdj_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgesvdj_strided_batched(handle::rocblas_handle,
                                                           left_svect::rocblas_svect,
                                                           right_svect::rocblas_svect,
                                                           m::rocblas_int, n::rocblas_int,
@@ -4891,7 +4889,7 @@ function rocsolver_cgesvdj_strided_batched(handle, left_svect, right_svect, m, n
                                            S, strideS, U, ldu, strideU, V, ldv, strideV,
                                            info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgesvdj_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgesvdj_strided_batched(handle::rocblas_handle,
                                                           left_svect::rocblas_svect,
                                                           right_svect::rocblas_svect,
                                                           m::rocblas_int, n::rocblas_int,
@@ -4919,7 +4917,7 @@ function rocsolver_zgesvdj_strided_batched(handle, left_svect, right_svect, m, n
                                            S, strideS, U, ldu, strideU, V, ldv, strideV,
                                            info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgesvdj_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgesvdj_strided_batched(handle::rocblas_handle,
                                                           left_svect::rocblas_svect,
                                                           right_svect::rocblas_svect,
                                                           m::rocblas_int, n::rocblas_int,
@@ -4945,7 +4943,7 @@ end
 function rocsolver_sgesvdx(handle, left_svect, right_svect, srange, m, n, A, lda, vl, vu,
                            il, iu, nsv, S, U, ldu, V, ldv, ifail, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgesvdx(handle::rocblas_handle, left_svect::rocblas_svect,
+    @check @ccall librocsolver.rocsolver_sgesvdx(handle::rocblas_handle, left_svect::rocblas_svect,
                                           right_svect::rocblas_svect,
                                           srange::rocblas_srange, m::rocblas_int,
                                           n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
@@ -4960,7 +4958,7 @@ end
 function rocsolver_dgesvdx(handle, left_svect, right_svect, srange, m, n, A, lda, vl, vu,
                            il, iu, nsv, S, U, ldu, V, ldv, ifail, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgesvdx(handle::rocblas_handle, left_svect::rocblas_svect,
+    @check @ccall librocsolver.rocsolver_dgesvdx(handle::rocblas_handle, left_svect::rocblas_svect,
                                           right_svect::rocblas_svect,
                                           srange::rocblas_srange, m::rocblas_int,
                                           n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
@@ -4975,7 +4973,7 @@ end
 function rocsolver_cgesvdx(handle, left_svect, right_svect, srange, m, n, A, lda, vl, vu,
                            il, iu, nsv, S, U, ldu, V, ldv, ifail, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgesvdx(handle::rocblas_handle, left_svect::rocblas_svect,
+    @check @ccall librocsolver.rocsolver_cgesvdx(handle::rocblas_handle, left_svect::rocblas_svect,
                                           right_svect::rocblas_svect,
                                           srange::rocblas_srange, m::rocblas_int,
                                           n::rocblas_int, A::Ptr{rocblas_float_complex},
@@ -4991,7 +4989,7 @@ end
 function rocsolver_zgesvdx(handle, left_svect, right_svect, srange, m, n, A, lda, vl, vu,
                            il, iu, nsv, S, U, ldu, V, ldv, ifail, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgesvdx(handle::rocblas_handle, left_svect::rocblas_svect,
+    @check @ccall librocsolver.rocsolver_zgesvdx(handle::rocblas_handle, left_svect::rocblas_svect,
                                           right_svect::rocblas_svect,
                                           srange::rocblas_srange, m::rocblas_int,
                                           n::rocblas_int, A::Ptr{rocblas_double_complex},
@@ -5008,7 +5006,7 @@ function rocsolver_sgesvdx_batched(handle, left_svect, right_svect, srange, m, n
                                    vl, vu, il, iu, nsv, S, strideS, U, ldu, strideU, V, ldv,
                                    strideV, ifail, strideF, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgesvdx_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgesvdx_batched(handle::rocblas_handle,
                                                   left_svect::rocblas_svect,
                                                   right_svect::rocblas_svect,
                                                   srange::rocblas_srange, m::rocblas_int,
@@ -5030,7 +5028,7 @@ function rocsolver_dgesvdx_batched(handle, left_svect, right_svect, srange, m, n
                                    vl, vu, il, iu, nsv, S, strideS, U, ldu, strideU, V, ldv,
                                    strideV, ifail, strideF, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgesvdx_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgesvdx_batched(handle::rocblas_handle,
                                                   left_svect::rocblas_svect,
                                                   right_svect::rocblas_svect,
                                                   srange::rocblas_srange, m::rocblas_int,
@@ -5052,7 +5050,7 @@ function rocsolver_cgesvdx_batched(handle, left_svect, right_svect, srange, m, n
                                    vl, vu, il, iu, nsv, S, strideS, U, ldu, strideU, V, ldv,
                                    strideV, ifail, strideF, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgesvdx_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgesvdx_batched(handle::rocblas_handle,
                                                   left_svect::rocblas_svect,
                                                   right_svect::rocblas_svect,
                                                   srange::rocblas_srange, m::rocblas_int,
@@ -5076,7 +5074,7 @@ function rocsolver_zgesvdx_batched(handle, left_svect, right_svect, srange, m, n
                                    vl, vu, il, iu, nsv, S, strideS, U, ldu, strideU, V, ldv,
                                    strideV, ifail, strideF, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgesvdx_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgesvdx_batched(handle::rocblas_handle,
                                                   left_svect::rocblas_svect,
                                                   right_svect::rocblas_svect,
                                                   srange::rocblas_srange, m::rocblas_int,
@@ -5101,7 +5099,7 @@ function rocsolver_sgesvdx_strided_batched(handle, left_svect, right_svect, sran
                                            ldu, strideU, V, ldv, strideV, ifail, strideF,
                                            info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgesvdx_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgesvdx_strided_batched(handle::rocblas_handle,
                                                           left_svect::rocblas_svect,
                                                           right_svect::rocblas_svect,
                                                           srange::rocblas_srange,
@@ -5128,7 +5126,7 @@ function rocsolver_dgesvdx_strided_batched(handle, left_svect, right_svect, sran
                                            ldu, strideU, V, ldv, strideV, ifail, strideF,
                                            info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgesvdx_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgesvdx_strided_batched(handle::rocblas_handle,
                                                           left_svect::rocblas_svect,
                                                           right_svect::rocblas_svect,
                                                           srange::rocblas_srange,
@@ -5155,7 +5153,7 @@ function rocsolver_cgesvdx_strided_batched(handle, left_svect, right_svect, sran
                                            ldu, strideU, V, ldv, strideV, ifail, strideF,
                                            info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgesvdx_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgesvdx_strided_batched(handle::rocblas_handle,
                                                           left_svect::rocblas_svect,
                                                           right_svect::rocblas_svect,
                                                           srange::rocblas_srange,
@@ -5185,7 +5183,7 @@ function rocsolver_zgesvdx_strided_batched(handle, left_svect, right_svect, sran
                                            ldu, strideU, V, ldv, strideV, ifail, strideF,
                                            info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgesvdx_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgesvdx_strided_batched(handle::rocblas_handle,
                                                           left_svect::rocblas_svect,
                                                           right_svect::rocblas_svect,
                                                           srange::rocblas_srange,
@@ -5212,7 +5210,7 @@ end
 
 function rocsolver_ssytd2(handle, uplo, n, A, lda, D, E, tau)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssytd2(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_ssytd2(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          D::Ptr{Cfloat}, E::Ptr{Cfloat},
                                          tau::Ptr{Cfloat})::rocblas_status
@@ -5220,7 +5218,7 @@ end
 
 function rocsolver_dsytd2(handle, uplo, n, A, lda, D, E, tau)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsytd2(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dsytd2(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          D::Ptr{Cdouble}, E::Ptr{Cdouble},
                                          tau::Ptr{Cdouble})::rocblas_status
@@ -5228,7 +5226,7 @@ end
 
 function rocsolver_chetd2(handle, uplo, n, A, lda, D, E, tau)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chetd2(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_chetd2(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int, D::Ptr{Cfloat}, E::Ptr{Cfloat},
                                          tau::Ptr{rocblas_float_complex})::rocblas_status
@@ -5236,7 +5234,7 @@ end
 
 function rocsolver_zhetd2(handle, uplo, n, A, lda, D, E, tau)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhetd2(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_zhetd2(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int, D::Ptr{Cdouble}, E::Ptr{Cdouble},
                                          tau::Ptr{rocblas_double_complex})::rocblas_status
@@ -5245,7 +5243,7 @@ end
 function rocsolver_ssytd2_batched(handle, uplo, n, A, lda, D, strideD, E, strideE, tau,
                                   strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssytd2_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_ssytd2_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                  lda::rocblas_int, D::Ptr{Cfloat},
                                                  strideD::rocblas_stride, E::Ptr{Cfloat},
@@ -5257,7 +5255,7 @@ end
 function rocsolver_dsytd2_batched(handle, uplo, n, A, lda, D, strideD, E, strideE, tau,
                                   strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsytd2_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dsytd2_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                  lda::rocblas_int, D::Ptr{Cdouble},
                                                  strideD::rocblas_stride, E::Ptr{Cdouble},
@@ -5269,7 +5267,7 @@ end
 function rocsolver_chetd2_batched(handle, uplo, n, A, lda, D, strideD, E, strideE, tau,
                                   strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chetd2_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_chetd2_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
                                                  lda::rocblas_int, D::Ptr{Cfloat},
@@ -5283,7 +5281,7 @@ end
 function rocsolver_zhetd2_batched(handle, uplo, n, A, lda, D, strideD, E, strideE, tau,
                                   strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhetd2_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_zhetd2_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
                                                  lda::rocblas_int, D::Ptr{Cdouble},
@@ -5297,7 +5295,7 @@ end
 function rocsolver_ssytd2_strided_batched(handle, uplo, n, A, lda, strideA, D, strideD, E,
                                           strideE, tau, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssytd2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssytd2_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{Cfloat}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -5313,7 +5311,7 @@ end
 function rocsolver_dsytd2_strided_batched(handle, uplo, n, A, lda, strideA, D, strideD, E,
                                           strideE, tau, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsytd2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsytd2_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{Cdouble}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -5329,7 +5327,7 @@ end
 function rocsolver_chetd2_strided_batched(handle, uplo, n, A, lda, strideA, D, strideD, E,
                                           strideE, tau, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chetd2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_chetd2_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
                                                          lda::rocblas_int,
@@ -5346,7 +5344,7 @@ end
 function rocsolver_zhetd2_strided_batched(handle, uplo, n, A, lda, strideA, D, strideD, E,
                                           strideE, tau, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhetd2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zhetd2_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
                                                          lda::rocblas_int,
@@ -5362,7 +5360,7 @@ end
 
 function rocsolver_ssytrd(handle, uplo, n, A, lda, D, E, tau)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssytrd(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_ssytrd(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          D::Ptr{Cfloat}, E::Ptr{Cfloat},
                                          tau::Ptr{Cfloat})::rocblas_status
@@ -5370,7 +5368,7 @@ end
 
 function rocsolver_dsytrd(handle, uplo, n, A, lda, D, E, tau)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsytrd(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dsytrd(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          D::Ptr{Cdouble}, E::Ptr{Cdouble},
                                          tau::Ptr{Cdouble})::rocblas_status
@@ -5378,7 +5376,7 @@ end
 
 function rocsolver_chetrd(handle, uplo, n, A, lda, D, E, tau)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chetrd(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_chetrd(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int, D::Ptr{Cfloat}, E::Ptr{Cfloat},
                                          tau::Ptr{rocblas_float_complex})::rocblas_status
@@ -5386,7 +5384,7 @@ end
 
 function rocsolver_zhetrd(handle, uplo, n, A, lda, D, E, tau)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhetrd(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_zhetrd(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int, D::Ptr{Cdouble}, E::Ptr{Cdouble},
                                          tau::Ptr{rocblas_double_complex})::rocblas_status
@@ -5395,7 +5393,7 @@ end
 function rocsolver_ssytrd_batched(handle, uplo, n, A, lda, D, strideD, E, strideE, tau,
                                   strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssytrd_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_ssytrd_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                  lda::rocblas_int, D::Ptr{Cfloat},
                                                  strideD::rocblas_stride, E::Ptr{Cfloat},
@@ -5407,7 +5405,7 @@ end
 function rocsolver_dsytrd_batched(handle, uplo, n, A, lda, D, strideD, E, strideE, tau,
                                   strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsytrd_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dsytrd_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                  lda::rocblas_int, D::Ptr{Cdouble},
                                                  strideD::rocblas_stride, E::Ptr{Cdouble},
@@ -5419,7 +5417,7 @@ end
 function rocsolver_chetrd_batched(handle, uplo, n, A, lda, D, strideD, E, strideE, tau,
                                   strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chetrd_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_chetrd_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
                                                  lda::rocblas_int, D::Ptr{Cfloat},
@@ -5433,7 +5431,7 @@ end
 function rocsolver_zhetrd_batched(handle, uplo, n, A, lda, D, strideD, E, strideE, tau,
                                   strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhetrd_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_zhetrd_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
                                                  lda::rocblas_int, D::Ptr{Cdouble},
@@ -5447,7 +5445,7 @@ end
 function rocsolver_ssytrd_strided_batched(handle, uplo, n, A, lda, strideA, D, strideD, E,
                                           strideE, tau, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssytrd_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssytrd_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{Cfloat}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -5463,7 +5461,7 @@ end
 function rocsolver_dsytrd_strided_batched(handle, uplo, n, A, lda, strideA, D, strideD, E,
                                           strideE, tau, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsytrd_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsytrd_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{Cdouble}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -5479,7 +5477,7 @@ end
 function rocsolver_chetrd_strided_batched(handle, uplo, n, A, lda, strideA, D, strideD, E,
                                           strideE, tau, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chetrd_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_chetrd_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
                                                          lda::rocblas_int,
@@ -5496,7 +5494,7 @@ end
 function rocsolver_zhetrd_strided_batched(handle, uplo, n, A, lda, strideA, D, strideD, E,
                                           strideE, tau, strideP, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhetrd_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zhetrd_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
                                                          lda::rocblas_int,
@@ -5512,7 +5510,7 @@ end
 
 function rocsolver_ssygs2(handle, itype, uplo, n, A, lda, B, ldb)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssygs2(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_ssygs2(handle::rocblas_handle, itype::rocblas_eform,
                                          uplo::rocblas_fill, n::rocblas_int, A::Ptr{Cfloat},
                                          lda::rocblas_int, B::Ptr{Cfloat},
                                          ldb::rocblas_int)::rocblas_status
@@ -5520,7 +5518,7 @@ end
 
 function rocsolver_dsygs2(handle, itype, uplo, n, A, lda, B, ldb)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsygs2(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_dsygs2(handle::rocblas_handle, itype::rocblas_eform,
                                          uplo::rocblas_fill, n::rocblas_int,
                                          A::Ptr{Cdouble}, lda::rocblas_int, B::Ptr{Cdouble},
                                          ldb::rocblas_int)::rocblas_status
@@ -5528,7 +5526,7 @@ end
 
 function rocsolver_chegs2(handle, itype, uplo, n, A, lda, B, ldb)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chegs2(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_chegs2(handle::rocblas_handle, itype::rocblas_eform,
                                          uplo::rocblas_fill, n::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                          B::Ptr{rocblas_float_complex},
@@ -5537,7 +5535,7 @@ end
 
 function rocsolver_zhegs2(handle, itype, uplo, n, A, lda, B, ldb)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhegs2(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_zhegs2(handle::rocblas_handle, itype::rocblas_eform,
                                          uplo::rocblas_fill, n::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                          B::Ptr{rocblas_double_complex},
@@ -5546,7 +5544,7 @@ end
 
 function rocsolver_ssygs2_batched(handle, itype, uplo, n, A, lda, B, ldb, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssygs2_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssygs2_batched(handle::rocblas_handle,
                                                  itype::rocblas_eform, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                  lda::rocblas_int, B::Ptr{Ptr{Cfloat}},
@@ -5556,7 +5554,7 @@ end
 
 function rocsolver_dsygs2_batched(handle, itype, uplo, n, A, lda, B, ldb, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsygs2_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsygs2_batched(handle::rocblas_handle,
                                                  itype::rocblas_eform, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                  lda::rocblas_int, B::Ptr{Ptr{Cdouble}},
@@ -5566,7 +5564,7 @@ end
 
 function rocsolver_chegs2_batched(handle, itype, uplo, n, A, lda, B, ldb, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chegs2_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_chegs2_batched(handle::rocblas_handle,
                                                  itype::rocblas_eform, uplo::rocblas_fill,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
@@ -5578,7 +5576,7 @@ end
 
 function rocsolver_zhegs2_batched(handle, itype, uplo, n, A, lda, B, ldb, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhegs2_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zhegs2_batched(handle::rocblas_handle,
                                                  itype::rocblas_eform, uplo::rocblas_fill,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
@@ -5591,7 +5589,7 @@ end
 function rocsolver_ssygs2_strided_batched(handle, itype, uplo, n, A, lda, strideA, B, ldb,
                                           strideB, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssygs2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssygs2_strided_batched(handle::rocblas_handle,
                                                          itype::rocblas_eform,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{Cfloat}, lda::rocblas_int,
@@ -5604,7 +5602,7 @@ end
 function rocsolver_dsygs2_strided_batched(handle, itype, uplo, n, A, lda, strideA, B, ldb,
                                           strideB, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsygs2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsygs2_strided_batched(handle::rocblas_handle,
                                                          itype::rocblas_eform,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{Cdouble}, lda::rocblas_int,
@@ -5617,7 +5615,7 @@ end
 function rocsolver_chegs2_strided_batched(handle, itype, uplo, n, A, lda, strideA, B, ldb,
                                           strideB, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chegs2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_chegs2_strided_batched(handle::rocblas_handle,
                                                          itype::rocblas_eform,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
@@ -5632,7 +5630,7 @@ end
 function rocsolver_zhegs2_strided_batched(handle, itype, uplo, n, A, lda, strideA, B, ldb,
                                           strideB, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhegs2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zhegs2_strided_batched(handle::rocblas_handle,
                                                          itype::rocblas_eform,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
@@ -5646,7 +5644,7 @@ end
 
 function rocsolver_ssygst(handle, itype, uplo, n, A, lda, B, ldb)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssygst(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_ssygst(handle::rocblas_handle, itype::rocblas_eform,
                                          uplo::rocblas_fill, n::rocblas_int, A::Ptr{Cfloat},
                                          lda::rocblas_int, B::Ptr{Cfloat},
                                          ldb::rocblas_int)::rocblas_status
@@ -5654,7 +5652,7 @@ end
 
 function rocsolver_dsygst(handle, itype, uplo, n, A, lda, B, ldb)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsygst(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_dsygst(handle::rocblas_handle, itype::rocblas_eform,
                                          uplo::rocblas_fill, n::rocblas_int,
                                          A::Ptr{Cdouble}, lda::rocblas_int, B::Ptr{Cdouble},
                                          ldb::rocblas_int)::rocblas_status
@@ -5662,7 +5660,7 @@ end
 
 function rocsolver_chegst(handle, itype, uplo, n, A, lda, B, ldb)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chegst(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_chegst(handle::rocblas_handle, itype::rocblas_eform,
                                          uplo::rocblas_fill, n::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                          B::Ptr{rocblas_float_complex},
@@ -5671,7 +5669,7 @@ end
 
 function rocsolver_zhegst(handle, itype, uplo, n, A, lda, B, ldb)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhegst(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_zhegst(handle::rocblas_handle, itype::rocblas_eform,
                                          uplo::rocblas_fill, n::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                          B::Ptr{rocblas_double_complex},
@@ -5680,7 +5678,7 @@ end
 
 function rocsolver_ssygst_batched(handle, itype, uplo, n, A, lda, B, ldb, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssygst_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssygst_batched(handle::rocblas_handle,
                                                  itype::rocblas_eform, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                  lda::rocblas_int, B::Ptr{Ptr{Cfloat}},
@@ -5690,7 +5688,7 @@ end
 
 function rocsolver_dsygst_batched(handle, itype, uplo, n, A, lda, B, ldb, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsygst_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsygst_batched(handle::rocblas_handle,
                                                  itype::rocblas_eform, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                  lda::rocblas_int, B::Ptr{Ptr{Cdouble}},
@@ -5700,7 +5698,7 @@ end
 
 function rocsolver_chegst_batched(handle, itype, uplo, n, A, lda, B, ldb, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chegst_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_chegst_batched(handle::rocblas_handle,
                                                  itype::rocblas_eform, uplo::rocblas_fill,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
@@ -5712,7 +5710,7 @@ end
 
 function rocsolver_zhegst_batched(handle, itype, uplo, n, A, lda, B, ldb, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhegst_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zhegst_batched(handle::rocblas_handle,
                                                  itype::rocblas_eform, uplo::rocblas_fill,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
@@ -5725,7 +5723,7 @@ end
 function rocsolver_ssygst_strided_batched(handle, itype, uplo, n, A, lda, strideA, B, ldb,
                                           strideB, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssygst_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssygst_strided_batched(handle::rocblas_handle,
                                                          itype::rocblas_eform,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{Cfloat}, lda::rocblas_int,
@@ -5738,7 +5736,7 @@ end
 function rocsolver_dsygst_strided_batched(handle, itype, uplo, n, A, lda, strideA, B, ldb,
                                           strideB, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsygst_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsygst_strided_batched(handle::rocblas_handle,
                                                          itype::rocblas_eform,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{Cdouble}, lda::rocblas_int,
@@ -5751,7 +5749,7 @@ end
 function rocsolver_chegst_strided_batched(handle, itype, uplo, n, A, lda, strideA, B, ldb,
                                           strideB, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chegst_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_chegst_strided_batched(handle::rocblas_handle,
                                                          itype::rocblas_eform,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
@@ -5766,7 +5764,7 @@ end
 function rocsolver_zhegst_strided_batched(handle, itype, uplo, n, A, lda, strideA, B, ldb,
                                           strideB, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhegst_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zhegst_strided_batched(handle::rocblas_handle,
                                                          itype::rocblas_eform,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
@@ -5780,7 +5778,7 @@ end
 
 function rocsolver_ssyev(handle, evect, uplo, n, A, lda, D, E, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssyev(handle::rocblas_handle, evect::rocblas_evect,
+    @check @ccall librocsolver.rocsolver_ssyev(handle::rocblas_handle, evect::rocblas_evect,
                                         uplo::rocblas_fill, n::rocblas_int, A::Ptr{Cfloat},
                                         lda::rocblas_int, D::Ptr{Cfloat}, E::Ptr{Cfloat},
                                         info::Ptr{rocblas_int})::rocblas_status
@@ -5788,7 +5786,7 @@ end
 
 function rocsolver_dsyev(handle, evect, uplo, n, A, lda, D, E, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsyev(handle::rocblas_handle, evect::rocblas_evect,
+    @check @ccall librocsolver.rocsolver_dsyev(handle::rocblas_handle, evect::rocblas_evect,
                                         uplo::rocblas_fill, n::rocblas_int, A::Ptr{Cdouble},
                                         lda::rocblas_int, D::Ptr{Cdouble}, E::Ptr{Cdouble},
                                         info::Ptr{rocblas_int})::rocblas_status
@@ -5796,7 +5794,7 @@ end
 
 function rocsolver_cheev(handle, evect, uplo, n, A, lda, D, E, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cheev(handle::rocblas_handle, evect::rocblas_evect,
+    @check @ccall librocsolver.rocsolver_cheev(handle::rocblas_handle, evect::rocblas_evect,
                                         uplo::rocblas_fill, n::rocblas_int,
                                         A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                         D::Ptr{Cfloat}, E::Ptr{Cfloat},
@@ -5805,7 +5803,7 @@ end
 
 function rocsolver_zheev(handle, evect, uplo, n, A, lda, D, E, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zheev(handle::rocblas_handle, evect::rocblas_evect,
+    @check @ccall librocsolver.rocsolver_zheev(handle::rocblas_handle, evect::rocblas_evect,
                                         uplo::rocblas_fill, n::rocblas_int,
                                         A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                         D::Ptr{Cdouble}, E::Ptr{Cdouble},
@@ -5815,7 +5813,7 @@ end
 function rocsolver_ssyev_batched(handle, evect, uplo, n, A, lda, D, strideD, E, strideE,
                                  info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssyev_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssyev_batched(handle::rocblas_handle,
                                                 evect::rocblas_evect, uplo::rocblas_fill,
                                                 n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                 lda::rocblas_int, D::Ptr{Cfloat},
@@ -5828,7 +5826,7 @@ end
 function rocsolver_dsyev_batched(handle, evect, uplo, n, A, lda, D, strideD, E, strideE,
                                  info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsyev_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsyev_batched(handle::rocblas_handle,
                                                 evect::rocblas_evect, uplo::rocblas_fill,
                                                 n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                 lda::rocblas_int, D::Ptr{Cdouble},
@@ -5841,7 +5839,7 @@ end
 function rocsolver_cheev_batched(handle, evect, uplo, n, A, lda, D, strideD, E, strideE,
                                  info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cheev_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cheev_batched(handle::rocblas_handle,
                                                 evect::rocblas_evect, uplo::rocblas_fill,
                                                 n::rocblas_int,
                                                 A::Ptr{Ptr{rocblas_float_complex}},
@@ -5855,7 +5853,7 @@ end
 function rocsolver_zheev_batched(handle, evect, uplo, n, A, lda, D, strideD, E, strideE,
                                  info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zheev_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zheev_batched(handle::rocblas_handle,
                                                 evect::rocblas_evect, uplo::rocblas_fill,
                                                 n::rocblas_int,
                                                 A::Ptr{Ptr{rocblas_double_complex}},
@@ -5869,7 +5867,7 @@ end
 function rocsolver_ssyev_strided_batched(handle, evect, uplo, n, A, lda, strideA, D,
                                          strideD, E, strideE, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssyev_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssyev_strided_batched(handle::rocblas_handle,
                                                         evect::rocblas_evect,
                                                         uplo::rocblas_fill, n::rocblas_int,
                                                         A::Ptr{Cfloat}, lda::rocblas_int,
@@ -5885,7 +5883,7 @@ end
 function rocsolver_dsyev_strided_batched(handle, evect, uplo, n, A, lda, strideA, D,
                                          strideD, E, strideE, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsyev_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsyev_strided_batched(handle::rocblas_handle,
                                                         evect::rocblas_evect,
                                                         uplo::rocblas_fill, n::rocblas_int,
                                                         A::Ptr{Cdouble}, lda::rocblas_int,
@@ -5901,7 +5899,7 @@ end
 function rocsolver_cheev_strided_batched(handle, evect, uplo, n, A, lda, strideA, D,
                                          strideD, E, strideE, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cheev_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cheev_strided_batched(handle::rocblas_handle,
                                                         evect::rocblas_evect,
                                                         uplo::rocblas_fill, n::rocblas_int,
                                                         A::Ptr{rocblas_float_complex},
@@ -5918,7 +5916,7 @@ end
 function rocsolver_zheev_strided_batched(handle, evect, uplo, n, A, lda, strideA, D,
                                          strideD, E, strideE, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zheev_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zheev_strided_batched(handle::rocblas_handle,
                                                         evect::rocblas_evect,
                                                         uplo::rocblas_fill, n::rocblas_int,
                                                         A::Ptr{rocblas_double_complex},
@@ -5934,7 +5932,7 @@ end
 
 function rocsolver_ssyevd(handle, evect, uplo, n, A, lda, D, E, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssyevd(handle::rocblas_handle, evect::rocblas_evect,
+    @check @ccall librocsolver.rocsolver_ssyevd(handle::rocblas_handle, evect::rocblas_evect,
                                          uplo::rocblas_fill, n::rocblas_int, A::Ptr{Cfloat},
                                          lda::rocblas_int, D::Ptr{Cfloat}, E::Ptr{Cfloat},
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -5942,7 +5940,7 @@ end
 
 function rocsolver_dsyevd(handle, evect, uplo, n, A, lda, D, E, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsyevd(handle::rocblas_handle, evect::rocblas_evect,
+    @check @ccall librocsolver.rocsolver_dsyevd(handle::rocblas_handle, evect::rocblas_evect,
                                          uplo::rocblas_fill, n::rocblas_int,
                                          A::Ptr{Cdouble}, lda::rocblas_int, D::Ptr{Cdouble},
                                          E::Ptr{Cdouble},
@@ -5951,7 +5949,7 @@ end
 
 function rocsolver_cheevd(handle, evect, uplo, n, A, lda, D, E, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cheevd(handle::rocblas_handle, evect::rocblas_evect,
+    @check @ccall librocsolver.rocsolver_cheevd(handle::rocblas_handle, evect::rocblas_evect,
                                          uplo::rocblas_fill, n::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                          D::Ptr{Cfloat}, E::Ptr{Cfloat},
@@ -5960,7 +5958,7 @@ end
 
 function rocsolver_zheevd(handle, evect, uplo, n, A, lda, D, E, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zheevd(handle::rocblas_handle, evect::rocblas_evect,
+    @check @ccall librocsolver.rocsolver_zheevd(handle::rocblas_handle, evect::rocblas_evect,
                                          uplo::rocblas_fill, n::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                          D::Ptr{Cdouble}, E::Ptr{Cdouble},
@@ -5970,7 +5968,7 @@ end
 function rocsolver_ssyevd_batched(handle, evect, uplo, n, A, lda, D, strideD, E, strideE,
                                   info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssyevd_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssyevd_batched(handle::rocblas_handle,
                                                  evect::rocblas_evect, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                  lda::rocblas_int, D::Ptr{Cfloat},
@@ -5983,7 +5981,7 @@ end
 function rocsolver_dsyevd_batched(handle, evect, uplo, n, A, lda, D, strideD, E, strideE,
                                   info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsyevd_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsyevd_batched(handle::rocblas_handle,
                                                  evect::rocblas_evect, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                  lda::rocblas_int, D::Ptr{Cdouble},
@@ -5996,7 +5994,7 @@ end
 function rocsolver_cheevd_batched(handle, evect, uplo, n, A, lda, D, strideD, E, strideE,
                                   info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cheevd_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cheevd_batched(handle::rocblas_handle,
                                                  evect::rocblas_evect, uplo::rocblas_fill,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
@@ -6010,7 +6008,7 @@ end
 function rocsolver_zheevd_batched(handle, evect, uplo, n, A, lda, D, strideD, E, strideE,
                                   info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zheevd_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zheevd_batched(handle::rocblas_handle,
                                                  evect::rocblas_evect, uplo::rocblas_fill,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
@@ -6024,7 +6022,7 @@ end
 function rocsolver_ssyevd_strided_batched(handle, evect, uplo, n, A, lda, strideA, D,
                                           strideD, E, strideE, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssyevd_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssyevd_strided_batched(handle::rocblas_handle,
                                                          evect::rocblas_evect,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{Cfloat}, lda::rocblas_int,
@@ -6040,7 +6038,7 @@ end
 function rocsolver_dsyevd_strided_batched(handle, evect, uplo, n, A, lda, strideA, D,
                                           strideD, E, strideE, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsyevd_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsyevd_strided_batched(handle::rocblas_handle,
                                                          evect::rocblas_evect,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{Cdouble}, lda::rocblas_int,
@@ -6056,7 +6054,7 @@ end
 function rocsolver_cheevd_strided_batched(handle, evect, uplo, n, A, lda, strideA, D,
                                           strideD, E, strideE, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cheevd_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cheevd_strided_batched(handle::rocblas_handle,
                                                          evect::rocblas_evect,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
@@ -6073,7 +6071,7 @@ end
 function rocsolver_zheevd_strided_batched(handle, evect, uplo, n, A, lda, strideA, D,
                                           strideD, E, strideE, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zheevd_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zheevd_strided_batched(handle::rocblas_handle,
                                                          evect::rocblas_evect,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
@@ -6090,7 +6088,7 @@ end
 function rocsolver_ssyevj(handle, esort, evect, uplo, n, A, lda, abstol, residual,
                           max_sweeps, n_sweeps, W, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssyevj(handle::rocblas_handle, esort::rocblas_esort,
+    @check @ccall librocsolver.rocsolver_ssyevj(handle::rocblas_handle, esort::rocblas_esort,
                                          evect::rocblas_evect, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          abstol::Cfloat, residual::Ptr{Cfloat},
@@ -6102,7 +6100,7 @@ end
 function rocsolver_dsyevj(handle, esort, evect, uplo, n, A, lda, abstol, residual,
                           max_sweeps, n_sweeps, W, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsyevj(handle::rocblas_handle, esort::rocblas_esort,
+    @check @ccall librocsolver.rocsolver_dsyevj(handle::rocblas_handle, esort::rocblas_esort,
                                          evect::rocblas_evect, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          abstol::Cdouble, residual::Ptr{Cdouble},
@@ -6114,7 +6112,7 @@ end
 function rocsolver_cheevj(handle, esort, evect, uplo, n, A, lda, abstol, residual,
                           max_sweeps, n_sweeps, W, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cheevj(handle::rocblas_handle, esort::rocblas_esort,
+    @check @ccall librocsolver.rocsolver_cheevj(handle::rocblas_handle, esort::rocblas_esort,
                                          evect::rocblas_evect, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int, abstol::Cfloat,
@@ -6126,7 +6124,7 @@ end
 function rocsolver_zheevj(handle, esort, evect, uplo, n, A, lda, abstol, residual,
                           max_sweeps, n_sweeps, W, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zheevj(handle::rocblas_handle, esort::rocblas_esort,
+    @check @ccall librocsolver.rocsolver_zheevj(handle::rocblas_handle, esort::rocblas_esort,
                                          evect::rocblas_evect, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int, abstol::Cdouble,
@@ -6138,7 +6136,7 @@ end
 function rocsolver_ssyevj_batched(handle, esort, evect, uplo, n, A, lda, abstol, residual,
                                   max_sweeps, n_sweeps, W, strideW, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssyevj_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssyevj_batched(handle::rocblas_handle,
                                                  esort::rocblas_esort, evect::rocblas_evect,
                                                  uplo::rocblas_fill, n::rocblas_int,
                                                  A::Ptr{Ptr{Cfloat}}, lda::rocblas_int,
@@ -6153,7 +6151,7 @@ end
 function rocsolver_dsyevj_batched(handle, esort, evect, uplo, n, A, lda, abstol, residual,
                                   max_sweeps, n_sweeps, W, strideW, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsyevj_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsyevj_batched(handle::rocblas_handle,
                                                  esort::rocblas_esort, evect::rocblas_evect,
                                                  uplo::rocblas_fill, n::rocblas_int,
                                                  A::Ptr{Ptr{Cdouble}}, lda::rocblas_int,
@@ -6168,7 +6166,7 @@ end
 function rocsolver_cheevj_batched(handle, esort, evect, uplo, n, A, lda, abstol, residual,
                                   max_sweeps, n_sweeps, W, strideW, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cheevj_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cheevj_batched(handle::rocblas_handle,
                                                  esort::rocblas_esort, evect::rocblas_evect,
                                                  uplo::rocblas_fill, n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
@@ -6184,7 +6182,7 @@ end
 function rocsolver_zheevj_batched(handle, esort, evect, uplo, n, A, lda, abstol, residual,
                                   max_sweeps, n_sweeps, W, strideW, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zheevj_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zheevj_batched(handle::rocblas_handle,
                                                  esort::rocblas_esort, evect::rocblas_evect,
                                                  uplo::rocblas_fill, n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
@@ -6201,7 +6199,7 @@ function rocsolver_ssyevj_strided_batched(handle, esort, evect, uplo, n, A, lda,
                                           abstol, residual, max_sweeps, n_sweeps, W,
                                           strideW, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssyevj_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssyevj_strided_batched(handle::rocblas_handle,
                                                          esort::rocblas_esort,
                                                          evect::rocblas_evect,
                                                          uplo::rocblas_fill, n::rocblas_int,
@@ -6221,7 +6219,7 @@ function rocsolver_dsyevj_strided_batched(handle, esort, evect, uplo, n, A, lda,
                                           abstol, residual, max_sweeps, n_sweeps, W,
                                           strideW, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsyevj_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsyevj_strided_batched(handle::rocblas_handle,
                                                          esort::rocblas_esort,
                                                          evect::rocblas_evect,
                                                          uplo::rocblas_fill, n::rocblas_int,
@@ -6241,7 +6239,7 @@ function rocsolver_cheevj_strided_batched(handle, esort, evect, uplo, n, A, lda,
                                           abstol, residual, max_sweeps, n_sweeps, W,
                                           strideW, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cheevj_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cheevj_strided_batched(handle::rocblas_handle,
                                                          esort::rocblas_esort,
                                                          evect::rocblas_evect,
                                                          uplo::rocblas_fill, n::rocblas_int,
@@ -6262,7 +6260,7 @@ function rocsolver_zheevj_strided_batched(handle, esort, evect, uplo, n, A, lda,
                                           abstol, residual, max_sweeps, n_sweeps, W,
                                           strideW, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zheevj_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zheevj_strided_batched(handle::rocblas_handle,
                                                          esort::rocblas_esort,
                                                          evect::rocblas_evect,
                                                          uplo::rocblas_fill, n::rocblas_int,
@@ -6282,7 +6280,7 @@ end
 function rocsolver_ssyevx(handle, evect, erange, uplo, n, A, lda, vl, vu, il, iu, abstol,
                           nev, W, Z, ldz, ifail, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssyevx(handle::rocblas_handle, evect::rocblas_evect,
+    @check @ccall librocsolver.rocsolver_ssyevx(handle::rocblas_handle, evect::rocblas_evect,
                                          erange::rocblas_erange, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          vl::Cfloat, vu::Cfloat, il::rocblas_int,
@@ -6296,7 +6294,7 @@ end
 function rocsolver_dsyevx(handle, evect, erange, uplo, n, A, lda, vl, vu, il, iu, abstol,
                           nev, W, Z, ldz, ifail, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsyevx(handle::rocblas_handle, evect::rocblas_evect,
+    @check @ccall librocsolver.rocsolver_dsyevx(handle::rocblas_handle, evect::rocblas_evect,
                                          erange::rocblas_erange, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          vl::Cdouble, vu::Cdouble, il::rocblas_int,
@@ -6310,7 +6308,7 @@ end
 function rocsolver_cheevx(handle, evect, erange, uplo, n, A, lda, vl, vu, il, iu, abstol,
                           nev, W, Z, ldz, ifail, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cheevx(handle::rocblas_handle, evect::rocblas_evect,
+    @check @ccall librocsolver.rocsolver_cheevx(handle::rocblas_handle, evect::rocblas_evect,
                                          erange::rocblas_erange, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int, vl::Cfloat, vu::Cfloat,
@@ -6324,7 +6322,7 @@ end
 function rocsolver_zheevx(handle, evect, erange, uplo, n, A, lda, vl, vu, il, iu, abstol,
                           nev, W, Z, ldz, ifail, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zheevx(handle::rocblas_handle, evect::rocblas_evect,
+    @check @ccall librocsolver.rocsolver_zheevx(handle::rocblas_handle, evect::rocblas_evect,
                                          erange::rocblas_erange, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int, vl::Cdouble, vu::Cdouble,
@@ -6339,7 +6337,7 @@ function rocsolver_ssyevx_batched(handle, evect, erange, uplo, n, A, lda, vl, vu
                                   abstol, nev, W, strideW, Z, ldz, ifail, strideF, info,
                                   batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssyevx_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssyevx_batched(handle::rocblas_handle,
                                                  evect::rocblas_evect,
                                                  erange::rocblas_erange, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
@@ -6358,7 +6356,7 @@ function rocsolver_dsyevx_batched(handle, evect, erange, uplo, n, A, lda, vl, vu
                                   abstol, nev, W, strideW, Z, ldz, ifail, strideF, info,
                                   batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsyevx_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsyevx_batched(handle::rocblas_handle,
                                                  evect::rocblas_evect,
                                                  erange::rocblas_erange, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
@@ -6377,7 +6375,7 @@ function rocsolver_cheevx_batched(handle, evect, erange, uplo, n, A, lda, vl, vu
                                   abstol, nev, W, strideW, Z, ldz, ifail, strideF, info,
                                   batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cheevx_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cheevx_batched(handle::rocblas_handle,
                                                  evect::rocblas_evect,
                                                  erange::rocblas_erange, uplo::rocblas_fill,
                                                  n::rocblas_int,
@@ -6397,7 +6395,7 @@ function rocsolver_zheevx_batched(handle, evect, erange, uplo, n, A, lda, vl, vu
                                   abstol, nev, W, strideW, Z, ldz, ifail, strideF, info,
                                   batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zheevx_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zheevx_batched(handle::rocblas_handle,
                                                  evect::rocblas_evect,
                                                  erange::rocblas_erange, uplo::rocblas_fill,
                                                  n::rocblas_int,
@@ -6417,7 +6415,7 @@ function rocsolver_ssyevx_strided_batched(handle, evect, erange, uplo, n, A, lda
                                           vl, vu, il, iu, abstol, nev, W, strideW, Z, ldz,
                                           strideZ, ifail, strideF, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssyevx_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssyevx_strided_batched(handle::rocblas_handle,
                                                          evect::rocblas_evect,
                                                          erange::rocblas_erange,
                                                          uplo::rocblas_fill, n::rocblas_int,
@@ -6441,7 +6439,7 @@ function rocsolver_dsyevx_strided_batched(handle, evect, erange, uplo, n, A, lda
                                           vl, vu, il, iu, abstol, nev, W, strideW, Z, ldz,
                                           strideZ, ifail, strideF, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsyevx_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsyevx_strided_batched(handle::rocblas_handle,
                                                          evect::rocblas_evect,
                                                          erange::rocblas_erange,
                                                          uplo::rocblas_fill, n::rocblas_int,
@@ -6465,7 +6463,7 @@ function rocsolver_cheevx_strided_batched(handle, evect, erange, uplo, n, A, lda
                                           vl, vu, il, iu, abstol, nev, W, strideW, Z, ldz,
                                           strideZ, ifail, strideF, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cheevx_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cheevx_strided_batched(handle::rocblas_handle,
                                                          evect::rocblas_evect,
                                                          erange::rocblas_erange,
                                                          uplo::rocblas_fill, n::rocblas_int,
@@ -6491,7 +6489,7 @@ function rocsolver_zheevx_strided_batched(handle, evect, erange, uplo, n, A, lda
                                           vl, vu, il, iu, abstol, nev, W, strideW, Z, ldz,
                                           strideZ, ifail, strideF, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zheevx_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zheevx_strided_batched(handle::rocblas_handle,
                                                          evect::rocblas_evect,
                                                          erange::rocblas_erange,
                                                          uplo::rocblas_fill, n::rocblas_int,
@@ -6515,7 +6513,7 @@ end
 
 function rocsolver_ssygv(handle, itype, evect, uplo, n, A, lda, B, ldb, D, E, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssygv(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_ssygv(handle::rocblas_handle, itype::rocblas_eform,
                                         evect::rocblas_evect, uplo::rocblas_fill,
                                         n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                         B::Ptr{Cfloat}, ldb::rocblas_int, D::Ptr{Cfloat},
@@ -6525,7 +6523,7 @@ end
 
 function rocsolver_dsygv(handle, itype, evect, uplo, n, A, lda, B, ldb, D, E, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsygv(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_dsygv(handle::rocblas_handle, itype::rocblas_eform,
                                         evect::rocblas_evect, uplo::rocblas_fill,
                                         n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                         B::Ptr{Cdouble}, ldb::rocblas_int, D::Ptr{Cdouble},
@@ -6535,7 +6533,7 @@ end
 
 function rocsolver_chegv(handle, itype, evect, uplo, n, A, lda, B, ldb, D, E, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chegv(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_chegv(handle::rocblas_handle, itype::rocblas_eform,
                                         evect::rocblas_evect, uplo::rocblas_fill,
                                         n::rocblas_int, A::Ptr{rocblas_float_complex},
                                         lda::rocblas_int, B::Ptr{rocblas_float_complex},
@@ -6545,7 +6543,7 @@ end
 
 function rocsolver_zhegv(handle, itype, evect, uplo, n, A, lda, B, ldb, D, E, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhegv(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_zhegv(handle::rocblas_handle, itype::rocblas_eform,
                                         evect::rocblas_evect, uplo::rocblas_fill,
                                         n::rocblas_int, A::Ptr{rocblas_double_complex},
                                         lda::rocblas_int, B::Ptr{rocblas_double_complex},
@@ -6556,7 +6554,7 @@ end
 function rocsolver_ssygv_batched(handle, itype, evect, uplo, n, A, lda, B, ldb, D, strideD,
                                  E, strideE, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssygv_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssygv_batched(handle::rocblas_handle,
                                                 itype::rocblas_eform, evect::rocblas_evect,
                                                 uplo::rocblas_fill, n::rocblas_int,
                                                 A::Ptr{Ptr{Cfloat}}, lda::rocblas_int,
@@ -6570,7 +6568,7 @@ end
 function rocsolver_dsygv_batched(handle, itype, evect, uplo, n, A, lda, B, ldb, D, strideD,
                                  E, strideE, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsygv_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsygv_batched(handle::rocblas_handle,
                                                 itype::rocblas_eform, evect::rocblas_evect,
                                                 uplo::rocblas_fill, n::rocblas_int,
                                                 A::Ptr{Ptr{Cdouble}}, lda::rocblas_int,
@@ -6584,7 +6582,7 @@ end
 function rocsolver_chegv_batched(handle, itype, evect, uplo, n, A, lda, B, ldb, D, strideD,
                                  E, strideE, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chegv_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_chegv_batched(handle::rocblas_handle,
                                                 itype::rocblas_eform, evect::rocblas_evect,
                                                 uplo::rocblas_fill, n::rocblas_int,
                                                 A::Ptr{Ptr{rocblas_float_complex}},
@@ -6600,7 +6598,7 @@ end
 function rocsolver_zhegv_batched(handle, itype, evect, uplo, n, A, lda, B, ldb, D, strideD,
                                  E, strideE, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhegv_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zhegv_batched(handle::rocblas_handle,
                                                 itype::rocblas_eform, evect::rocblas_evect,
                                                 uplo::rocblas_fill, n::rocblas_int,
                                                 A::Ptr{Ptr{rocblas_double_complex}},
@@ -6617,7 +6615,7 @@ function rocsolver_ssygv_strided_batched(handle, itype, evect, uplo, n, A, lda, 
                                          ldb, strideB, D, strideD, E, strideE, info,
                                          batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssygv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssygv_strided_batched(handle::rocblas_handle,
                                                         itype::rocblas_eform,
                                                         evect::rocblas_evect,
                                                         uplo::rocblas_fill, n::rocblas_int,
@@ -6637,7 +6635,7 @@ function rocsolver_dsygv_strided_batched(handle, itype, evect, uplo, n, A, lda, 
                                          ldb, strideB, D, strideD, E, strideE, info,
                                          batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsygv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsygv_strided_batched(handle::rocblas_handle,
                                                         itype::rocblas_eform,
                                                         evect::rocblas_evect,
                                                         uplo::rocblas_fill, n::rocblas_int,
@@ -6657,7 +6655,7 @@ function rocsolver_chegv_strided_batched(handle, itype, evect, uplo, n, A, lda, 
                                          ldb, strideB, D, strideD, E, strideE, info,
                                          batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chegv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_chegv_strided_batched(handle::rocblas_handle,
                                                         itype::rocblas_eform,
                                                         evect::rocblas_evect,
                                                         uplo::rocblas_fill, n::rocblas_int,
@@ -6679,7 +6677,7 @@ function rocsolver_zhegv_strided_batched(handle, itype, evect, uplo, n, A, lda, 
                                          ldb, strideB, D, strideD, E, strideE, info,
                                          batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhegv_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zhegv_strided_batched(handle::rocblas_handle,
                                                         itype::rocblas_eform,
                                                         evect::rocblas_evect,
                                                         uplo::rocblas_fill, n::rocblas_int,
@@ -6699,7 +6697,7 @@ end
 
 function rocsolver_ssygvd(handle, itype, evect, uplo, n, A, lda, B, ldb, D, E, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssygvd(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_ssygvd(handle::rocblas_handle, itype::rocblas_eform,
                                          evect::rocblas_evect, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          B::Ptr{Cfloat}, ldb::rocblas_int, D::Ptr{Cfloat},
@@ -6709,7 +6707,7 @@ end
 
 function rocsolver_dsygvd(handle, itype, evect, uplo, n, A, lda, B, ldb, D, E, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsygvd(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_dsygvd(handle::rocblas_handle, itype::rocblas_eform,
                                          evect::rocblas_evect, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          B::Ptr{Cdouble}, ldb::rocblas_int, D::Ptr{Cdouble},
@@ -6719,7 +6717,7 @@ end
 
 function rocsolver_chegvd(handle, itype, evect, uplo, n, A, lda, B, ldb, D, E, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chegvd(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_chegvd(handle::rocblas_handle, itype::rocblas_eform,
                                          evect::rocblas_evect, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int, B::Ptr{rocblas_float_complex},
@@ -6729,7 +6727,7 @@ end
 
 function rocsolver_zhegvd(handle, itype, evect, uplo, n, A, lda, B, ldb, D, E, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhegvd(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_zhegvd(handle::rocblas_handle, itype::rocblas_eform,
                                          evect::rocblas_evect, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int, B::Ptr{rocblas_double_complex},
@@ -6740,7 +6738,7 @@ end
 function rocsolver_ssygvd_batched(handle, itype, evect, uplo, n, A, lda, B, ldb, D, strideD,
                                   E, strideE, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssygvd_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssygvd_batched(handle::rocblas_handle,
                                                  itype::rocblas_eform, evect::rocblas_evect,
                                                  uplo::rocblas_fill, n::rocblas_int,
                                                  A::Ptr{Ptr{Cfloat}}, lda::rocblas_int,
@@ -6754,7 +6752,7 @@ end
 function rocsolver_dsygvd_batched(handle, itype, evect, uplo, n, A, lda, B, ldb, D, strideD,
                                   E, strideE, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsygvd_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsygvd_batched(handle::rocblas_handle,
                                                  itype::rocblas_eform, evect::rocblas_evect,
                                                  uplo::rocblas_fill, n::rocblas_int,
                                                  A::Ptr{Ptr{Cdouble}}, lda::rocblas_int,
@@ -6768,7 +6766,7 @@ end
 function rocsolver_chegvd_batched(handle, itype, evect, uplo, n, A, lda, B, ldb, D, strideD,
                                   E, strideE, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chegvd_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_chegvd_batched(handle::rocblas_handle,
                                                  itype::rocblas_eform, evect::rocblas_evect,
                                                  uplo::rocblas_fill, n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
@@ -6784,7 +6782,7 @@ end
 function rocsolver_zhegvd_batched(handle, itype, evect, uplo, n, A, lda, B, ldb, D, strideD,
                                   E, strideE, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhegvd_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zhegvd_batched(handle::rocblas_handle,
                                                  itype::rocblas_eform, evect::rocblas_evect,
                                                  uplo::rocblas_fill, n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
@@ -6801,7 +6799,7 @@ function rocsolver_ssygvd_strided_batched(handle, itype, evect, uplo, n, A, lda,
                                           ldb, strideB, D, strideD, E, strideE, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssygvd_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssygvd_strided_batched(handle::rocblas_handle,
                                                          itype::rocblas_eform,
                                                          evect::rocblas_evect,
                                                          uplo::rocblas_fill, n::rocblas_int,
@@ -6821,7 +6819,7 @@ function rocsolver_dsygvd_strided_batched(handle, itype, evect, uplo, n, A, lda,
                                           ldb, strideB, D, strideD, E, strideE, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsygvd_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsygvd_strided_batched(handle::rocblas_handle,
                                                          itype::rocblas_eform,
                                                          evect::rocblas_evect,
                                                          uplo::rocblas_fill, n::rocblas_int,
@@ -6841,7 +6839,7 @@ function rocsolver_chegvd_strided_batched(handle, itype, evect, uplo, n, A, lda,
                                           ldb, strideB, D, strideD, E, strideE, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chegvd_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_chegvd_strided_batched(handle::rocblas_handle,
                                                          itype::rocblas_eform,
                                                          evect::rocblas_evect,
                                                          uplo::rocblas_fill, n::rocblas_int,
@@ -6863,7 +6861,7 @@ function rocsolver_zhegvd_strided_batched(handle, itype, evect, uplo, n, A, lda,
                                           ldb, strideB, D, strideD, E, strideE, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhegvd_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zhegvd_strided_batched(handle::rocblas_handle,
                                                          itype::rocblas_eform,
                                                          evect::rocblas_evect,
                                                          uplo::rocblas_fill, n::rocblas_int,
@@ -6884,7 +6882,7 @@ end
 function rocsolver_ssygvj(handle, itype, evect, uplo, n, A, lda, B, ldb, abstol, residual,
                           max_sweeps, n_sweeps, W, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssygvj(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_ssygvj(handle::rocblas_handle, itype::rocblas_eform,
                                          evect::rocblas_evect, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          B::Ptr{Cfloat}, ldb::rocblas_int, abstol::Cfloat,
@@ -6896,7 +6894,7 @@ end
 function rocsolver_dsygvj(handle, itype, evect, uplo, n, A, lda, B, ldb, abstol, residual,
                           max_sweeps, n_sweeps, W, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsygvj(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_dsygvj(handle::rocblas_handle, itype::rocblas_eform,
                                          evect::rocblas_evect, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          B::Ptr{Cdouble}, ldb::rocblas_int, abstol::Cdouble,
@@ -6908,7 +6906,7 @@ end
 function rocsolver_chegvj(handle, itype, evect, uplo, n, A, lda, B, ldb, abstol, residual,
                           max_sweeps, n_sweeps, W, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chegvj(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_chegvj(handle::rocblas_handle, itype::rocblas_eform,
                                          evect::rocblas_evect, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int, B::Ptr{rocblas_float_complex},
@@ -6921,7 +6919,7 @@ end
 function rocsolver_zhegvj(handle, itype, evect, uplo, n, A, lda, B, ldb, abstol, residual,
                           max_sweeps, n_sweeps, W, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhegvj(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_zhegvj(handle::rocblas_handle, itype::rocblas_eform,
                                          evect::rocblas_evect, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int, B::Ptr{rocblas_double_complex},
@@ -6935,7 +6933,7 @@ function rocsolver_ssygvj_batched(handle, itype, evect, uplo, n, A, lda, B, ldb,
                                   residual, max_sweeps, n_sweeps, W, strideW, info,
                                   batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssygvj_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssygvj_batched(handle::rocblas_handle,
                                                  itype::rocblas_eform, evect::rocblas_evect,
                                                  uplo::rocblas_fill, n::rocblas_int,
                                                  A::Ptr{Ptr{Cfloat}}, lda::rocblas_int,
@@ -6952,7 +6950,7 @@ function rocsolver_dsygvj_batched(handle, itype, evect, uplo, n, A, lda, B, ldb,
                                   residual, max_sweeps, n_sweeps, W, strideW, info,
                                   batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsygvj_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsygvj_batched(handle::rocblas_handle,
                                                  itype::rocblas_eform, evect::rocblas_evect,
                                                  uplo::rocblas_fill, n::rocblas_int,
                                                  A::Ptr{Ptr{Cdouble}}, lda::rocblas_int,
@@ -6969,7 +6967,7 @@ function rocsolver_chegvj_batched(handle, itype, evect, uplo, n, A, lda, B, ldb,
                                   residual, max_sweeps, n_sweeps, W, strideW, info,
                                   batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chegvj_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_chegvj_batched(handle::rocblas_handle,
                                                  itype::rocblas_eform, evect::rocblas_evect,
                                                  uplo::rocblas_fill, n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
@@ -6988,7 +6986,7 @@ function rocsolver_zhegvj_batched(handle, itype, evect, uplo, n, A, lda, B, ldb,
                                   residual, max_sweeps, n_sweeps, W, strideW, info,
                                   batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhegvj_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zhegvj_batched(handle::rocblas_handle,
                                                  itype::rocblas_eform, evect::rocblas_evect,
                                                  uplo::rocblas_fill, n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
@@ -7007,7 +7005,7 @@ function rocsolver_ssygvj_strided_batched(handle, itype, evect, uplo, n, A, lda,
                                           ldb, strideB, abstol, residual, max_sweeps,
                                           n_sweeps, W, strideW, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssygvj_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssygvj_strided_batched(handle::rocblas_handle,
                                                          itype::rocblas_eform,
                                                          evect::rocblas_evect,
                                                          uplo::rocblas_fill, n::rocblas_int,
@@ -7029,7 +7027,7 @@ function rocsolver_dsygvj_strided_batched(handle, itype, evect, uplo, n, A, lda,
                                           ldb, strideB, abstol, residual, max_sweeps,
                                           n_sweeps, W, strideW, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsygvj_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsygvj_strided_batched(handle::rocblas_handle,
                                                          itype::rocblas_eform,
                                                          evect::rocblas_evect,
                                                          uplo::rocblas_fill, n::rocblas_int,
@@ -7051,7 +7049,7 @@ function rocsolver_chegvj_strided_batched(handle, itype, evect, uplo, n, A, lda,
                                           ldb, strideB, abstol, residual, max_sweeps,
                                           n_sweeps, W, strideW, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chegvj_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_chegvj_strided_batched(handle::rocblas_handle,
                                                          itype::rocblas_eform,
                                                          evect::rocblas_evect,
                                                          uplo::rocblas_fill, n::rocblas_int,
@@ -7075,7 +7073,7 @@ function rocsolver_zhegvj_strided_batched(handle, itype, evect, uplo, n, A, lda,
                                           ldb, strideB, abstol, residual, max_sweeps,
                                           n_sweeps, W, strideW, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhegvj_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zhegvj_strided_batched(handle::rocblas_handle,
                                                          itype::rocblas_eform,
                                                          evect::rocblas_evect,
                                                          uplo::rocblas_fill, n::rocblas_int,
@@ -7098,7 +7096,7 @@ end
 function rocsolver_ssygvx(handle, itype, evect, erange, uplo, n, A, lda, B, ldb, vl, vu, il,
                           iu, abstol, nev, W, Z, ldz, ifail, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssygvx(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_ssygvx(handle::rocblas_handle, itype::rocblas_eform,
                                          evect::rocblas_evect, erange::rocblas_erange,
                                          uplo::rocblas_fill, n::rocblas_int, A::Ptr{Cfloat},
                                          lda::rocblas_int, B::Ptr{Cfloat}, ldb::rocblas_int,
@@ -7113,7 +7111,7 @@ end
 function rocsolver_dsygvx(handle, itype, evect, erange, uplo, n, A, lda, B, ldb, vl, vu, il,
                           iu, abstol, nev, W, Z, ldz, ifail, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsygvx(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_dsygvx(handle::rocblas_handle, itype::rocblas_eform,
                                          evect::rocblas_evect, erange::rocblas_erange,
                                          uplo::rocblas_fill, n::rocblas_int,
                                          A::Ptr{Cdouble}, lda::rocblas_int, B::Ptr{Cdouble},
@@ -7128,7 +7126,7 @@ end
 function rocsolver_chegvx(handle, itype, evect, erange, uplo, n, A, lda, B, ldb, vl, vu, il,
                           iu, abstol, nev, W, Z, ldz, ifail, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chegvx(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_chegvx(handle::rocblas_handle, itype::rocblas_eform,
                                          evect::rocblas_evect, erange::rocblas_erange,
                                          uplo::rocblas_fill, n::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
@@ -7144,7 +7142,7 @@ end
 function rocsolver_zhegvx(handle, itype, evect, erange, uplo, n, A, lda, B, ldb, vl, vu, il,
                           iu, abstol, nev, W, Z, ldz, ifail, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhegvx(handle::rocblas_handle, itype::rocblas_eform,
+    @check @ccall librocsolver.rocsolver_zhegvx(handle::rocblas_handle, itype::rocblas_eform,
                                          evect::rocblas_evect, erange::rocblas_erange,
                                          uplo::rocblas_fill, n::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
@@ -7161,7 +7159,7 @@ function rocsolver_ssygvx_batched(handle, itype, evect, erange, uplo, n, A, lda,
                                   vu, il, iu, abstol, nev, W, strideW, Z, ldz, ifail,
                                   strideF, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssygvx_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssygvx_batched(handle::rocblas_handle,
                                                  itype::rocblas_eform, evect::rocblas_evect,
                                                  erange::rocblas_erange, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
@@ -7181,7 +7179,7 @@ function rocsolver_dsygvx_batched(handle, itype, evect, erange, uplo, n, A, lda,
                                   vu, il, iu, abstol, nev, W, strideW, Z, ldz, ifail,
                                   strideF, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsygvx_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsygvx_batched(handle::rocblas_handle,
                                                  itype::rocblas_eform, evect::rocblas_evect,
                                                  erange::rocblas_erange, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
@@ -7201,7 +7199,7 @@ function rocsolver_chegvx_batched(handle, itype, evect, erange, uplo, n, A, lda,
                                   vu, il, iu, abstol, nev, W, strideW, Z, ldz, ifail,
                                   strideF, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chegvx_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_chegvx_batched(handle::rocblas_handle,
                                                  itype::rocblas_eform, evect::rocblas_evect,
                                                  erange::rocblas_erange, uplo::rocblas_fill,
                                                  n::rocblas_int,
@@ -7223,7 +7221,7 @@ function rocsolver_zhegvx_batched(handle, itype, evect, erange, uplo, n, A, lda,
                                   vu, il, iu, abstol, nev, W, strideW, Z, ldz, ifail,
                                   strideF, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhegvx_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zhegvx_batched(handle::rocblas_handle,
                                                  itype::rocblas_eform, evect::rocblas_evect,
                                                  erange::rocblas_erange, uplo::rocblas_fill,
                                                  n::rocblas_int,
@@ -7246,7 +7244,7 @@ function rocsolver_ssygvx_strided_batched(handle, itype, evect, erange, uplo, n,
                                           nev, W, strideW, Z, ldz, strideZ, ifail, strideF,
                                           info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssygvx_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssygvx_strided_batched(handle::rocblas_handle,
                                                          itype::rocblas_eform,
                                                          evect::rocblas_evect,
                                                          erange::rocblas_erange,
@@ -7274,7 +7272,7 @@ function rocsolver_dsygvx_strided_batched(handle, itype, evect, erange, uplo, n,
                                           nev, W, strideW, Z, ldz, strideZ, ifail, strideF,
                                           info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsygvx_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsygvx_strided_batched(handle::rocblas_handle,
                                                          itype::rocblas_eform,
                                                          evect::rocblas_evect,
                                                          erange::rocblas_erange,
@@ -7302,7 +7300,7 @@ function rocsolver_chegvx_strided_batched(handle, itype, evect, erange, uplo, n,
                                           nev, W, strideW, Z, ldz, strideZ, ifail, strideF,
                                           info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_chegvx_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_chegvx_strided_batched(handle::rocblas_handle,
                                                          itype::rocblas_eform,
                                                          evect::rocblas_evect,
                                                          erange::rocblas_erange,
@@ -7333,7 +7331,7 @@ function rocsolver_zhegvx_strided_batched(handle, itype, evect, erange, uplo, n,
                                           nev, W, strideW, Z, ldz, strideZ, ifail, strideF,
                                           info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zhegvx_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zhegvx_strided_batched(handle::rocblas_handle,
                                                          itype::rocblas_eform,
                                                          evect::rocblas_evect,
                                                          erange::rocblas_erange,
@@ -7361,7 +7359,7 @@ end
 
 function rocsolver_sgetri_outofplace(handle, n, A, lda, ipiv, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetri_outofplace(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgetri_outofplace(handle::rocblas_handle, n::rocblas_int,
                                                     A::Ptr{Cfloat}, lda::rocblas_int,
                                                     ipiv::Ptr{rocblas_int}, C::Ptr{Cfloat},
                                                     ldc::rocblas_int,
@@ -7370,7 +7368,7 @@ end
 
 function rocsolver_dgetri_outofplace(handle, n, A, lda, ipiv, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetri_outofplace(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgetri_outofplace(handle::rocblas_handle, n::rocblas_int,
                                                     A::Ptr{Cdouble}, lda::rocblas_int,
                                                     ipiv::Ptr{rocblas_int}, C::Ptr{Cdouble},
                                                     ldc::rocblas_int,
@@ -7379,7 +7377,7 @@ end
 
 function rocsolver_cgetri_outofplace(handle, n, A, lda, ipiv, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetri_outofplace(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgetri_outofplace(handle::rocblas_handle, n::rocblas_int,
                                                     A::Ptr{rocblas_float_complex},
                                                     lda::rocblas_int,
                                                     ipiv::Ptr{rocblas_int},
@@ -7390,7 +7388,7 @@ end
 
 function rocsolver_zgetri_outofplace(handle, n, A, lda, ipiv, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetri_outofplace(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgetri_outofplace(handle::rocblas_handle, n::rocblas_int,
                                                     A::Ptr{rocblas_double_complex},
                                                     lda::rocblas_int,
                                                     ipiv::Ptr{rocblas_int},
@@ -7402,7 +7400,7 @@ end
 function rocsolver_sgetri_outofplace_batched(handle, n, A, lda, ipiv, strideP, C, ldc, info,
                                              batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetri_outofplace_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgetri_outofplace_batched(handle::rocblas_handle,
                                                             n::rocblas_int,
                                                             A::Ptr{Ptr{Cfloat}},
                                                             lda::rocblas_int,
@@ -7417,7 +7415,7 @@ end
 function rocsolver_dgetri_outofplace_batched(handle, n, A, lda, ipiv, strideP, C, ldc, info,
                                              batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetri_outofplace_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgetri_outofplace_batched(handle::rocblas_handle,
                                                             n::rocblas_int,
                                                             A::Ptr{Ptr{Cdouble}},
                                                             lda::rocblas_int,
@@ -7432,7 +7430,7 @@ end
 function rocsolver_cgetri_outofplace_batched(handle, n, A, lda, ipiv, strideP, C, ldc, info,
                                              batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetri_outofplace_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgetri_outofplace_batched(handle::rocblas_handle,
                                                             n::rocblas_int,
                                                             A::Ptr{Ptr{rocblas_float_complex}},
                                                             lda::rocblas_int,
@@ -7447,7 +7445,7 @@ end
 function rocsolver_zgetri_outofplace_batched(handle, n, A, lda, ipiv, strideP, C, ldc, info,
                                              batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetri_outofplace_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgetri_outofplace_batched(handle::rocblas_handle,
                                                             n::rocblas_int,
                                                             A::Ptr{Ptr{rocblas_double_complex}},
                                                             lda::rocblas_int,
@@ -7463,7 +7461,7 @@ function rocsolver_sgetri_outofplace_strided_batched(handle, n, A, lda, strideA,
                                                      strideP, C, ldc, strideC, info,
                                                      batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetri_outofplace_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgetri_outofplace_strided_batched(handle::rocblas_handle,
                                                                     n::rocblas_int,
                                                                     A::Ptr{Cfloat},
                                                                     lda::rocblas_int,
@@ -7481,7 +7479,7 @@ function rocsolver_dgetri_outofplace_strided_batched(handle, n, A, lda, strideA,
                                                      strideP, C, ldc, strideC, info,
                                                      batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetri_outofplace_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgetri_outofplace_strided_batched(handle::rocblas_handle,
                                                                     n::rocblas_int,
                                                                     A::Ptr{Cdouble},
                                                                     lda::rocblas_int,
@@ -7499,7 +7497,7 @@ function rocsolver_cgetri_outofplace_strided_batched(handle, n, A, lda, strideA,
                                                      strideP, C, ldc, strideC, info,
                                                      batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetri_outofplace_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgetri_outofplace_strided_batched(handle::rocblas_handle,
                                                                     n::rocblas_int,
                                                                     A::Ptr{rocblas_float_complex},
                                                                     lda::rocblas_int,
@@ -7517,7 +7515,7 @@ function rocsolver_zgetri_outofplace_strided_batched(handle, n, A, lda, strideA,
                                                      strideP, C, ldc, strideC, info,
                                                      batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetri_outofplace_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgetri_outofplace_strided_batched(handle::rocblas_handle,
                                                                     n::rocblas_int,
                                                                     A::Ptr{rocblas_double_complex},
                                                                     lda::rocblas_int,
@@ -7533,7 +7531,7 @@ end
 
 function rocsolver_sgetri_npvt_outofplace(handle, n, A, lda, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetri_npvt_outofplace(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgetri_npvt_outofplace(handle::rocblas_handle,
                                                          n::rocblas_int, A::Ptr{Cfloat},
                                                          lda::rocblas_int, C::Ptr{Cfloat},
                                                          ldc::rocblas_int,
@@ -7542,7 +7540,7 @@ end
 
 function rocsolver_dgetri_npvt_outofplace(handle, n, A, lda, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetri_npvt_outofplace(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgetri_npvt_outofplace(handle::rocblas_handle,
                                                          n::rocblas_int, A::Ptr{Cdouble},
                                                          lda::rocblas_int, C::Ptr{Cdouble},
                                                          ldc::rocblas_int,
@@ -7551,7 +7549,7 @@ end
 
 function rocsolver_cgetri_npvt_outofplace(handle, n, A, lda, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetri_npvt_outofplace(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgetri_npvt_outofplace(handle::rocblas_handle,
                                                          n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
                                                          lda::rocblas_int,
@@ -7562,7 +7560,7 @@ end
 
 function rocsolver_zgetri_npvt_outofplace(handle, n, A, lda, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetri_npvt_outofplace(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgetri_npvt_outofplace(handle::rocblas_handle,
                                                          n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
                                                          lda::rocblas_int,
@@ -7574,7 +7572,7 @@ end
 function rocsolver_sgetri_npvt_outofplace_batched(handle, n, A, lda, C, ldc, info,
                                                   batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetri_npvt_outofplace_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgetri_npvt_outofplace_batched(handle::rocblas_handle,
                                                                  n::rocblas_int,
                                                                  A::Ptr{Ptr{Cfloat}},
                                                                  lda::rocblas_int,
@@ -7587,7 +7585,7 @@ end
 function rocsolver_dgetri_npvt_outofplace_batched(handle, n, A, lda, C, ldc, info,
                                                   batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetri_npvt_outofplace_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgetri_npvt_outofplace_batched(handle::rocblas_handle,
                                                                  n::rocblas_int,
                                                                  A::Ptr{Ptr{Cdouble}},
                                                                  lda::rocblas_int,
@@ -7600,7 +7598,7 @@ end
 function rocsolver_cgetri_npvt_outofplace_batched(handle, n, A, lda, C, ldc, info,
                                                   batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetri_npvt_outofplace_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgetri_npvt_outofplace_batched(handle::rocblas_handle,
                                                                  n::rocblas_int,
                                                                  A::Ptr{Ptr{rocblas_float_complex}},
                                                                  lda::rocblas_int,
@@ -7613,7 +7611,7 @@ end
 function rocsolver_zgetri_npvt_outofplace_batched(handle, n, A, lda, C, ldc, info,
                                                   batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetri_npvt_outofplace_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgetri_npvt_outofplace_batched(handle::rocblas_handle,
                                                                  n::rocblas_int,
                                                                  A::Ptr{Ptr{rocblas_double_complex}},
                                                                  lda::rocblas_int,
@@ -7626,7 +7624,7 @@ end
 function rocsolver_sgetri_npvt_outofplace_strided_batched(handle, n, A, lda, strideA, C,
                                                           ldc, strideC, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgetri_npvt_outofplace_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgetri_npvt_outofplace_strided_batched(handle::rocblas_handle,
                                                                          n::rocblas_int,
                                                                          A::Ptr{Cfloat},
                                                                          lda::rocblas_int,
@@ -7641,7 +7639,7 @@ end
 function rocsolver_dgetri_npvt_outofplace_strided_batched(handle, n, A, lda, strideA, C,
                                                           ldc, strideC, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgetri_npvt_outofplace_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgetri_npvt_outofplace_strided_batched(handle::rocblas_handle,
                                                                          n::rocblas_int,
                                                                          A::Ptr{Cdouble},
                                                                          lda::rocblas_int,
@@ -7656,7 +7654,7 @@ end
 function rocsolver_cgetri_npvt_outofplace_strided_batched(handle, n, A, lda, strideA, C,
                                                           ldc, strideC, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgetri_npvt_outofplace_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgetri_npvt_outofplace_strided_batched(handle::rocblas_handle,
                                                                          n::rocblas_int,
                                                                          A::Ptr{rocblas_float_complex},
                                                                          lda::rocblas_int,
@@ -7671,7 +7669,7 @@ end
 function rocsolver_zgetri_npvt_outofplace_strided_batched(handle, n, A, lda, strideA, C,
                                                           ldc, strideC, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgetri_npvt_outofplace_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgetri_npvt_outofplace_strided_batched(handle::rocblas_handle,
                                                                          n::rocblas_int,
                                                                          A::Ptr{rocblas_double_complex},
                                                                          lda::rocblas_int,
@@ -7685,7 +7683,7 @@ end
 
 function rocsolver_strtri(handle, uplo, diag, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_strtri(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_strtri(handle::rocblas_handle, uplo::rocblas_fill,
                                          diag::rocblas_diagonal, n::rocblas_int,
                                          A::Ptr{Cfloat}, lda::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -7693,7 +7691,7 @@ end
 
 function rocsolver_dtrtri(handle, uplo, diag, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dtrtri(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dtrtri(handle::rocblas_handle, uplo::rocblas_fill,
                                          diag::rocblas_diagonal, n::rocblas_int,
                                          A::Ptr{Cdouble}, lda::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -7701,7 +7699,7 @@ end
 
 function rocsolver_ctrtri(handle, uplo, diag, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ctrtri(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_ctrtri(handle::rocblas_handle, uplo::rocblas_fill,
                                          diag::rocblas_diagonal, n::rocblas_int,
                                          A::Ptr{rocblas_float_complex}, lda::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -7709,7 +7707,7 @@ end
 
 function rocsolver_ztrtri(handle, uplo, diag, n, A, lda, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ztrtri(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_ztrtri(handle::rocblas_handle, uplo::rocblas_fill,
                                          diag::rocblas_diagonal, n::rocblas_int,
                                          A::Ptr{rocblas_double_complex}, lda::rocblas_int,
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -7717,7 +7715,7 @@ end
 
 function rocsolver_strtri_batched(handle, uplo, diag, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_strtri_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_strtri_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  diag::rocblas_diagonal, n::rocblas_int,
                                                  A::Ptr{Ptr{Cfloat}}, lda::rocblas_int,
                                                  info::Ptr{rocblas_int},
@@ -7726,7 +7724,7 @@ end
 
 function rocsolver_dtrtri_batched(handle, uplo, diag, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dtrtri_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dtrtri_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  diag::rocblas_diagonal, n::rocblas_int,
                                                  A::Ptr{Ptr{Cdouble}}, lda::rocblas_int,
                                                  info::Ptr{rocblas_int},
@@ -7735,7 +7733,7 @@ end
 
 function rocsolver_ctrtri_batched(handle, uplo, diag, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ctrtri_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_ctrtri_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  diag::rocblas_diagonal, n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
                                                  lda::rocblas_int, info::Ptr{rocblas_int},
@@ -7744,7 +7742,7 @@ end
 
 function rocsolver_ztrtri_batched(handle, uplo, diag, n, A, lda, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ztrtri_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_ztrtri_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  diag::rocblas_diagonal, n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
                                                  lda::rocblas_int, info::Ptr{rocblas_int},
@@ -7754,7 +7752,7 @@ end
 function rocsolver_strtri_strided_batched(handle, uplo, diag, n, A, lda, strideA, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_strtri_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_strtri_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill,
                                                          diag::rocblas_diagonal,
                                                          n::rocblas_int, A::Ptr{Cfloat},
@@ -7767,7 +7765,7 @@ end
 function rocsolver_dtrtri_strided_batched(handle, uplo, diag, n, A, lda, strideA, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dtrtri_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dtrtri_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill,
                                                          diag::rocblas_diagonal,
                                                          n::rocblas_int, A::Ptr{Cdouble},
@@ -7780,7 +7778,7 @@ end
 function rocsolver_ctrtri_strided_batched(handle, uplo, diag, n, A, lda, strideA, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ctrtri_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ctrtri_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill,
                                                          diag::rocblas_diagonal,
                                                          n::rocblas_int,
@@ -7794,7 +7792,7 @@ end
 function rocsolver_ztrtri_strided_batched(handle, uplo, diag, n, A, lda, strideA, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ztrtri_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ztrtri_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill,
                                                          diag::rocblas_diagonal,
                                                          n::rocblas_int,
@@ -7807,7 +7805,7 @@ end
 
 function rocsolver_ssytf2(handle, uplo, n, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssytf2(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_ssytf2(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_int},
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -7815,7 +7813,7 @@ end
 
 function rocsolver_dsytf2(handle, uplo, n, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsytf2(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dsytf2(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_int},
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -7823,7 +7821,7 @@ end
 
 function rocsolver_csytf2(handle, uplo, n, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_csytf2(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_csytf2(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -7831,7 +7829,7 @@ end
 
 function rocsolver_zsytf2(handle, uplo, n, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zsytf2(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_zsytf2(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -7839,7 +7837,7 @@ end
 
 function rocsolver_ssytf2_batched(handle, uplo, n, A, lda, ipiv, strideP, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssytf2_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_ssytf2_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                  lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                                  strideP::rocblas_stride,
@@ -7849,7 +7847,7 @@ end
 
 function rocsolver_dsytf2_batched(handle, uplo, n, A, lda, ipiv, strideP, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsytf2_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dsytf2_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                  lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                                  strideP::rocblas_stride,
@@ -7859,7 +7857,7 @@ end
 
 function rocsolver_csytf2_batched(handle, uplo, n, A, lda, ipiv, strideP, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_csytf2_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_csytf2_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
                                                  lda::rocblas_int, ipiv::Ptr{rocblas_int},
@@ -7870,7 +7868,7 @@ end
 
 function rocsolver_zsytf2_batched(handle, uplo, n, A, lda, ipiv, strideP, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zsytf2_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_zsytf2_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
                                                  lda::rocblas_int, ipiv::Ptr{rocblas_int},
@@ -7882,7 +7880,7 @@ end
 function rocsolver_ssytf2_strided_batched(handle, uplo, n, A, lda, strideA, ipiv, strideP,
                                           info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssytf2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssytf2_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{Cfloat}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -7895,7 +7893,7 @@ end
 function rocsolver_dsytf2_strided_batched(handle, uplo, n, A, lda, strideA, ipiv, strideP,
                                           info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsytf2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsytf2_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{Cdouble}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -7908,7 +7906,7 @@ end
 function rocsolver_csytf2_strided_batched(handle, uplo, n, A, lda, strideA, ipiv, strideP,
                                           info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_csytf2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_csytf2_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
                                                          lda::rocblas_int,
@@ -7922,7 +7920,7 @@ end
 function rocsolver_zsytf2_strided_batched(handle, uplo, n, A, lda, strideA, ipiv, strideP,
                                           info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zsytf2_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zsytf2_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
                                                          lda::rocblas_int,
@@ -7935,7 +7933,7 @@ end
 
 function rocsolver_ssytrf(handle, uplo, n, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssytrf(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_ssytrf(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cfloat}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_int},
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -7943,7 +7941,7 @@ end
 
 function rocsolver_dsytrf(handle, uplo, n, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsytrf(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dsytrf(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{Cdouble}, lda::rocblas_int,
                                          ipiv::Ptr{rocblas_int},
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -7951,7 +7949,7 @@ end
 
 function rocsolver_csytrf(handle, uplo, n, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_csytrf(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_csytrf(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_float_complex},
                                          lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -7959,7 +7957,7 @@ end
 
 function rocsolver_zsytrf(handle, uplo, n, A, lda, ipiv, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zsytrf(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_zsytrf(handle::rocblas_handle, uplo::rocblas_fill,
                                          n::rocblas_int, A::Ptr{rocblas_double_complex},
                                          lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                          info::Ptr{rocblas_int})::rocblas_status
@@ -7967,7 +7965,7 @@ end
 
 function rocsolver_ssytrf_batched(handle, uplo, n, A, lda, ipiv, strideP, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssytrf_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_ssytrf_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cfloat}},
                                                  lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                                  strideP::rocblas_stride,
@@ -7977,7 +7975,7 @@ end
 
 function rocsolver_dsytrf_batched(handle, uplo, n, A, lda, ipiv, strideP, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsytrf_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_dsytrf_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int, A::Ptr{Ptr{Cdouble}},
                                                  lda::rocblas_int, ipiv::Ptr{rocblas_int},
                                                  strideP::rocblas_stride,
@@ -7987,7 +7985,7 @@ end
 
 function rocsolver_csytrf_batched(handle, uplo, n, A, lda, ipiv, strideP, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_csytrf_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_csytrf_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_float_complex}},
                                                  lda::rocblas_int, ipiv::Ptr{rocblas_int},
@@ -7998,7 +7996,7 @@ end
 
 function rocsolver_zsytrf_batched(handle, uplo, n, A, lda, ipiv, strideP, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zsytrf_batched(handle::rocblas_handle, uplo::rocblas_fill,
+    @check @ccall librocsolver.rocsolver_zsytrf_batched(handle::rocblas_handle, uplo::rocblas_fill,
                                                  n::rocblas_int,
                                                  A::Ptr{Ptr{rocblas_double_complex}},
                                                  lda::rocblas_int, ipiv::Ptr{rocblas_int},
@@ -8010,7 +8008,7 @@ end
 function rocsolver_ssytrf_strided_batched(handle, uplo, n, A, lda, strideA, ipiv, strideP,
                                           info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_ssytrf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_ssytrf_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{Cfloat}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -8023,7 +8021,7 @@ end
 function rocsolver_dsytrf_strided_batched(handle, uplo, n, A, lda, strideA, ipiv, strideP,
                                           info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dsytrf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dsytrf_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{Cdouble}, lda::rocblas_int,
                                                          strideA::rocblas_stride,
@@ -8036,7 +8034,7 @@ end
 function rocsolver_csytrf_strided_batched(handle, uplo, n, A, lda, strideA, ipiv, strideP,
                                           info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_csytrf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_csytrf_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{rocblas_float_complex},
                                                          lda::rocblas_int,
@@ -8050,7 +8048,7 @@ end
 function rocsolver_zsytrf_strided_batched(handle, uplo, n, A, lda, strideA, ipiv, strideP,
                                           info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zsytrf_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zsytrf_strided_batched(handle::rocblas_handle,
                                                          uplo::rocblas_fill, n::rocblas_int,
                                                          A::Ptr{rocblas_double_complex},
                                                          lda::rocblas_int,
@@ -8063,7 +8061,7 @@ end
 
 function rocsolver_sgeblttrf_npvt(handle, nb, nblocks, A, lda, B, ldb, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgeblttrf_npvt(handle::rocblas_handle, nb::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgeblttrf_npvt(handle::rocblas_handle, nb::rocblas_int,
                                                  nblocks::rocblas_int, A::Ptr{Cfloat},
                                                  lda::rocblas_int, B::Ptr{Cfloat},
                                                  ldb::rocblas_int, C::Ptr{Cfloat},
@@ -8073,7 +8071,7 @@ end
 
 function rocsolver_dgeblttrf_npvt(handle, nb, nblocks, A, lda, B, ldb, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgeblttrf_npvt(handle::rocblas_handle, nb::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgeblttrf_npvt(handle::rocblas_handle, nb::rocblas_int,
                                                  nblocks::rocblas_int, A::Ptr{Cdouble},
                                                  lda::rocblas_int, B::Ptr{Cdouble},
                                                  ldb::rocblas_int, C::Ptr{Cdouble},
@@ -8083,7 +8081,7 @@ end
 
 function rocsolver_cgeblttrf_npvt(handle, nb, nblocks, A, lda, B, ldb, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgeblttrf_npvt(handle::rocblas_handle, nb::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgeblttrf_npvt(handle::rocblas_handle, nb::rocblas_int,
                                                  nblocks::rocblas_int,
                                                  A::Ptr{rocblas_float_complex},
                                                  lda::rocblas_int,
@@ -8096,7 +8094,7 @@ end
 
 function rocsolver_zgeblttrf_npvt(handle, nb, nblocks, A, lda, B, ldb, C, ldc, info)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgeblttrf_npvt(handle::rocblas_handle, nb::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgeblttrf_npvt(handle::rocblas_handle, nb::rocblas_int,
                                                  nblocks::rocblas_int,
                                                  A::Ptr{rocblas_double_complex},
                                                  lda::rocblas_int,
@@ -8110,7 +8108,7 @@ end
 function rocsolver_sgeblttrf_npvt_batched(handle, nb, nblocks, A, lda, B, ldb, C, ldc, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgeblttrf_npvt_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgeblttrf_npvt_batched(handle::rocblas_handle,
                                                          nb::rocblas_int,
                                                          nblocks::rocblas_int,
                                                          A::Ptr{Ptr{Cfloat}},
@@ -8126,7 +8124,7 @@ end
 function rocsolver_dgeblttrf_npvt_batched(handle, nb, nblocks, A, lda, B, ldb, C, ldc, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgeblttrf_npvt_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgeblttrf_npvt_batched(handle::rocblas_handle,
                                                          nb::rocblas_int,
                                                          nblocks::rocblas_int,
                                                          A::Ptr{Ptr{Cdouble}},
@@ -8142,7 +8140,7 @@ end
 function rocsolver_cgeblttrf_npvt_batched(handle, nb, nblocks, A, lda, B, ldb, C, ldc, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgeblttrf_npvt_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgeblttrf_npvt_batched(handle::rocblas_handle,
                                                          nb::rocblas_int,
                                                          nblocks::rocblas_int,
                                                          A::Ptr{Ptr{rocblas_float_complex}},
@@ -8158,7 +8156,7 @@ end
 function rocsolver_zgeblttrf_npvt_batched(handle, nb, nblocks, A, lda, B, ldb, C, ldc, info,
                                           batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgeblttrf_npvt_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgeblttrf_npvt_batched(handle::rocblas_handle,
                                                          nb::rocblas_int,
                                                          nblocks::rocblas_int,
                                                          A::Ptr{Ptr{rocblas_double_complex}},
@@ -8175,7 +8173,7 @@ function rocsolver_sgeblttrf_npvt_strided_batched(handle, nb, nblocks, A, lda, s
                                                   ldb, strideB, C, ldc, strideC, info,
                                                   batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgeblttrf_npvt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgeblttrf_npvt_strided_batched(handle::rocblas_handle,
                                                                  nb::rocblas_int,
                                                                  nblocks::rocblas_int,
                                                                  A::Ptr{Cfloat},
@@ -8195,7 +8193,7 @@ function rocsolver_dgeblttrf_npvt_strided_batched(handle, nb, nblocks, A, lda, s
                                                   ldb, strideB, C, ldc, strideC, info,
                                                   batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgeblttrf_npvt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgeblttrf_npvt_strided_batched(handle::rocblas_handle,
                                                                  nb::rocblas_int,
                                                                  nblocks::rocblas_int,
                                                                  A::Ptr{Cdouble},
@@ -8215,7 +8213,7 @@ function rocsolver_cgeblttrf_npvt_strided_batched(handle, nb, nblocks, A, lda, s
                                                   ldb, strideB, C, ldc, strideC, info,
                                                   batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgeblttrf_npvt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgeblttrf_npvt_strided_batched(handle::rocblas_handle,
                                                                  nb::rocblas_int,
                                                                  nblocks::rocblas_int,
                                                                  A::Ptr{rocblas_float_complex},
@@ -8235,7 +8233,7 @@ function rocsolver_zgeblttrf_npvt_strided_batched(handle, nb, nblocks, A, lda, s
                                                   ldb, strideB, C, ldc, strideC, info,
                                                   batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgeblttrf_npvt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgeblttrf_npvt_strided_batched(handle::rocblas_handle,
                                                                  nb::rocblas_int,
                                                                  nblocks::rocblas_int,
                                                                  A::Ptr{rocblas_double_complex},
@@ -8255,7 +8253,7 @@ function rocsolver_sgeblttrf_npvt_interleaved_batched(handle, nb, nblocks, A, in
                                                       strideA, B, incb, ldb, strideB, C,
                                                       incc, ldc, strideC, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgeblttrf_npvt_interleaved_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgeblttrf_npvt_interleaved_batched(handle::rocblas_handle,
                                                                      nb::rocblas_int,
                                                                      nblocks::rocblas_int,
                                                                      A::Ptr{Cfloat},
@@ -8278,7 +8276,7 @@ function rocsolver_dgeblttrf_npvt_interleaved_batched(handle, nb, nblocks, A, in
                                                       strideA, B, incb, ldb, strideB, C,
                                                       incc, ldc, strideC, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgeblttrf_npvt_interleaved_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgeblttrf_npvt_interleaved_batched(handle::rocblas_handle,
                                                                      nb::rocblas_int,
                                                                      nblocks::rocblas_int,
                                                                      A::Ptr{Cdouble},
@@ -8301,7 +8299,7 @@ function rocsolver_cgeblttrf_npvt_interleaved_batched(handle, nb, nblocks, A, in
                                                       strideA, B, incb, ldb, strideB, C,
                                                       incc, ldc, strideC, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgeblttrf_npvt_interleaved_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgeblttrf_npvt_interleaved_batched(handle::rocblas_handle,
                                                                      nb::rocblas_int,
                                                                      nblocks::rocblas_int,
                                                                      A::Ptr{rocblas_float_complex},
@@ -8324,7 +8322,7 @@ function rocsolver_zgeblttrf_npvt_interleaved_batched(handle, nb, nblocks, A, in
                                                       strideA, B, incb, ldb, strideB, C,
                                                       incc, ldc, strideC, info, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgeblttrf_npvt_interleaved_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgeblttrf_npvt_interleaved_batched(handle::rocblas_handle,
                                                                      nb::rocblas_int,
                                                                      nblocks::rocblas_int,
                                                                      A::Ptr{rocblas_double_complex},
@@ -8345,7 +8343,7 @@ end
 
 function rocsolver_sgeblttrs_npvt(handle, nb, nblocks, nrhs, A, lda, B, ldb, C, ldc, X, ldx)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgeblttrs_npvt(handle::rocblas_handle, nb::rocblas_int,
+    @check @ccall librocsolver.rocsolver_sgeblttrs_npvt(handle::rocblas_handle, nb::rocblas_int,
                                                  nblocks::rocblas_int, nrhs::rocblas_int,
                                                  A::Ptr{Cfloat}, lda::rocblas_int,
                                                  B::Ptr{Cfloat}, ldb::rocblas_int,
@@ -8356,7 +8354,7 @@ end
 
 function rocsolver_dgeblttrs_npvt(handle, nb, nblocks, nrhs, A, lda, B, ldb, C, ldc, X, ldx)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgeblttrs_npvt(handle::rocblas_handle, nb::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dgeblttrs_npvt(handle::rocblas_handle, nb::rocblas_int,
                                                  nblocks::rocblas_int, nrhs::rocblas_int,
                                                  A::Ptr{Cdouble}, lda::rocblas_int,
                                                  B::Ptr{Cdouble}, ldb::rocblas_int,
@@ -8367,7 +8365,7 @@ end
 
 function rocsolver_cgeblttrs_npvt(handle, nb, nblocks, nrhs, A, lda, B, ldb, C, ldc, X, ldx)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgeblttrs_npvt(handle::rocblas_handle, nb::rocblas_int,
+    @check @ccall librocsolver.rocsolver_cgeblttrs_npvt(handle::rocblas_handle, nb::rocblas_int,
                                                  nblocks::rocblas_int, nrhs::rocblas_int,
                                                  A::Ptr{rocblas_float_complex},
                                                  lda::rocblas_int,
@@ -8381,7 +8379,7 @@ end
 
 function rocsolver_zgeblttrs_npvt(handle, nb, nblocks, nrhs, A, lda, B, ldb, C, ldc, X, ldx)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgeblttrs_npvt(handle::rocblas_handle, nb::rocblas_int,
+    @check @ccall librocsolver.rocsolver_zgeblttrs_npvt(handle::rocblas_handle, nb::rocblas_int,
                                                  nblocks::rocblas_int, nrhs::rocblas_int,
                                                  A::Ptr{rocblas_double_complex},
                                                  lda::rocblas_int,
@@ -8396,7 +8394,7 @@ end
 function rocsolver_sgeblttrs_npvt_batched(handle, nb, nblocks, nrhs, A, lda, B, ldb, C, ldc,
                                           X, ldx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgeblttrs_npvt_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgeblttrs_npvt_batched(handle::rocblas_handle,
                                                          nb::rocblas_int,
                                                          nblocks::rocblas_int,
                                                          nrhs::rocblas_int,
@@ -8414,7 +8412,7 @@ end
 function rocsolver_dgeblttrs_npvt_batched(handle, nb, nblocks, nrhs, A, lda, B, ldb, C, ldc,
                                           X, ldx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgeblttrs_npvt_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgeblttrs_npvt_batched(handle::rocblas_handle,
                                                          nb::rocblas_int,
                                                          nblocks::rocblas_int,
                                                          nrhs::rocblas_int,
@@ -8432,7 +8430,7 @@ end
 function rocsolver_cgeblttrs_npvt_batched(handle, nb, nblocks, nrhs, A, lda, B, ldb, C, ldc,
                                           X, ldx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgeblttrs_npvt_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgeblttrs_npvt_batched(handle::rocblas_handle,
                                                          nb::rocblas_int,
                                                          nblocks::rocblas_int,
                                                          nrhs::rocblas_int,
@@ -8450,7 +8448,7 @@ end
 function rocsolver_zgeblttrs_npvt_batched(handle, nb, nblocks, nrhs, A, lda, B, ldb, C, ldc,
                                           X, ldx, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgeblttrs_npvt_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgeblttrs_npvt_batched(handle::rocblas_handle,
                                                          nb::rocblas_int,
                                                          nblocks::rocblas_int,
                                                          nrhs::rocblas_int,
@@ -8469,7 +8467,7 @@ function rocsolver_sgeblttrs_npvt_strided_batched(handle, nb, nblocks, nrhs, A, 
                                                   strideA, B, ldb, strideB, C, ldc, strideC,
                                                   X, ldx, strideX, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgeblttrs_npvt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgeblttrs_npvt_strided_batched(handle::rocblas_handle,
                                                                  nb::rocblas_int,
                                                                  nblocks::rocblas_int,
                                                                  nrhs::rocblas_int,
@@ -8492,7 +8490,7 @@ function rocsolver_dgeblttrs_npvt_strided_batched(handle, nb, nblocks, nrhs, A, 
                                                   strideA, B, ldb, strideB, C, ldc, strideC,
                                                   X, ldx, strideX, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgeblttrs_npvt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgeblttrs_npvt_strided_batched(handle::rocblas_handle,
                                                                  nb::rocblas_int,
                                                                  nblocks::rocblas_int,
                                                                  nrhs::rocblas_int,
@@ -8515,7 +8513,7 @@ function rocsolver_cgeblttrs_npvt_strided_batched(handle, nb, nblocks, nrhs, A, 
                                                   strideA, B, ldb, strideB, C, ldc, strideC,
                                                   X, ldx, strideX, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgeblttrs_npvt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgeblttrs_npvt_strided_batched(handle::rocblas_handle,
                                                                  nb::rocblas_int,
                                                                  nblocks::rocblas_int,
                                                                  nrhs::rocblas_int,
@@ -8538,7 +8536,7 @@ function rocsolver_zgeblttrs_npvt_strided_batched(handle, nb, nblocks, nrhs, A, 
                                                   strideA, B, ldb, strideB, C, ldc, strideC,
                                                   X, ldx, strideX, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgeblttrs_npvt_strided_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgeblttrs_npvt_strided_batched(handle::rocblas_handle,
                                                                  nb::rocblas_int,
                                                                  nblocks::rocblas_int,
                                                                  nrhs::rocblas_int,
@@ -8562,7 +8560,7 @@ function rocsolver_sgeblttrs_npvt_interleaved_batched(handle, nb, nblocks, nrhs,
                                                       C, incc, ldc, strideC, X, incx, ldx,
                                                       strideX, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_sgeblttrs_npvt_interleaved_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_sgeblttrs_npvt_interleaved_batched(handle::rocblas_handle,
                                                                      nb::rocblas_int,
                                                                      nblocks::rocblas_int,
                                                                      nrhs::rocblas_int,
@@ -8590,7 +8588,7 @@ function rocsolver_dgeblttrs_npvt_interleaved_batched(handle, nb, nblocks, nrhs,
                                                       C, incc, ldc, strideC, X, incx, ldx,
                                                       strideX, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dgeblttrs_npvt_interleaved_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_dgeblttrs_npvt_interleaved_batched(handle::rocblas_handle,
                                                                      nb::rocblas_int,
                                                                      nblocks::rocblas_int,
                                                                      nrhs::rocblas_int,
@@ -8618,7 +8616,7 @@ function rocsolver_cgeblttrs_npvt_interleaved_batched(handle, nb, nblocks, nrhs,
                                                       C, incc, ldc, strideC, X, incx, ldx,
                                                       strideX, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_cgeblttrs_npvt_interleaved_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_cgeblttrs_npvt_interleaved_batched(handle::rocblas_handle,
                                                                      nb::rocblas_int,
                                                                      nblocks::rocblas_int,
                                                                      nrhs::rocblas_int,
@@ -8646,7 +8644,7 @@ function rocsolver_zgeblttrs_npvt_interleaved_batched(handle, nb, nblocks, nrhs,
                                                       C, incc, ldc, strideC, X, incx, ldx,
                                                       strideX, batch_count)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_zgeblttrs_npvt_interleaved_batched(handle::rocblas_handle,
+    @check @ccall librocsolver.rocsolver_zgeblttrs_npvt_interleaved_batched(handle::rocblas_handle,
                                                                      nb::rocblas_int,
                                                                      nblocks::rocblas_int,
                                                                      nrhs::rocblas_int,
@@ -8671,31 +8669,31 @@ end
 
 function rocsolver_create_rfinfo(rfinfo, handle)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_create_rfinfo(rfinfo::Ptr{rocsolver_rfinfo},
+    @check @ccall librocsolver.rocsolver_create_rfinfo(rfinfo::Ptr{rocsolver_rfinfo},
                                                 handle::rocblas_handle)::rocblas_status
 end
 
 function rocsolver_destroy_rfinfo(rfinfo)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_destroy_rfinfo(rfinfo::rocsolver_rfinfo)::rocblas_status
+    @check @ccall librocsolver.rocsolver_destroy_rfinfo(rfinfo::rocsolver_rfinfo)::rocblas_status
 end
 
 function rocsolver_set_rfinfo_mode(rfinfo, mode)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_set_rfinfo_mode(rfinfo::rocsolver_rfinfo,
+    @check @ccall librocsolver.rocsolver_set_rfinfo_mode(rfinfo::rocsolver_rfinfo,
                                                   mode::rocsolver_rfinfo_mode)::rocblas_status
 end
 
 function rocsolver_get_rfinfo_mode(rfinfo, mode)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_get_rfinfo_mode(rfinfo::rocsolver_rfinfo,
+    @check @ccall librocsolver.rocsolver_get_rfinfo_mode(rfinfo::rocsolver_rfinfo,
                                                   mode::Ptr{rocsolver_rfinfo_mode})::rocblas_status
 end
 
 function rocsolver_scsrrf_sumlu(handle, n, nnzL, ptrL, indL, valL, nnzU, ptrU, indU, valU,
                                 ptrT, indT, valT)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_scsrrf_sumlu(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_scsrrf_sumlu(handle::rocblas_handle, n::rocblas_int,
                                                nnzL::rocblas_int, ptrL::Ptr{rocblas_int},
                                                indL::Ptr{rocblas_int}, valL::Ptr{Cfloat},
                                                nnzU::rocblas_int, ptrU::Ptr{rocblas_int},
@@ -8708,7 +8706,7 @@ end
 function rocsolver_dcsrrf_sumlu(handle, n, nnzL, ptrL, indL, valL, nnzU, ptrU, indU, valU,
                                 ptrT, indT, valT)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dcsrrf_sumlu(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dcsrrf_sumlu(handle::rocblas_handle, n::rocblas_int,
                                                nnzL::rocblas_int, ptrL::Ptr{rocblas_int},
                                                indL::Ptr{rocblas_int}, valL::Ptr{Cdouble},
                                                nnzU::rocblas_int, ptrU::Ptr{rocblas_int},
@@ -8721,7 +8719,7 @@ end
 function rocsolver_scsrrf_splitlu(handle, n, nnzT, ptrT, indT, valT, ptrL, indL, valL, ptrU,
                                   indU, valU)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_scsrrf_splitlu(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_scsrrf_splitlu(handle::rocblas_handle, n::rocblas_int,
                                                  nnzT::rocblas_int, ptrT::Ptr{rocblas_int},
                                                  indT::Ptr{rocblas_int}, valT::Ptr{Cfloat},
                                                  ptrL::Ptr{rocblas_int},
@@ -8734,7 +8732,7 @@ end
 function rocsolver_dcsrrf_splitlu(handle, n, nnzT, ptrT, indT, valT, ptrL, indL, valL, ptrU,
                                   indU, valU)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dcsrrf_splitlu(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dcsrrf_splitlu(handle::rocblas_handle, n::rocblas_int,
                                                  nnzT::rocblas_int, ptrT::Ptr{rocblas_int},
                                                  indT::Ptr{rocblas_int}, valT::Ptr{Cdouble},
                                                  ptrL::Ptr{rocblas_int},
@@ -8747,7 +8745,7 @@ end
 function rocsolver_scsrrf_analysis(handle, n, nrhs, nnzM, ptrM, indM, valM, nnzT, ptrT,
                                    indT, valT, pivP, pivQ, B, ldb, rfinfo)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_scsrrf_analysis(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_scsrrf_analysis(handle::rocblas_handle, n::rocblas_int,
                                                   nrhs::rocblas_int, nnzM::rocblas_int,
                                                   ptrM::Ptr{rocblas_int},
                                                   indM::Ptr{rocblas_int}, valM::Ptr{Cfloat},
@@ -8762,7 +8760,7 @@ end
 function rocsolver_dcsrrf_analysis(handle, n, nrhs, nnzM, ptrM, indM, valM, nnzT, ptrT,
                                    indT, valT, pivP, pivQ, B, ldb, rfinfo)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dcsrrf_analysis(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dcsrrf_analysis(handle::rocblas_handle, n::rocblas_int,
                                                   nrhs::rocblas_int, nnzM::rocblas_int,
                                                   ptrM::Ptr{rocblas_int},
                                                   indM::Ptr{rocblas_int},
@@ -8779,7 +8777,7 @@ end
 function rocsolver_scsrrf_refactlu(handle, n, nnzA, ptrA, indA, valA, nnzT, ptrT, indT,
                                    valT, pivP, pivQ, rfinfo)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_scsrrf_refactlu(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_scsrrf_refactlu(handle::rocblas_handle, n::rocblas_int,
                                                   nnzA::rocblas_int, ptrA::Ptr{rocblas_int},
                                                   indA::Ptr{rocblas_int}, valA::Ptr{Cfloat},
                                                   nnzT::rocblas_int, ptrT::Ptr{rocblas_int},
@@ -8792,7 +8790,7 @@ end
 function rocsolver_dcsrrf_refactlu(handle, n, nnzA, ptrA, indA, valA, nnzT, ptrT, indT,
                                    valT, pivP, pivQ, rfinfo)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dcsrrf_refactlu(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dcsrrf_refactlu(handle::rocblas_handle, n::rocblas_int,
                                                   nnzA::rocblas_int, ptrA::Ptr{rocblas_int},
                                                   indA::Ptr{rocblas_int},
                                                   valA::Ptr{Cdouble}, nnzT::rocblas_int,
@@ -8807,7 +8805,7 @@ end
 function rocsolver_scsrrf_refactchol(handle, n, nnzA, ptrA, indA, valA, nnzT, ptrT, indT,
                                      valT, pivQ, rfinfo)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_scsrrf_refactchol(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_scsrrf_refactchol(handle::rocblas_handle, n::rocblas_int,
                                                     nnzA::rocblas_int,
                                                     ptrA::Ptr{rocblas_int},
                                                     indA::Ptr{rocblas_int},
@@ -8822,7 +8820,7 @@ end
 function rocsolver_dcsrrf_refactchol(handle, n, nnzA, ptrA, indA, valA, nnzT, ptrT, indT,
                                      valT, pivQ, rfinfo)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dcsrrf_refactchol(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dcsrrf_refactchol(handle::rocblas_handle, n::rocblas_int,
                                                     nnzA::rocblas_int,
                                                     ptrA::Ptr{rocblas_int},
                                                     indA::Ptr{rocblas_int},
@@ -8837,7 +8835,7 @@ end
 function rocsolver_scsrrf_solve(handle, n, nrhs, nnzT, ptrT, indT, valT, pivP, pivQ, B, ldb,
                                 rfinfo)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_scsrrf_solve(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_scsrrf_solve(handle::rocblas_handle, n::rocblas_int,
                                                nrhs::rocblas_int, nnzT::rocblas_int,
                                                ptrT::Ptr{rocblas_int},
                                                indT::Ptr{rocblas_int}, valT::Ptr{Cfloat},
@@ -8850,7 +8848,7 @@ end
 function rocsolver_dcsrrf_solve(handle, n, nrhs, nnzT, ptrT, indT, valT, pivP, pivQ, B, ldb,
                                 rfinfo)
     AMDGPU.prepare_state()
-    @ccall librocsolver.rocsolver_dcsrrf_solve(handle::rocblas_handle, n::rocblas_int,
+    @check @ccall librocsolver.rocsolver_dcsrrf_solve(handle::rocblas_handle, n::rocblas_int,
                                                nrhs::rocblas_int, nnzT::rocblas_int,
                                                ptrT::Ptr{rocblas_int},
                                                indT::Ptr{rocblas_int}, valT::Ptr{Cdouble},


### PR DESCRIPTION
- Fix import on non-functional machines (close #685).
- Add `@check` back to `ccall` (removed by #617).