### PR TITLE
Fix FFT execution on separate Julia task

### DIFF
--- a/src/fft/fft.jl
+++ b/src/fft/fft.jl
@@ -88,6 +88,7 @@ function update_stream!(plan::ROCFFTPlan)
     new_stream = AMDGPU.stream()
     if plan.stream != new_stream
         plan.stream = new_stream
+        info = plan.execution_info
         rocfft_execution_info_set_stream(info, new_stream)
     end
     return

--- a/test/rocarray/fft.jl
+++ b/test/rocarray/fft.jl
@@ -334,4 +334,19 @@ end
     end
 end
 
+@testset "Asynchronous" begin
+    X = rand(Float32, 10, 10)
+    d_X = ROCArray(X)
+
+    p = plan_rfft(X)
+    d_p = plan_rfft(d_X)
+
+    Y = p * X
+
+    task = Threads.@spawn d_p * d_X  # executes FFT on separate AMDGPU stream
+    d_Y = fetch(task)
+
+    @test isapprox(collect(d_Y), Y; rtol=MYRTOL, atol=MYATOL)
+end
+
 end # testset FFT


### PR DESCRIPTION
This PR fixes the execution of an FFT plan on a different AMDGPU stream (or Julia task) from the one used to create the plan.

Example:

```julia
using AMDGPU
using AbstractFFTs

x = ROCArray(rand(Float32, 100, 200))

p = plan_rfft(x)
y = p * x

task = Threads.@spawn p * x   # this currently fails! (switches to a different stream)
z = fetch(task)

Array(z) == Array(y)  # should be true
```

This currently fails simply because the `info` variable is not defined in `update_stream!`.