### PR TITLE
Prefer librocalution_hip over librocalution

### DIFF
--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -213,8 +213,7 @@ function __init__()
     end
 
     hiplibs = (
-        ("rocBLAS", :rocblas), ("rocSPARSE", :rocsparse),
-        ("rocSOLVER", :rocsolver), ("rocALUTION", :rocalution),
+        ("rocBLAS", :rocblas), ("rocSPARSE", :rocsparse), ("rocSOLVER", :rocsolver),
         ("rocRAND", :rocrand), ("rocFFT", :rocfft), ("MIOpen", :MIOpen))
     for (name, symbol) in hiplibs
         functional(symbol) || @warn "$name is unavailable, functionality will be disabled."

--- a/src/discovery/discovery.jl
+++ b/src/discovery/discovery.jl
@@ -106,7 +106,10 @@ function __init__()
         global librocblas = get_library(lib_prefix * "rocblas"; rocm_path)
         global librocsparse = get_library(lib_prefix * "rocsparse"; rocm_path)
         global librocsolver = get_library(lib_prefix * "rocsolver"; rocm_path)
-        global librocalution = get_library(lib_prefix * "rocalution"; rocm_path)
+        # XXX: librocalution is not used by AMDGPU, but depends on MPI
+        #      this opens up various issues https://juliaparallel.org/MPI.jl/stable/knownissues/#Known-issues
+        #      This fix would be to provide librocalution through JLL, for now we use just "librocalution_hip"
+        global librocalution = get_library(lib_prefix * "rocalution_hip"; rocm_path)
         global librocrand = get_library(lib_prefix * "rocrand"; rocm_path)
         global librocfft = get_library(lib_prefix * "rocfft"; rocm_path)
         global libMIOpen_path = get_library(lib_prefix * "MIOpen"; rocm_path)

--- a/src/discovery/discovery.jl
+++ b/src/discovery/discovery.jl
@@ -35,7 +35,7 @@ function get_device_libs(from_artifact::Bool; rocm_path::String)
 end
 
 export lld_artifact, lld_path, libhsaruntime, libdevice_libs, libhip
-export librocblas, librocsparse, librocsolver, librocalution
+export librocblas, librocsparse, librocsolver
 export librocrand, librocfft, libMIOpen_path
 export julia_exeflags
 
@@ -106,10 +106,6 @@ function __init__()
         global librocblas = get_library(lib_prefix * "rocblas"; rocm_path)
         global librocsparse = get_library(lib_prefix * "rocsparse"; rocm_path)
         global librocsolver = get_library(lib_prefix * "rocsolver"; rocm_path)
-        # XXX: librocalution is not used by AMDGPU, but depends on MPI
-        #      this opens up various issues https://juliaparallel.org/MPI.jl/stable/knownissues/#Known-issues
-        #      This fix would be to provide librocalution through JLL, for now we use just "librocalution_hip"
-        global librocalution = get_library(lib_prefix * "rocalution_hip"; rocm_path)
         global librocrand = get_library(lib_prefix * "rocrand"; rocm_path)
         global librocfft = get_library(lib_prefix * "rocfft"; rocm_path)
         global libMIOpen_path = get_library(lib_prefix * "MIOpen"; rocm_path)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -9,7 +9,6 @@ function versioninfo()
         _status(functional(:hip))         "HIP"              _ver(:hip, HIP.runtime_version)     _libpath(libhip);
         _status(functional(:rocblas))     "rocBLAS"          _ver(:rocblas, rocBLAS.version)     _libpath(librocblas);
         _status(functional(:rocsolver))   "rocSOLVER"        _ver(:rocsolver, rocSOLVER.version) _libpath(librocsolver);
-        _status(functional(:rocalution))  "rocALUTION"       "-"                                 _libpath(librocalution);
         _status(functional(:rocsparse))   "rocSPARSE"        "-"                                 _libpath(librocsparse);
         _status(functional(:rocrand))     "rocRAND"          _ver(:rocrand, rocRAND.version)     _libpath(librocrand);
         _status(functional(:rocfft))      "rocFFT"           _ver(:rocfft, rocFFT.version)       _libpath(librocfft);
@@ -62,7 +61,6 @@ function correctly. Available `component` values are:
 - `:device_libs` - Queries ROCm device libraries availability
 - `:rocblas`     - Queries rocBLAS library availability
 - `:rocsolver`   - Queries rocSOLVER library availability
-- `:rocalution`  - Queries rocALUTION library availability
 - `:rocsparse`   - Queries rocSPARSE library availability
 - `:rocrand`     - Queries rocRAND library availability
 - `:rocfft`      - Queries rocFFT library availability
@@ -82,8 +80,6 @@ function functional(component::Symbol)
         return !isempty(librocblas)
     elseif component == :rocsolver
         return !isempty(librocsolver)
-    elseif component == :rocalution
-        return !isempty(librocalution)
     elseif component == :rocsparse
         return !isempty(librocsparse)
     elseif component == :rocrand
@@ -95,7 +91,7 @@ function functional(component::Symbol)
     elseif component == :all
         for component in (
             :hip, :lld, :device_libs, :rocblas, :rocsolver,
-            :rocalution, :rocsparse, :rocrand, :rocfft, :MIOpen,
+            :rocsparse, :rocrand, :rocfft, :MIOpen,
         )
             functional(component) || return false
         end


### PR DESCRIPTION
Fixes #690. Rocalution is currently not used by AMDGPU.jl and using a system library with a different MPI then the rest of Julia will not work. For now just prefer `librocalution_hip`.
