### PR TITLE
Take fewer locks

### DIFF
--- a/src/blas/highlevel.jl
+++ b/src/blas/highlevel.jl
@@ -90,10 +90,15 @@ end
 # BLAS 2
 #
 
-LinearAlgebra.istriu(M::UpperTriangular{T,S}) where {T<:ROCBLASFloat, S<:StridedROCMatrix} = true
-LinearAlgebra.istril(M::UpperTriangular{T,S}) where {T<:ROCBLASFloat, S<:StridedROCMatrix} = false
-LinearAlgebra.istriu(M::LowerTriangular{T,S}) where {T<:ROCBLASFloat, S<:StridedROCMatrix} = false
-LinearAlgebra.istril(M::LowerTriangular{T,S}) where {T<:ROCBLASFloat, S<:StridedROCMatrix} = true
+const ROCUpperOrUnitUpperTriangular = LinearAlgebra.UpperOrUnitUpperTriangular{
+    <:Any,<:Union{<:ROCArray, Adjoint{<:Any, <:ROCArray}, Transpose{<:Any, <:ROCArray}}}
+const ROCLowerOrUnitLowerTriangular = LinearAlgebra.LowerOrUnitLowerTriangular{
+    <:Any,<:Union{<:ROCArray, Adjoint{<:Any, <:ROCArray}, Transpose{<:Any, <:ROCArray}}}
+
+LinearAlgebra.istriu(::ROCUpperOrUnitUpperTriangular) = true
+LinearAlgebra.istril(::ROCUpperOrUnitUpperTriangular) = false
+LinearAlgebra.istriu(::ROCLowerOrUnitLowerTriangular) = false
+LinearAlgebra.istril(::ROCLowerOrUnitLowerTriangular) = true
 
 # multiplication
 LinearAlgebra.generic_trimatmul!(

--- a/src/blas/highlevel.jl
+++ b/src/blas/highlevel.jl
@@ -90,6 +90,11 @@ end
 # BLAS 2
 #
 
+LinearAlgebra.istriu(M::UpperTriangular{T,S}) where {T<:ROCBLASFloat, S<:StridedROCMatrix} = true
+LinearAlgebra.istril(M::UpperTriangular{T,S}) where {T<:ROCBLASFloat, S<:StridedROCMatrix} = false
+LinearAlgebra.istriu(M::LowerTriangular{T,S}) where {T<:ROCBLASFloat, S<:StridedROCMatrix} = false
+LinearAlgebra.istril(M::LowerTriangular{T,S}) where {T<:ROCBLASFloat, S<:StridedROCMatrix} = true
+
 # multiplication
 LinearAlgebra.generic_trimatmul!(
     c::StridedROCVector{T}, uploc, isunitc, tfun::Function,

--- a/src/dnn/convolution.jl
+++ b/src/dnn/convolution.jl
@@ -38,10 +38,10 @@ get_conv_cache_type(::Type{miopenConvBwdDataAlgorithm_t}) = CONV_BWD_DATA_BENCHM
 get_conv_cache_type(::Type{miopenConvBwdWeightsAlgorithm_t}) = CONV_BWD_WEIGHT_BENCHMARK_CACHE
 
 function get_benchmark_cache(conv_type::C, conv_args) where C <: CONV_ALGOS
-    perf_results = lock(get_conv_cache_type(conv_type)) do cache
-        get(cache, conv_args, nothing)
-    end
-    isnothing(perf_results) && return nothing
+    cache = get_conv_cache_type(conv_type).payload
+    perf_results = get(cache, conv_args, nothing)
+    perf_results ≡ nothing && return nothing
+
     workspace = ROCArray{UInt8}(undef, perf_results.memory)
     perf_results, workspace
 end


### PR DESCRIPTION
- Revert `maybe_collect` to old behavior. Current one is too aggressive.
- Fixes #697.
  @jariji, this PR reduces the amount of locks taken, so there should be no locks in the finalizer. Feel free to re-open the issue, if you are still seeing the errors after this PR.
- Add `istriu` methods for `ROCArray` to fix triangular `lmul!` in 1.11.2.