### PR TITLE
Bump AcceleratedKernels to version 0.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -42,7 +42,7 @@ AMDGPUEnzymeCoreExt = "EnzymeCore"
 
 [compat]
 AbstractFFTs = "1.0"
-AcceleratedKernels = "0.2"
+AcceleratedKernels = "0.3"
 Adapt = "4"
 Atomix = "1"
 CEnum = "0.4, 0.5"


### PR DESCRIPTION
Making mapreduce and accumulate respect the `init` value by having a separate `neutral=GPUArrays.neutral_element` is a breaking change, hence the version bump.