### PR TITLE
Override `Base._throw_dmrs` to avoid dynamic string allocation

### DIFF
--- a/src/device/quirks.jl
+++ b/src/device/quirks.jl
@@ -88,3 +88,7 @@ end
     end
     return v
 end
+
+# TODO remove once we support strings/exceptions.
+@device_override Base._throw_dmrs(n, str, dims) =
+    @print_and_throw "Dimensions mismatch when reshaping. New dimensions must be consistent with array size\n"

--- a/test/device/array.jl
+++ b/test/device/array.jl
@@ -67,3 +67,16 @@ end
     @roc groupsize=(10, 10) kernel(array_dev)
     @test array == Array(array_dev)
 end
+
+@testset "reshape view" begin
+    function kernel!(A)
+        i = workitemIdx().x
+        B = reshape(view(A, :, i), (size(A, 1),))
+        @inbounds B[1] = 9.0
+        return
+    end
+
+    A = ROCArray{Float64}(undef, 1, 4)
+    @roc groupsize=4 kernel!(A)
+    @test all(Array(A) .≈ 9.0)
+end


### PR DESCRIPTION
Fixes #736 