### PR TITLE
Disable maybe_collect if failed to get free memory

### DIFF
--- a/src/hip/HIP.jl
+++ b/src/hip/HIP.jl
@@ -1,6 +1,5 @@
 module HIP
-export HIPError
-export devices, device_synchronize, default_stream
+export HIPError, devices, device_synchronize, default_stream
 
 using CEnum
 


### PR DESCRIPTION
Closes #738 

Wondering if we should get rid of it completely given that we have caching allocator now.