### PR TITLE
Export more types

### DIFF
--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -30,7 +30,9 @@ const LAUNCH_BLOCKING::Ref{Bool} = Ref{Bool}(false)
 export @roc, roc, rocconvert
 export HIPDevice, has_rocm_gpu
 export ROCArray, ROCVector, ROCMatrix, ROCVecOrMat
-export DenseROCArray, DenseROCVector, DenseROCMatrix, StridedROCMatrix
+export DenseROCArray, DenseROCVector, DenseROCMatrix, DenseROCVecOrMat,
+       StridedROCArray, StridedROCVector, StridedROCMatrix, StridedROCVecOrMat,
+       AnyROCArray, AnyROCVector, AnyROCMatrix, AnyROCVecOrMat
 
 struct LockedObject{T}
     lock::ReentrantLock


### PR DESCRIPTION
I wanted to use `StridedROCVector` in a project and I remarked that only `StridedROCMatrix` was exported.

This PR exports the same symbols than `CUDA.jl`.