### PR TITLE
HIP fix for unsafe_copy3d

### DIFF
--- a/src/runtime/memory/hip.jl
+++ b/src/runtime/memory/hip.jl
@@ -216,8 +216,6 @@ function attributes(ptr)
     st, data[]
 end
 
-# TODO unsafe_copy3d! is broken in HIP:
-# https://github.com/ROCm-Developer-Tools/HIP/issues/3289#issuecomment-1651195870
 """
 Asynchronous 3D array copy.
 


### PR DESCRIPTION
The issue in HIP got resolved as of ROCm 6.0 https://github.com/ROCm/hip/issues/3289#issuecomment-1920700024