### PR TITLE
Update indexing.jl

### DIFF
--- a/src/kernels/indexing.jl
+++ b/src/kernels/indexing.jl
@@ -9,7 +9,7 @@ function Base.findall(bools::AnyROCArray{Bool})
     I = keytype(bools)
     indices = cumsum(reshape(bools, prod(size(bools))))
 
-    n = @allowscalar indices[end]
+    n = isempty(indices) ? 0 : @allowscalar indices[end]
     ys = ROCArray{I}(undef, n)
 
     if n > 0


### PR DESCRIPTION
Backport the same fix than https://github.com/JuliaGPU/CUDA.jl/pull/2554.
I have an index 0 after a call to `findall` and I suspect that it is the same issue.