### PR TITLE
Include AcceleratedKernels-0.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -43,7 +43,7 @@ AMDGPUEnzymeCoreExt = "EnzymeCore"
 
 [compat]
 AbstractFFTs = "1.0"
-AcceleratedKernels = "0.3.1"
+AcceleratedKernels = "0.3.1, 0.4"
 Adapt = "4"
 Atomix = "1"
 CEnum = "0.4, 0.5"


### PR DESCRIPTION
There are no GPU-related breaking changes (only a kwarg removed from the multithreaded CPU backend), so both 0.3 and 0.4 can be kept.