### PR TITLE
Patch to find rocm libs on Fedora

### DIFF
--- a/src/discovery/utils.jl
+++ b/src/discovery/utils.jl
@@ -53,8 +53,10 @@ end
 
 function find_rocm_library(lib::String; rocm_path::String, ext::String = dlext)::String
     libdir = joinpath(rocm_path, Sys.islinux() ? "lib" : "bin")
-    isdir(libdir) || return ""
-
+    if !isdir(libdir)
+        libdir = rocm_path # Fedora installs rocm libraries to /usr/lib64
+        isdir(libdir) || return ""
+    end
     for file in readdir(libdir; join=true)
         fname = basename(file)
         matched = startswith(fname, lib) && endswith(fname, ext)


### PR DESCRIPTION
The function `find_rocm_libs` looks for a directory `$ROCM_PATH/lib` but Fedora installs `librocblas.so` etc. in `/usr/lib64`. The patch causes `find_rocm_libs` to look first for `$ROCM_PATH/lib`, and if not found to look for `$ROCM_PATH`.  (If neither is found, then the function returns an empty string as it would without the patch.)

This way, by setting
```
export ROCM_PATH=/usr/lib64
```
on Fedora, all the ROCM libraries are found and show up in the `AMDGPU.versioninfo()` table.