### PR TITLE
Add memory barrier semantics to `sync_workgroup`

### DIFF
--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -84,6 +84,10 @@ include("memory.jl")
 
 Base.Experimental.@MethodTable(method_table)
 
+#needs to be before Device since sync uses this
+const syncscope_agent = UnsafeAtomics.Internal.LLVMSyncScope{:agent}()
+const syncscope_workgroup = UnsafeAtomics.Internal.LLVMSyncScope{:workgroup}()
+
 # Device sources must load _before_ the compiler infrastructure,
 # because of generated functions.
 include("device/Device.jl")
@@ -130,12 +134,11 @@ include("random.jl")
 
 # Enable hardware FP atomics for +/- ops.
 const ROCIndexableRef{Indexable <: ROCDeviceArray} = Atomix.IndexableRef{Indexable}
-const agent = UnsafeAtomics.Internal.LLVMSyncScope{:agent}()
 function Atomix.modify!(ref::ROCIndexableRef, op::OP, x, ord) where OP <: Union{typeof(+), typeof(-)}
     x = Atomix.asstorable(ref, x)
     ptr = Atomix.pointer(ref)
     root = Atomix.gcroot(ref)
-    GC.@preserve root UnsafeAtomics.modify!(ptr, op, x, ord, agent)
+    GC.@preserve root UnsafeAtomics.modify!(ptr, op, x, ord, syncscope_agent)
 end
 
 include("ROCKernels.jl")

--- a/src/ROCKernels.jl
+++ b/src/ROCKernels.jl
@@ -171,7 +171,8 @@ end
 # - https://github.com/llvm/llvm-project/blob/714b2fdf3a385e5b9a95c435f56b1696ec3ec9e8/libclc/opencl/lib/amdgcn/mem_fence/fence.cl#L28
 @device_override @inline function KA.__synchronize()
     # XXX(vchuravy): Determine semantics, but agreement sofar is LOCAL_MEM barrier 
-    ccall("llvm.amdgcn.s.waitcnt", llvmcall, Cvoid, (Cint,), 0xff) # memory barrier
+    # We want CLK_GLOBAL_MEM_FENCE | CLK_LOCAL_MEM_FENCE
+    ccall("llvm.amdgcn.s.waitcnt", llvmcall, Cvoid, (Cint,), 0) # memory barrier
     AMDGPU.Device.sync_workgroup()
 end
 

--- a/src/ROCKernels.jl
+++ b/src/ROCKernels.jl
@@ -166,13 +166,7 @@ end
 
 # Other.
 
-# x-ref:
-# - https://github.com/llvm/llvm-project/blob/5c22793eadd8758d589eafd1cbbb2897ab8b3c8b/libclc/opencl/lib/amdgcn/synchronization/barrier.cl#L11
-# - https://github.com/llvm/llvm-project/blob/714b2fdf3a385e5b9a95c435f56b1696ec3ec9e8/libclc/opencl/lib/amdgcn/mem_fence/fence.cl#L28
 @device_override @inline function KA.__synchronize()
-    # XXX(vchuravy): Determine semantics, but agreement sofar is LOCAL_MEM barrier 
-    # We want CLK_GLOBAL_MEM_FENCE | CLK_LOCAL_MEM_FENCE
-    ccall("llvm.amdgcn.s.waitcnt", llvmcall, Cvoid, (Cint,), 0) # memory barrier
     AMDGPU.Device.sync_workgroup()
 end
 

--- a/src/ROCKernels.jl
+++ b/src/ROCKernels.jl
@@ -166,7 +166,12 @@ end
 
 # Other.
 
+# x-ref:
+# - https://github.com/llvm/llvm-project/blob/5c22793eadd8758d589eafd1cbbb2897ab8b3c8b/libclc/opencl/lib/amdgcn/synchronization/barrier.cl#L11
+# - https://github.com/llvm/llvm-project/blob/714b2fdf3a385e5b9a95c435f56b1696ec3ec9e8/libclc/opencl/lib/amdgcn/mem_fence/fence.cl#L28
 @device_override @inline function KA.__synchronize()
+    # XXX(vchuravy): Determine semantics, but agreement sofar is LOCAL_MEM barrier 
+    ccall("llvm.amdgcn.s.waitcnt", llvmcall, Cvoid, (Cint,), 0xff) # memory barrier
     AMDGPU.Device.sync_workgroup()
 end
 

--- a/src/device/Device.jl
+++ b/src/device/Device.jl
@@ -14,6 +14,7 @@ import ..Runtime
 import ..Mem
 import ..AMDGPU
 import .AMDGPU: method_table
+import ..UnsafeAtomics
 
 include("addrspaces.jl")
 include("globals.jl")


### PR DESCRIPTION
KA.__synchronize also has memory barrier semantics and should be
equivalent to OpenCL's `barrier(CLK_LOCAL_MEM_FENCE)`.

x-ref: https://github.com/JuliaGPU/OpenCL.jl/pull/300

This fixes the data-races I observed in https://github.com/JuliaGPU/AcceleratedKernels.jl/issues/41#issuecomment-2995688972