### PR TITLE
Refactor initialization logic to allow for automatic detection in Fedora

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -58,7 +58,7 @@ Pkg.add("AMDGPU")
     `/opt/rocm`) so for `AMDGPU` to find them you must set an environment variable.
     ```
     export ROCM_PATH=/usr/lib64
-```
+    ```
 
 ## Test
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -53,7 +53,7 @@ Pkg.add("AMDGPU")
     Fedora provides its own ROCM packages.
     ```
     sudo dnf install rocminfo rccl-devel rocblas-devel rocfft-devel rocsparse-devel rocsolver-devel rocrand-devel roctracer-devel miopen-devel rocm-hip-devel
-```
+    ```
 However, the libraries are not installed in the usual location (under 
 `/opt/rocm`) so for `AMDGPU` to find them you must set an environment variable.
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -54,7 +54,7 @@ Pkg.add("AMDGPU")
     ```
     sudo dnf install rocminfo rccl-devel rocblas-devel rocfft-devel rocsparse-devel rocsolver-devel rocrand-devel roctracer-devel miopen-devel rocm-hip-devel
     ```
-However, the libraries are not installed in the usual location (under 
+    However, the libraries are not installed in the usual location (under 
 `/opt/rocm`) so for `AMDGPU` to find them you must set an environment variable.
 ```
 export ROCM_PATH=/usr/lib64

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -57,7 +57,7 @@ Pkg.add("AMDGPU")
     However, the libraries are not installed in the usual location (under 
     `/opt/rocm`) so for `AMDGPU` to find them you must set an environment variable.
     ```
-export ROCM_PATH=/usr/lib64
+    export ROCM_PATH=/usr/lib64
 ```
 
 ## Test

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -51,7 +51,7 @@ Pkg.add("AMDGPU")
 !!! note "On Fedora ROCm packages"
     Although not included in the AMD's list of supported Linux distributions,
     Fedora provides its own ROCM packages.
-```
+    ```
 sudo dnf install rocminfo rccl-devel rocblas-devel rocfft-devel rocsparse-devel rocsolver-devel rocrand-devel roctracer-devel miopen-devel rocm-hip-devel
 ```
 However, the libraries are not installed in the usual location (under 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -52,7 +52,7 @@ Pkg.add("AMDGPU")
     Although not included in the AMD's list of supported Linux distributions,
     Fedora provides its own ROCM packages.
     ```
-sudo dnf install rocminfo rccl-devel rocblas-devel rocfft-devel rocsparse-devel rocsolver-devel rocrand-devel roctracer-devel miopen-devel rocm-hip-devel
+    sudo dnf install rocminfo rccl-devel rocblas-devel rocfft-devel rocsparse-devel rocsolver-devel rocrand-devel roctracer-devel miopen-devel rocm-hip-devel
 ```
 However, the libraries are not installed in the usual location (under 
 `/opt/rocm`) so for `AMDGPU` to find them you must set an environment variable.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -48,6 +48,18 @@ Pkg.add("AMDGPU")
 !!! note "On Windows AMD Software"
     Adrenalin Edition contains HIP library itself, while ROCm provides support for other functionality.
 
+!!! note "On Fedora ROCm packages"
+     Although not included in the AMD's list of supported Linux distributions,
+Fedora provides its own ROCM packages.
+```
+sudo dnf install rocminfo rccl-devel rocblas-devel rocfft-devel rocsparse-devel rocsolver-devel rocrand-devel roctracer-devel miopen-devel rocm-hip-devel
+```
+However, the libraries are not installed in the usual location (under 
+`/opt/rocm`) so for `AMDGPU` to find them you must set an environment variable.
+```
+export ROCM_PATH=/usr/lib64
+```
+
 ## Test
 
 To ensure that everything works, you can run the test suite:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -56,7 +56,7 @@ Pkg.add("AMDGPU")
     ```
     However, the libraries are not installed in the usual location (under 
     `/opt/rocm`) so for `AMDGPU` to find them you must set an environment variable.
-```
+    ```
 export ROCM_PATH=/usr/lib64
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -50,7 +50,7 @@ Pkg.add("AMDGPU")
 
 !!! note "On Fedora ROCm packages"
     Although not included in the AMD's list of supported Linux distributions,
-Fedora provides its own ROCM packages.
+    Fedora provides its own ROCM packages.
 ```
 sudo dnf install rocminfo rccl-devel rocblas-devel rocfft-devel rocsparse-devel rocsolver-devel rocrand-devel roctracer-devel miopen-devel rocm-hip-devel
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -55,7 +55,7 @@ Pkg.add("AMDGPU")
     sudo dnf install rocminfo rccl-devel rocblas-devel rocfft-devel rocsparse-devel rocsolver-devel rocrand-devel roctracer-devel miopen-devel rocm-hip-devel
     ```
     However, the libraries are not installed in the usual location (under 
-`/opt/rocm`) so for `AMDGPU` to find them you must set an environment variable.
+    `/opt/rocm`) so for `AMDGPU` to find them you must set an environment variable.
 ```
 export ROCM_PATH=/usr/lib64
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -49,7 +49,7 @@ Pkg.add("AMDGPU")
     Adrenalin Edition contains HIP library itself, while ROCm provides support for other functionality.
 
 !!! note "On Fedora ROCm packages"
-     Although not included in the AMD's list of supported Linux distributions,
+    Although not included in the AMD's list of supported Linux distributions,
 Fedora provides its own ROCM packages.
 ```
 sudo dnf install rocminfo rccl-devel rocblas-devel rocfft-devel rocsparse-devel rocsolver-devel rocrand-devel roctracer-devel miopen-devel rocm-hip-devel

--- a/docs/src/install_tips.md
+++ b/docs/src/install_tips.md
@@ -35,6 +35,10 @@ Depending on your GPU model and the functionality you want to use, you may have
 to force the GPU architecture by setting the `HSA_OVERRIDE_GFX_VERSION`
 variable to a compatible version.
 
+You may also have more than one type of GPU, for example a dedicated AMD GPU and an integrated one.
+In that case use `rocminfo` to find which device they are and setting `HIP_VISIBLE_DEVICES` to the specific device you want to use.
+Otherwise the runtime may crash if it sees two different architectures.
+
 ## Extra Setup Details
 
 List of additional steps that may be needed to take to ensure everything is working:

--- a/src/discovery/discovery.jl
+++ b/src/discovery/discovery.jl
@@ -44,18 +44,20 @@ function _hip_runtime_version()
     VersionNumber(major, minor, patch)
 end
 
+global rel_libdir::String = ""
+global libhsaruntime::String = ""
+global lld_path::String = ""
+global lld_artifact::Bool = false
+global libhip::String = ""
+global libdevice_libs::String = ""
+global librocblas::String = ""
+global librocsparse::String = ""
+global librocsolver::String = ""
+global librocrand::String = ""
+global librocfft::String = ""
+global libMIOpen_path::String = ""
+
 function __init__()
-    global libhsaruntime = ""
-    global lld_path = ""
-    global lld_artifact = ""
-    global libhip = ""
-    global libdevice_libs = ""
-    global librocblas = ""
-    global librocsparse = ""
-    global librocsolver = ""
-    global librocrand = ""
-    global librocfft = ""
-    global libMIOpen_path = ""
 
     if Sys.islinux() && isdir("/sys/class/kfd/kfd/topology/nodes/")
         for node_id in readdir("/sys/class/kfd/kfd/topology/nodes/")

--- a/src/discovery/utils.jl
+++ b/src/discovery/utils.jl
@@ -1,13 +1,39 @@
+# use amdhip as query for a valid rocm_path
+function check_rocm_path(path::String)
+    libname = (Sys.islinux() ? "libamdhip64" : "amdhip64") * "."*dlext
+    path2 = path
+    isfile(joinpath(path2, libname)) && @goto success
+    path2 = joinpath(path, "lib")
+    isfile(joinpath(path2, libname)) && @goto success
+    path2 = joinpath(path, "bin")
+    isfile(joinpath(path2, libname)) && @goto success
+    path2 = joinpath(path, "lib64")
+    isfile(joinpath(path2, libname)) && @goto success
+    return ""
+    @label success
+    @assert isdir(path2)
+    rel_libdir = relpath(path2, path)
+    return path2
+end
+
+
 """
 Find root ROCm directory.
 """
 function find_roc_path()::String
     env_dir = get(ENV, "ROCM_PATH", "")
-    isdir(env_dir) && return env_dir
+    isdir(env_dir) && check_rocm_path(env_dir) != "" && return env_dir
 
     if Sys.islinux()
-#        isdir("/opt/rocm") && return "/opt/rocm" # shim for Ubuntu rocm packages.
-        rocm_path = read(`hipconfig --rocmpath`, String)
+        hipconfig = Sys.which("hipconfig")
+        if !isnothing(hipconfig)
+            rocm_path = read(`$hipconfig --rocmpath`, String)
+            rocm_path = check_rocm_path(rocm_path)
+            isdir(rocm_path) && return rocm_path
+        end
+        rocm_path = check_rocm_path("/opt/rocm")
+        isdir(rocm_path) && return rocm_path
+        rocm_path = check_rocm_path("/usr")
         isdir(rocm_path) && return rocm_path
     elseif Sys.iswindows()
         disk_dir = dirname(dirname(homedir())) # Disk C root directory.
@@ -26,22 +52,52 @@ function find_roc_path()::String
     return ""
 end
 
+# use
+function check_device_libs(path::String)
+    if isdir(path)
+        file_path = joinpath(path, "hip" * ".bc")
+        if !ispath(file_path)
+            file_path = joinpath(path, "hip"* ".amdgcn.bc")
+            if !ispath(file_path)
+                # failed to find matching bitcode file
+                return ""
+            end
+        end
+        return path
+    else
+        return ""
+    end
+end
+
 function find_device_libs(rocm_path::String)::String
     env_dir = get(ENV, "ROCM_PATH", "")
     if isdir(env_dir)
         path = joinpath(env_dir, "amdgcn", "bitcode")
+        path = check_device_libs(path)
         isdir(path) && return path
     end
-
     # Might be set by tools like Spack or the user
     hip_devlibs_path = get(ENV, "HIP_DEVICE_LIB_PATH", "")
     hip_devlibs_path !== "" && return hip_devlibs_path
     devlibs_path = get(ENV, "DEVICE_LIB_PATH", "")
     devlibs_path !== "" && return devlibs_path
-
+    # Try using hipconfig to find the device libraries.
     # Try the canonical location.
     canonical_dir = joinpath(rocm_path, "amdgcn", "bitcode")
+    canonical_dir = check_device_libs(canonical_dir)
     isdir(canonical_dir) && return canonical_dir
+    # Fedora might put it in a weird place
+    hipconfig = Sys.which("hipconfig")
+    if !isnothing(hipconfig)
+        clang_path = read(`$hipconfig --hipclangpath`, String)
+        lib_path = joinpath(clang_path ,".." , "lib","clang")
+        if isdir(lib_path)
+            lib_path = joinpath(lib_path, only(readdir(lib_path)))
+            lib_path = joinpath(lib_path, "amdgcn", "bitcode")
+            lib_path = check_device_libs(lib_path)
+            isdir(lib_path) && return lib_path
+        end
+    end
     return ""
 end
 
@@ -54,14 +110,11 @@ function find_rocm_library(libs::Vector; rocm_path::String, ext::String = dlext)
 end
 
 function find_rocm_library(lib::String; rocm_path::String, ext::String = dlext)::String
-    libdir = joinpath(rocm_path, Sys.islinux() ? "lib" : "bin")
-    if !isdir(libdir)
-        libdir = rocm_path # Fedora installs rocm libraries to /usr/lib64
-        isdir(libdir) || return ""
-    end
+    libdir = joinpath(rocm_path, rel_libdir)
+    @assert isdir(libdir)
     for file in readdir(libdir; join=true)
         fname = basename(file)
-        matched = startswith(fname, lib) && endswith(fname, ext)
+        matched = startswith(fname, lib) && contains(fname, ext)
         matched && return file
     end
     return ""
@@ -69,8 +122,15 @@ end
 
 function find_ld_lld(rocm_path::String)::String
     lld_name = "ld.lld" * (Sys.iswindows() ? ".exe" : "")
-    for subdir in (joinpath("llvm", "bin"), "bin")
-        exp_ld_path = joinpath(rocm_path, subdir, lld_name)
+
+    dirs = (joinpath(rocm_path,"llvm", "bin"), joinpath(rocm_path,"bin"))
+    hipconfig = Sys.which("hipconfig")
+     if !isnothing(hipconfig)
+        clang_path = read(`$hipconfig --hipclangpath`, String)
+        dirs = (dirs ..., clang_path)
+     end
+    for dir in dirs
+        exp_ld_path = joinpath(dir, lld_name)
         ispath(exp_ld_path) || continue
         try
             tmpfile = tempname(;cleanup=false)

--- a/src/discovery/utils.jl
+++ b/src/discovery/utils.jl
@@ -6,7 +6,9 @@ function find_roc_path()::String
     isdir(env_dir) && return env_dir
 
     if Sys.islinux()
-        isdir("/opt/rocm") && return "/opt/rocm" # shim for Ubuntu rocm packages.
+#        isdir("/opt/rocm") && return "/opt/rocm" # shim for Ubuntu rocm packages.
+        rocm_path = read(`hipconfig --rocmpath`, String)
+        isdir(rocm_path) && return rocm_path
     elseif Sys.iswindows()
         disk_dir = dirname(dirname(homedir())) # Disk C root directory.
         rocm_dir = joinpath(disk_dir, "Program Files", "AMD", "ROCm")

--- a/src/discovery/utils.jl
+++ b/src/discovery/utils.jl
@@ -1,6 +1,6 @@
 # use amdhip as query for a valid rocm_path
 function check_rocm_path(path::String)
-    libname = (Sys.islinux() ? "libamdhip64" : "amdhip64") * "."*dlext
+    libname = (Sys.islinux() ? "libamdhip64" : "amdhip64") * "." * dlext
     path2 = path
     isfile(joinpath(path2, libname)) && @goto success
     path2 = joinpath(path, "lib")
@@ -12,14 +12,10 @@ function check_rocm_path(path::String)
     return ""
     @label success
     @assert isdir(path2)
-    rel_libdir = relpath(path2, path)
     return path2
 end
 
-
-"""
-Find root ROCm directory.
-"""
+# Find root ROCm directory.
 function find_roc_path()::String
     env_dir = get(ENV, "ROCM_PATH", "")
     isdir(env_dir) && check_rocm_path(env_dir) != "" && return env_dir
@@ -52,7 +48,7 @@ function find_roc_path()::String
     return ""
 end
 
-# use
+# use hip.bc as query for a valid device libs dir
 function check_device_libs(path::String)
     if isdir(path)
         file_path = joinpath(path, "hip" * ".bc")

--- a/src/discovery/utils.jl
+++ b/src/discovery/utils.jl
@@ -53,8 +53,10 @@ end
 
 function find_rocm_library(lib::String; rocm_path::String, ext::String = dlext)::String
     libdir = joinpath(rocm_path, Sys.islinux() ? "lib" : "bin")
-    isdir(libdir) || return ""
-
+    if !isdir(libdir)
+        libdir = rocm_path # Fedora installs rocm libraries to /usr/lib64
+        isdir(libdir) || return ""
+    end
     for file in readdir(libdir; join=true)
         fname = basename(file)
         matched = startswith(fname, lib) && endswith(fname, ext)


### PR DESCRIPTION
This builds on top of https://github.com/JuliaGPU/AMDGPU.jl/pull/775 but detects the libs automatically. It also detects the device libs if one ever wants to use the native rocm libs for this.
I tested that this works on my local fedora install

Closes #579 