### PR TITLE
follow up #788, improve docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -52,12 +52,7 @@ Pkg.add("AMDGPU")
     Although not included in the AMD's list of supported Linux distributions,
     Fedora provides its own ROCM packages.
     ```
-    sudo dnf install rocminfo rccl-devel rocblas-devel rocfft-devel rocsparse-devel rocsolver-devel rocrand-devel roctracer-devel miopen-devel rocm-hip-devel
-    ```
-    However, the libraries are not installed in the usual location (under 
-    `/opt/rocm`) so for `AMDGPU` to find them you must set an environment variable.
-    ```
-    export ROCM_PATH=/usr/lib64
+    sudo dnf install rocminfo rocblas rocfft rocsparse rocsolver rocrand roctracer miopen rocm-hip-devel
     ```
 
 ## Test

--- a/docs/src/install_tips.md
+++ b/docs/src/install_tips.md
@@ -17,18 +17,15 @@ To avoid this, use 'unsafe' conversion option:
 
 ## ROCm system libraries
 
-AMDGPU.jl looks into standard directories
-and uses `Libdl.find_library` to find ROCm libraries.
+On Linux, AMDGPU.jl queries the location of ROCm libraries through `rocminfo` by default.
+If not successful or on Windows, the following standard directories are searched:
 
-Standard path:
-- Linux: `/opt/rocm`
+Standard paths:
+- Linux: `/opt/rocm`, `/usr`
 - Windows: `C:/Program Files/AMD/ROCm/<rocm-version>`
 
 If you have non-standard path for ROCm, set `ROCM_PATH=<path>`
-environment variable before launching Julia. For example, if ROCm is installed
-in your Linux system root (e.g. on Fedora), set `ROCM_PATH=/usr/lib64/rocm/gfx11` or
-`ROCM_PATH=/usr/lib64/rocm/gfx1103`, depending on your GPU's architecture. You
-can query the architecture using the `amdgpu-arch` command. The `AMDGPU.versioninfo()`
+environment variable before launching Julia. The `AMDGPU.versioninfo()`
 function prints the paths of any libraries found.
 
 Depending on your GPU model and the functionality you want to use, you may have


### PR DESCRIPTION
Installing the non-devel packages only works just fine for me. I also deleted rccl from the list since AFAIK, we don't support it atm (ref #651). It can always be added back once we can make use of it.