### PR TITLE
Update unsafe_wrap, implement `KA.pagelock!` & remove old stuff

### DIFF
--- a/src/ROCKernels.jl
+++ b/src/ROCKernels.jl
@@ -51,6 +51,11 @@ function KA.copyto!(::ROCBackend, A, B)
     return
 end
 
+function KA.pagelock!(::ROCBackend, x::Array)
+    AMDGPU.Mem.pin(pointer(x), sizeof(x))
+    return
+end
+
 function KA.launch_config(kernel::KA.Kernel{ROCBackend}, ndrange, workgroupsize)
     if ndrange isa Integer
         ndrange = (ndrange,)

--- a/src/hip/HIP.jl
+++ b/src/hip/HIP.jl
@@ -85,9 +85,9 @@ Blocks until all kernels on all streams have completed.
 Uses currently active device.
 """
 function device_synchronize()
-    AMDGPU.maybe_collect(; blocking=true)
     hipDeviceSynchronize()
     AMDGPU.synchronize() # To trigger any Julia-kernel exception.
+    AMDGPU.maybe_collect(; blocking=true)
     return
 end
 
@@ -100,14 +100,6 @@ function memcpy(dst, src, sz, kind, stream::HIPStream)
     sz == 0 && return
     HIP.hipMemcpyWithStream(dst, src, sz, kind, stream)
     return
-end
-
-function __init__()
-    global old_nonblock_sync = if AMDGPU.functional(:hip)
-        runtime_version() < v"5.4"
-    else
-        false
-    end
 end
 
 end

--- a/src/hip/libhip_common.jl
+++ b/src/hip/libhip_common.jl
@@ -11,21 +11,12 @@ const HIP_LAUNCH_PARAM_END = Ptr{Cvoid}(3)
 end
 
 @cenum hipMemoryType begin
-    hipMemoryTypeHost
-    hipMemoryTypeDevice
-    hipMemoryTypeArray
-    hipMemoryTypeUnified
-    hipMemoryTypeManaged
-end
-
-# TODO use this once we support ROCm 6+ only.
-@cenum hipMemoryTypeV2 begin
-    hipMemoryTypeUnregisteredV2 = 0
-    hipMemoryTypeHostV2 = 1
-    hipMemoryTypeDeviceV2 = 2
-    hipMemoryTypeManagedV2 = 3
-    hipMemoryTypeArrayV2 = 10
-    hipMemoryTypeUnifiedV2 = 11
+    hipMemoryTypeUnregistered = 0
+    hipMemoryTypeHost = 1
+    hipMemoryTypeDevice = 2
+    hipMemoryTypeManaged = 3
+    hipMemoryTypeArray = 10
+    hipMemoryTypeUnified = 11
 end
 
 @cenum hiprtcResult::UInt32 begin

--- a/src/hip/stream.jl
+++ b/src/hip/stream.jl
@@ -125,23 +125,12 @@ function nonblocking_synchronize(stream::HIPStream)
     return
 end
 
-function nonblocking_synchronize_old(stream::HIPStream)
-    while true
-        yield()
-        isdone(stream) && return
-    end
-end
-
 wait(stream::HIPStream) = hipStreamSynchronize(stream)
 
 function synchronize(stream::HIPStream; blocking::Bool = false)
     if use_nonblocking_synchronize && !blocking
         if !_low_latency_synchronize(stream)
-            if old_nonblock_sync
-                nonblocking_synchronize_old(stream)
-            else
-                nonblocking_synchronize(stream)
-            end
+            nonblocking_synchronize(stream)
             AMDGPU.maybe_collect(; blocking=true)
         end
     else

--- a/test/rocarray/base.jl
+++ b/test/rocarray/base.jl
@@ -115,7 +115,7 @@ end
     @testset "Wrap device array" begin
         x = AMDGPU.rand(Float32, 4, 4)
         xhost = Array(x)
-        xd = unsafe_wrap(ROCArray, pointer(x), size(x); lock=false)
+        xd = unsafe_wrap(ROCArray, pointer(x), size(x))
 
         xd .+= 1f0
         @test Array(x) ≈ Array(xd) ≈ xhost .+ 1f0
@@ -132,8 +132,8 @@ end
         x = zeros(Float32, 16)
         @test AMDGPU.Mem.is_pinned(Ptr{Cvoid}(pointer(x))) == false
 
-        xd1 = unsafe_wrap(ROCArray, pointer(x), size(x))
-        xd2 = unsafe_wrap(ROCArray, pointer(x), size(x))
+        xd1 = unsafe_wrap(ROCArray, pointer(x), size(x); own=true)
+        xd2 = unsafe_wrap(ROCArray, pointer(x), size(x); own=true)
 
         @test AMDGPU.Mem.is_pinned(Ptr{Cvoid}(pointer(xd1))) == true
         @test AMDGPU.Mem.is_pinned(Ptr{Cvoid}(pointer(xd2))) == true


### PR DESCRIPTION
- Implement `KA.pagelock!`, although unsure why it is needed in the first place, since we have `unsafe_wrap`.
- Update `unsafe_wrap` to match Base definition: remove `lock` kwargs and add `own` kwarg.
- Remove old nonblocking sync (pre ROCm 6.0).
- Remove old memtype pointer definition (pre ROCm 6.0).

Closes #799, #724.