### PR TITLE
Disable eager GC by default

### DIFF
--- a/docs/src/install_tips.md
+++ b/docs/src/install_tips.md
@@ -91,10 +91,10 @@ Template of `LocalPreferences.toml` with all options:
 
 ```toml
 [AMDGPU]
-# If `true` (default), eagerly run GC to keep the pool from growing too big.
+# If `true` (default is `false`), eagerly run GC to keep the pool from growing too big.
 # GC is triggered during new allocatoins or synchronization points.
-eager_gc = false
-# Use non-blocking synchronization for all `AMDGPU.synchronize()` calls.
+eager_gc = true
+# Use non-blocking synchronization for all `AMDGPU.synchronize()` calls (default is `true`).
 nonblocking_synchronization = true
 # Memory limit specifies maximum amount of memory in percentages
 # a current Julia process can use.

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -134,7 +134,7 @@ function account!(stats::MemoryStats, bytes::Integer)
     Base.@atomic stats.live += bytes
 end
 
-const EAGER_GC::Ref{Bool} = Ref{Bool}(@load_preference("eager_gc", true))
+const EAGER_GC::Ref{Bool} = Ref{Bool}(@load_preference("eager_gc", false))
 
 function eager_gc!(flag::Bool)
     global EAGER_GC[] = flag


### PR DESCRIPTION
Instead (IMO) we should encourage users to use [`GPUArrays.@cached`](https://amdgpu.juliagpu.org/dev/tutorials/perf#Use-Caching-Memory-Allocator) if they care about VRAM consumption and performance.