### PR TITLE
enable cooperative group tests only on 1.12

### DIFF
--- a/test/device/launch.jl
+++ b/test/device/launch.jl
@@ -151,6 +151,8 @@ if VERSION >= v"1.12-" && !iszero(AMDGPU.HIP.properties(AMDGPU.device()).coopera
                 end
                 AMDGPU.Device.sync_grid()
             end
+
+            return nothing
         end
 
         n = 4


### PR DESCRIPTION
It seems there are some issues with cooperative groups on older LLVM versions, so enable the tests on 1.12+ only

Should fix #824