### PR TITLE
Update discovery.jl with minimal approach to fix Windows discovery process

### DIFF
--- a/src/discovery/discovery.jl
+++ b/src/discovery/discovery.jl
@@ -44,7 +44,7 @@ function _hip_runtime_version()
     VersionNumber(major, minor, patch)
 end
 
-global rel_libdir::String = ""
+global rel_libdir::String = Sys.islinux() ? "" : "bin"
 global libhsaruntime::String = ""
 global lld_path::String = ""
 global lld_artifact::Bool = false


### PR DESCRIPTION
Changes `rel_libdir` for Windows to "bin", otherwise leaves it as "" and leaves `lib_prefix` untouched to preserve Linux functionality.

Note: `amdhip64_6.dll` is in a subdirectory on Windows, but `libamdhip64.so` is top level to the ROCm path in Linux. This difference may cause issues for `libhip` in the future if it is ever modified to be consistent across platforms.