### PR TITLE
Update profiling docs: rocprof v1, v3 and roctx

### DIFF
--- a/docs/src/tutorials/profiling.md
+++ b/docs/src/tutorials/profiling.md
@@ -79,7 +79,7 @@ rocprofv3 --output-format pftrace --hsa-trace --marker-trace --kernel-trace --me
 This will produce a number of `prof_output.pftrace` files which can be visualized
 using [Perfetto UI](https://ui.perfetto.dev/).
 
-`rocprofv3` is now recommended by ADM, however on ROCm 6.2.4 nothing seems to be reported.
+`rocprofv3` is now recommended by AMD, however on ROCm 6.2.4 nothing seems to be reported.
 
 #### Visualization of the results
 Here is an example of visualizing the `profile.jl` script above in Perfetto.

--- a/docs/src/tutorials/profiling.md
+++ b/docs/src/tutorials/profiling.md
@@ -2,10 +2,11 @@
 
 ## rocprof
 
-[rocprofv2](https://github.com/ROCm/rocprofiler?tab=readme-ov-file#rocprofiler-v2)
-allows profiling both HSA & HIP API calls (rocprof being deprecated).
+[rocprof](https://github.com/ROCm/rocm-systems/tree/develop/projects/rocprofiler)
+allows profiling HSA & HIP API calls, kernel launches, and more...
+Multiple major versions are available: `rocprof`, `rocprofv2` and `rocprofv3`.
 
-Let's profile simple copying kernel saved in `profile.jl` file:
+Let's profile a simple copying kernel saved in a `profile.jl` file:
 ```julia
 using AMDGPU
 
@@ -38,12 +39,51 @@ main(2^24)
 
 ### Profiling problematic code
 
+As mentioned above, there are different `rocprof` versions and see which one works the best.
+On older ROCm versions, the newer `rocprofv2` and `rocprofv3` may not work so well.
+
+!!! note
+    While AMDGPU.jl uses the HIP API, only `--hsa-trace` seems to capture CPU API calls,
+    of the lower-level HSA API, while `--hip-trace` has no effect.
+
+    This applies to ROCm 6.2.4 at least, and was tested on AMDGPU 2.1.3.
+    If with other versions HIP API calls can be captured then please amend this documentation.
+
+#### rocprof
 ```bash
-ENABLE_JITPROFILING=1 rocprofv2 --plugin perfetto --hip-trace --hsa-trace --kernel-trace -o prof julia ./profile.jl
+rocprof --hsa-trace --roctx-trace julia ./profile.jl
 ```
 
-This will produce `prof_output.pftrace` file which can be visualized
+This enables HSA and ROC-TX (see below) tracing.
+Memory copies and kernel launches are reported as well.
+
+This will produce an `output.json` file which can be visualized
 using [Perfetto UI](https://ui.perfetto.dev/).
+
+#### rocprofv2
+```bash
+rocprofv2 --plugin perfetto --hsa-trace --roctx-trace --kernel-trace -o prof julia ./profile.jl
+```
+
+In principle this should enable various types of tracing,
+but note that on ROCm 6.2.4 only kernel launches seem to be reported.
+
+This will produce a `prof_output.pftrace` file which can be visualized
+using [Perfetto UI](https://ui.perfetto.dev/).
+
+#### rocprofv3
+```bash
+rocprofv3 --output-format pftrace --hsa-trace --marker-trace --kernel-trace --memory-copy-trace  -- julia ./profile.jl
+```
+
+This will produce a number of `prof_output.pftrace` files which can be visualized
+using [Perfetto UI](https://ui.perfetto.dev/).
+
+`rocprofv3` is now recommended by ADM, however on ROCm 6.2.4 nothing seems to be reported.
+
+#### Visualization of the results
+Here is an example of visualizing the `profile.jl` script above in Perfetto.
+Use `W`/`S` to zoom in/out and `A`/`D` to move left/right in the timeline.
 
 ![image](../assets/profile_1.png)
 
@@ -68,6 +108,30 @@ kernel launches are adjacent to each other and that the average
 wall duration is lower.
 
 ![image](../assets/profile_2.png)
+
+### Marking regions
+When launching lots of kernels, it can be difficult to understand
+the trace in terms of high-level program behavior.
+In that case, the ROC-TX API can be used to mark regions that will be visible in the traces.
+
+Here is an example of calling the API directly:
+```julia
+function rangePush(message)
+    @ccall "libroctx64".roctxRangePushA(message::Ptr{Cchar})::Cint
+end
+
+function rangePop()
+    @ccall "libroctx64".roctxRangePop()::Cint
+end
+
+rangePush("Section name")
+# Launch some kernels, call some functions, etc...
+rangePop()
+```
+
+While [ROCTX.jl](https://github.com/JuliaGPU/ROCTX.jl) aims to offer a Julia wrapper around it,
+it does not seem to be working yet. PRs welcome!
+(Note: the `ccall`s above do _not_ require ROCTX.jl to be loaded!)
 
 ## Debugging
 


### PR DESCRIPTION
Hi, this PR is the result of trying to profile some Julia code on LUMI (default ROCm version 6.0.something, there is a build of 6.2.4 available, planned upgrade to 6.3 soon), and eventually succeeding after multiple days. Please let me know if any information is wrong and I will happily correct it. It would also be helpful if others with more experience could run the various commands on other versions of ROCm and see if the situation is different there.

Here is a test script that I used:
```jl
using AMDGPU

function rangePush(message)
    @ccall "libroctx64".roctxRangePushA(message::Ptr{Cchar})::Cint
end

function rangePop()
    @ccall "libroctx64".roctxRangePop()::Cint
end

N = 10000
mat = ROCArray(randn(N, N))
vec = ROCArray(randn(N))

tot = 0.0
for i in 1:10
    rangePush("Iteration $i")
    tot += sum(mat .* vec)
    rangePop()
end
println(tot)
```

PS: Given the existence of https://github.com/JuliaGPU/AMDGPU.jl/pull/801, I suppose that rocprofv3 is not expected to be working yet?