### PR TITLE
Drain sticky HIP error

### DIFF
--- a/src/hip/error.jl
+++ b/src/hip/error.jl
@@ -145,3 +145,17 @@ function check(err::hipError_t)
         throw(HIPError(err))
     end
 end
+
+"""
+    clear_last_error()
+
+Consume any sticky HIP error on the current context without throwing,
+logging it at the `@debug` level if one was present.
+"""
+function clear_last_error()
+    err = @gcsafe_ccall libhip.hipGetLastError()::hipError_t
+    if err != hipSuccess
+        @debug "Cleared sticky HIP error before library call" error=HIPError(err)
+    end
+    return
+end

--- a/src/tls.jl
+++ b/src/tls.jl
@@ -190,6 +190,7 @@ function priority!(f::Function, p::Symbol)
 end
 
 @inline function prepare_state(state = task_local_state!())
+    HIP.clear_last_error() # Drain any sticky HIP error left by a prior kernel failure
     hip_ctx = Ref{HIP.hipCtx_t}()
     HIP.hipCtxGetCurrent(hip_ctx)
     state.context.context != hip_ctx[] &&


### PR DESCRIPTION
After a GPU kernel failure ROCm leaves a sticky error on the HIP context that is returned by every subsequent HIP API call, including `hipCtxGetCurrent`. In CI, ParallelTestRunner reuses worker processes, so an error from test A surfaces as a spurious library failure (`rocsparse_status_internal_error`, `ROCRAND_STATUS_LAUNCH_FAILURE`) in test B.

Add `HIP.clear_last_error()` which calls `hipGetLastError()` to drain the error, and call it at the top of `prepare_state()` which is the shared entry point for all HIP operations.