### PR TITLE
Rework stream finalizer

### DIFF
--- a/src/hip/stream.jl
+++ b/src/hip/stream.jl
@@ -28,10 +28,10 @@ function HIPStream(priority::Symbol = :normal)
     d = device()
     stream = HIPStream(stream_ref[], priority, d, HIPContext(d), true)
     return finalizer(stream) do s
+        Base.@atomic s.valid = false
         AMDGPU.context!(s.ctx) do
             hipStreamDestroy(s.stream)
         end
-        Base.@atomic s.valid = false
     end
 end
 
@@ -51,6 +51,7 @@ function HIPStream(stream::hipStream_t)
 end
 
 function isdone(stream::HIPStream)
+    isvalid(stream) || return true
     query = hipStreamQuery(stream)
     if query == hipSuccess
         return true
@@ -111,7 +112,7 @@ function nonblocking_synchronize(stream::HIPStream)
                     err isa EOFError && break
                     rethrow()
                 end
-                hipStreamQuery(stream) != hipErrorNotReady && break
+                (!isvalid(stream) || hipStreamQuery(stream) != hipErrorNotReady) && break
             end
         finally
             notify(event)

--- a/test/core/tls.jl
+++ b/test/core/tls.jl
@@ -46,10 +46,10 @@ end
 
     @testset "Validity" begin
         s = HIPStream()
-        @test AMDGPU.isvalid(s)
+        @test AMDGPU.HIP.isvalid(s)
 
         finalize(s)
-        @test !AMDGPU.isvalid(s)
+        @test !AMDGPU.HIP.isvalid(s)
 
         # Must return true without segfaulting on an already-finalized stream.
         @test AMDGPU.HIP.isdone(s) == true

--- a/test/core/tls.jl
+++ b/test/core/tls.jl
@@ -43,4 +43,15 @@ end
         s2 = AMDGPU.stream()
         @test s1 ≡ s2
     end
+
+    @testset "Validity" begin
+        s = HIPStream()
+        @test AMDGPU.isvalid(s)
+
+        finalize(s)
+        @test !AMDGPU.isvalid(s)
+
+        # Must return true without segfaulting on an already-finalized stream.
+        @test AMDGPU.HIP.isdone(s) == true
+    end
 end


### PR DESCRIPTION
With HIP 7, passing an invalid `hipStream_t` to stream-related APIs causes a segfault rather than returning `hipErrorContextIsDestroyed`. This adds guards for it in both the finalizer and `isdone()` with an `isvalid` check, and ensure `valid` is set to `false` atomically _before_ `hipStreamDestroy` is called (so any concurrent reader sees the stream as invalid before the handle is freed).