### PR TITLE
Add io stream to versioninfo

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -21,7 +21,7 @@ function versioninfo(io::IO=stdout)
 
     if functional(:hip)
         println(io)
-        @info "AMDGPU devices"
+        println(io, "AMDGPU devices")
         show(io, MIME"text/plain"(), AMDGPU.devices())
         println(io)
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,4 @@
-function versioninfo()
+function versioninfo(io::IO=stdout)
     @info "AMDGPU versioninfo"
     _status(st::Bool) = st ? "+" : "-"
     _libpath(p::String) = isempty(p) ? "-" : p
@@ -15,14 +15,15 @@ function versioninfo()
         _status(functional(:MIOpen))      "MIOpen"           _ver(:MIOpen, MIOpen.version)       _libpath(libMIOpen_path);
     ]
 
-    PrettyTables.pretty_table(data; column_labels=[
+    PrettyTables.pretty_table(io, data; column_labels=[
         "Available", "Name", "Version", "Path"],
         alignment=[:c, :l, :l, :l])
 
     if functional(:hip)
-        println()
+        println(io)
         @info "AMDGPU devices"
-        display(AMDGPU.devices())
+        show(io, MIME"text/plain"(), AMDGPU.devices())
+        println(io)
     end
     return
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,5 @@
 function versioninfo(io::IO=stdout)
-    @info "AMDGPU versioninfo"
+    println(io, "AMDGPU versioninfo")
     _status(st::Bool) = st ? "+" : "-"
     _libpath(p::String) = isempty(p) ? "-" : p
     _ver(lib::Symbol, ver_fn) = functional(lib) ? "$(ver_fn())" : "-"


### PR DESCRIPTION
This PR adds an io stream to `AMDGPU.versioninfo()` to be compatible with KA's interface and implements `KA.versioninfo`.

x-ref https://github.com/JuliaGPU/KernelAbstractions.jl/issues/617#issuecomment-4742139302 and https://github.com/JuliaGPU/KernelAbstractions.jl/pull/712