### PR TITLE
Improve discovery robustness

### DIFF
--- a/src/discovery/utils.jl
+++ b/src/discovery/utils.jl
@@ -9,6 +9,13 @@ function check_rocm_path(path::String)
     isfile(joinpath(path2, libname)) && @goto success
     path2 = joinpath(path, "lib64")
     isfile(joinpath(path2, libname)) && @goto success
+    # Check Debian/Ubuntu multiarch lib paths (e.g. /usr/lib/x86_64-linux-gnu)
+    if Sys.islinux()
+        for triplet in ("x86_64-linux-gnu", "aarch64-linux-gnu", "i386-linux-gnu")
+            path2 = joinpath(path, "lib", triplet)
+            isfile(joinpath(path2, libname)) && @goto success
+        end
+    end
     return ""
 
     @label success
@@ -137,9 +144,10 @@ function find_ld_lld(rocm_path::String)::String
             run(pipeline(`$exp_ld_path -v`; stdout=tmpfile))
             vstr = read(tmpfile, String)
             rm(tmpfile)
-            vstr = replace(vstr, "AMD " => "")
-            vstr_splits = split(vstr, ' ')
-            if VersionNumber(vstr_splits[2]) >= v"6.0.0"
+            # Match first version number in the output, e.g.:
+            # "AMD LLD 15.0.0 ..." or "Ubuntu LLD 21.0.0 ..."
+            m = match(r"(\d+\.\d+(?:\.\d+)?)", vstr)
+            if m !== nothing && VersionNumber(m.captures[1]) >= v"6.0.0"
                 return exp_ld_path
             end
         catch

--- a/src/discovery/utils.jl
+++ b/src/discovery/utils.jl
@@ -144,8 +144,7 @@ function find_ld_lld(rocm_path::String)::String
             run(pipeline(`$exp_ld_path -v`; stdout=tmpfile))
             vstr = read(tmpfile, String)
             rm(tmpfile)
-            # Match first version number in the output, e.g.:
-            # "AMD LLD 15.0.0 ..." or "Ubuntu LLD 21.0.0 ..."
+            # Match first version number in the output, e.g. "AMD LLD 15.0.0 ..." or "Ubuntu LLD 21.0.0 ..."
             m = match(r"(\d+\.\d+(?:\.\d+)?)", vstr)
             if m !== nothing && VersionNumber(m.captures[1]) >= v"6.0.0"
                 return exp_ld_path


### PR DESCRIPTION
Ubuntu 26 ships ROCm to be installed with `apt` in a location AMDGPU does not yet expects and with modified LLD naming which causes issues https://github.com/JuliaGPU/AMDGPU.jl/issues/920#issuecomment-4536656216.