### PR TITLE
Fix rocFFT error with multiple tasks

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -43,7 +43,7 @@ steps:
       rocmgpu: "*"
     if: build.message !~ /\[skip tests\]/
     command: "julia --project -e 'using Pkg; Pkg.update()'"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 90
     env:
       JULIA_NUM_THREADS: 4
       JULIA_AMDGPU_CORE_MUST_LOAD: "1"
@@ -62,7 +62,7 @@ steps:
       rocmgpu: "*"
     if: build.message !~ /\[skip tests\]/
     command: "julia --project -e 'using Pkg; Pkg.update()'"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 90
     env:
       JULIA_NUM_THREADS: 4
       JULIA_AMDGPU_CORE_MUST_LOAD: "1"
@@ -81,7 +81,7 @@ steps:
       rocmgpu: "*"
     if: build.message !~ /\[skip tests\]/
     command: "julia --project -e 'using Pkg; Pkg.update()'"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 90
     env:
       JULIA_NUM_THREADS: 4
       JULIA_AMDGPU_CORE_MUST_LOAD: "1"
@@ -100,7 +100,7 @@ steps:
       rocmgpu: "*"
     if: build.message !~ /\[skip tests\]/
     command: "julia --project -e 'using Pkg; Pkg.update()'"
-    timeout_in_minutes: 60
+    timeout_in_minutes: 90
     soft_fail: true
     env:
       JULIA_NUM_THREADS: 4

--- a/src/fft/fft.jl
+++ b/src/fft/fft.jl
@@ -15,7 +15,6 @@ function AMDGPU.unsafe_free!(plan::ROCFFTPlan)
         unsafe_free!(plan.buffer)
     end
     unsafe_free!(plan.workarea)
-    rocfft_execution_info_destroy(plan.execution_info)
 end
 
 const ROCFFT_FORWARD = true
@@ -27,9 +26,7 @@ const ROCFFT_INVERSE = false
 # K is flag for forward/inverse
 mutable struct cROCFFTPlan{T,K,inplace,N,R,B} <: ROCFFTPlan{T, K, inplace}
     handle::rocfft_plan
-    stream::HIPStream
     workarea::ROCVector{Int8}
-    execution_info::rocfft_execution_info
     sz::NTuple{N, Int} # Julia size of input array
     osz::NTuple{N, Int} # Julia size of output array
     xtype::rocfft_transform_type
@@ -47,25 +44,14 @@ mutable struct cROCFFTPlan{T,K,inplace,N,R,B} <: ROCFFTPlan{T, K, inplace}
         xtype::rocfft_transform_type, region::NTuple{R,Int},
         buffer::B, input_sz_as_key::Bool, key_T::Type,
     ) where {T,K,inplace,N,R,B}
-        info_ref = Ref{rocfft_execution_info}()
-        rocfft_execution_info_create(info_ref)
-        info = info_ref[]
-
-        stream = AMDGPU.stream()
-        rocfft_execution_info_set_stream(info, stream)
-        if length(workarea) > 0
-            rocfft_execution_info_set_work_buffer(info, workarea, length(workarea))
-        end
-        p = new(handle, stream, workarea, info, size(X), sizey, xtype, region, buffer, input_sz_as_key, key_T)
+        p = new(handle, workarea, size(X), sizey, xtype, region, buffer, input_sz_as_key, key_T)
         return finalizer(AMDGPU.unsafe_free!, p)
     end
 end
 
 mutable struct rROCFFTPlan{T,K,inplace,N,R,B} <: ROCFFTPlan{T,K,inplace}
     handle::rocfft_plan
-    stream::HIPStream
     workarea::ROCVector{Int8}
-    execution_info::rocfft_execution_info
     sz::NTuple{N,Int} # Julia size of input array
     osz::NTuple{N,Int} # Julia size of output array
     xtype::rocfft_transform_type
@@ -82,25 +68,23 @@ mutable struct rROCFFTPlan{T,K,inplace,N,R,B} <: ROCFFTPlan{T,K,inplace}
         sizey::Tuple, xtype::rocfft_transform_type, region::NTuple{R,Int},
         buffer::B, input_sz_as_key::Bool, key_T::Type,
     ) where {T,inplace,N,K,R,B}
-        info_ref = Ref{rocfft_execution_info}()
-        rocfft_execution_info_create(info_ref)
-        info = info_ref[]
-
-        stream = AMDGPU.stream()
-        rocfft_execution_info_set_stream(info, stream)
-        if length(workarea) > 0
-            rocfft_execution_info_set_work_buffer(info, workarea, length(workarea))
-        end
-        p = new(handle, stream, workarea, info, size(X), sizey, xtype, region, buffer, input_sz_as_key, key_T)
+        p = new(handle, workarea, size(X), sizey, xtype, region, buffer, input_sz_as_key, key_T)
         return finalizer(unsafe_free!, p)
     end
 end
 
-function update_stream!(plan::ROCFFTPlan)
-    new_stream = AMDGPU.stream()
-    plan.stream = new_stream
-    rocfft_execution_info_set_stream(plan.execution_info, new_stream)
-    return
+# Create a per-call execution_info with the current task's stream and workbuffer.
+# rocfft_execution_info_set_stream must be called on the same OS thread as rocfft_execute;
+# creating it fresh per-call avoids any OS-thread binding issues from task migration.
+function make_execution_info(plan::ROCFFTPlan)
+    info_ref = Ref{rocfft_execution_info}()
+    rocfft_execution_info_create(info_ref)
+    info = info_ref[]
+    rocfft_execution_info_set_stream(info, AMDGPU.stream())
+    if length(plan.workarea) > 0
+        rocfft_execution_info_set_work_buffer(info, plan.workarea, length(plan.workarea))
+    end
+    return info
 end
 
 const xtypenames = ("complex forward", "complex inverse", "real forward", "real inverse")
@@ -254,15 +238,17 @@ function assert_applicable(p::ROCFFTPlan{T,K}, X::ROCArray{T}, Y::ROCArray{Ty}) 
 end
 
 function unsafe_execute!(plan::cROCFFTPlan{T,K,true,N}, X::ROCArray{T,N}) where {T,K,N}
-    update_stream!(plan)
-    rocfft_execute(plan, [pointer(X),], C_NULL, plan.execution_info)
+    info = make_execution_info(plan)
+    rocfft_execute(plan, [pointer(X),], C_NULL, info)
+    rocfft_execution_info_destroy(info)
 end
 
 function unsafe_execute!(
     plan::cROCFFTPlan{T,K,false,N}, X::ROCArray{T,N}, Y::ROCArray{T},
 ) where {T,N,K}
-    update_stream!(plan)
-    rocfft_execute(plan, [pointer(X),], [pointer(Y),], plan.execution_info)
+    info = make_execution_info(plan)
+    rocfft_execute(plan, [pointer(X),], [pointer(Y),], info)
+    rocfft_execution_info_destroy(info)
 end
 
 function unsafe_execute!(
@@ -270,8 +256,9 @@ function unsafe_execute!(
     X::ROCArray{T,N}, Y::ROCArray{<:rocfftComplexes,N},
 ) where {T<:rocfftReals,N}
     @assert plan.xtype == rocfft_transform_type_real_forward
-    update_stream!(plan)
-    rocfft_execute(plan, [pointer(X),], [pointer(Y),], plan.execution_info)
+    info = make_execution_info(plan)
+    rocfft_execute(plan, [pointer(X),], [pointer(Y),], info)
+    rocfft_execution_info_destroy(info)
 end
 
 function unsafe_execute!(
@@ -279,8 +266,9 @@ function unsafe_execute!(
     X::ROCArray{T,N}, Y::ROCArray{<:rocfftReals,N},
 ) where {T<:rocfftComplexes,N}
     @assert plan.xtype == rocfft_transform_type_real_inverse
-    update_stream!(plan)
-    rocfft_execute(plan, [pointer(X),], [pointer(Y),], plan.execution_info)
+    info = make_execution_info(plan)
+    rocfft_execute(plan, [pointer(X),], [pointer(Y),], info)
+    rocfft_execution_info_destroy(info)
 end
 
 function LinearAlgebra.mul!(y::ROCArray{Ty}, p::ROCFFTPlan{T,K,false}, x::ROCArray{T}) where {T,Ty,K}

--- a/src/fft/fft.jl
+++ b/src/fft/fft.jl
@@ -51,7 +51,6 @@ mutable struct cROCFFTPlan{T,K,inplace,N,R,B} <: ROCFFTPlan{T, K, inplace}
         rocfft_execution_info_create(info_ref)
         info = info_ref[]
 
-        # assign to the current stream
         stream = AMDGPU.stream()
         rocfft_execution_info_set_stream(info, stream)
         if length(workarea) > 0
@@ -99,11 +98,8 @@ end
 
 function update_stream!(plan::ROCFFTPlan)
     new_stream = AMDGPU.stream()
-    if plan.stream != new_stream
-        plan.stream = new_stream
-        info = plan.execution_info
-        rocfft_execution_info_set_stream(info, new_stream)
-    end
+    plan.stream = new_stream
+    rocfft_execution_info_set_stream(plan.execution_info, new_stream)
     return
 end
 

--- a/src/fft/fft.jl
+++ b/src/fft/fft.jl
@@ -76,15 +76,19 @@ end
 # Create a per-call execution_info with the current task's stream and workbuffer.
 # rocfft_execution_info_set_stream must be called on the same OS thread as rocfft_execute;
 # creating it fresh per-call avoids any OS-thread binding issues from task migration.
-function make_execution_info(plan::ROCFFTPlan)
+function with_execution_info(f::F, plan::ROCFFTPlan) where {F}
     info_ref = Ref{rocfft_execution_info}()
     rocfft_execution_info_create(info_ref)
     info = info_ref[]
-    rocfft_execution_info_set_stream(info, AMDGPU.stream())
-    if length(plan.workarea) > 0
-        rocfft_execution_info_set_work_buffer(info, plan.workarea, length(plan.workarea))
+    try
+        rocfft_execution_info_set_stream(info, AMDGPU.stream())
+        if length(plan.workarea) > 0
+            rocfft_execution_info_set_work_buffer(info, plan.workarea, length(plan.workarea))
+        end
+        return f(info)
+    finally
+        rocfft_execution_info_destroy(info)
     end
-    return info
 end
 
 const xtypenames = ("complex forward", "complex inverse", "real forward", "real inverse")
@@ -238,17 +242,20 @@ function assert_applicable(p::ROCFFTPlan{T,K}, X::ROCArray{T}, Y::ROCArray{Ty}) 
 end
 
 function unsafe_execute!(plan::cROCFFTPlan{T,K,true,N}, X::ROCArray{T,N}) where {T,K,N}
-    info = make_execution_info(plan)
-    rocfft_execute(plan, [pointer(X),], C_NULL, info)
-    rocfft_execution_info_destroy(info)
+    in_buffer = [pointer(X)]
+    with_execution_info(plan) do info
+        rocfft_execute(plan, in_buffer, C_NULL, info)
+    end
 end
 
 function unsafe_execute!(
     plan::cROCFFTPlan{T,K,false,N}, X::ROCArray{T,N}, Y::ROCArray{T},
 ) where {T,N,K}
-    info = make_execution_info(plan)
-    rocfft_execute(plan, [pointer(X),], [pointer(Y),], info)
-    rocfft_execution_info_destroy(info)
+    in_buffer = [pointer(X)]
+    out_buffer = [pointer(Y)]
+    with_execution_info(plan) do info
+        rocfft_execute(plan, in_buffer, out_buffer, info)
+    end
 end
 
 function unsafe_execute!(
@@ -256,9 +263,11 @@ function unsafe_execute!(
     X::ROCArray{T,N}, Y::ROCArray{<:rocfftComplexes,N},
 ) where {T<:rocfftReals,N}
     @assert plan.xtype == rocfft_transform_type_real_forward
-    info = make_execution_info(plan)
-    rocfft_execute(plan, [pointer(X),], [pointer(Y),], info)
-    rocfft_execution_info_destroy(info)
+    in_buffer = [pointer(X)]
+    out_buffer = [pointer(Y)]
+    with_execution_info(plan) do info
+        rocfft_execute(plan, in_buffer, out_buffer, info)
+    end
 end
 
 function unsafe_execute!(
@@ -266,9 +275,11 @@ function unsafe_execute!(
     X::ROCArray{T,N}, Y::ROCArray{<:rocfftReals,N},
 ) where {T<:rocfftComplexes,N}
     @assert plan.xtype == rocfft_transform_type_real_inverse
-    info = make_execution_info(plan)
-    rocfft_execute(plan, [pointer(X),], [pointer(Y),], info)
-    rocfft_execution_info_destroy(info)
+    in_buffer = [pointer(X)]
+    out_buffer = [pointer(Y)]
+    with_execution_info(plan) do info
+        rocfft_execute(plan, in_buffer, out_buffer, info)
+    end
 end
 
 function LinearAlgebra.mul!(y::ROCArray{Ty}, p::ROCFFTPlan{T,K,false}, x::ROCArray{T}) where {T,Ty,K}

--- a/test/hip_rocarray/fft.jl
+++ b/test/hip_rocarray/fft.jl
@@ -357,10 +357,15 @@ end
 
     Y = p * X
 
-    task = Threads.@spawn d_p * d_X  # executes FFT on separate AMDGPU stream
-    d_Y = fetch(task)
+    for _ in 1:10
+        task = Threads.@spawn begin # executes FFT on separate AMDGPU stream
+            yield()
+            d_p * d_X
+        end
+        d_Y = fetch(task)
 
-    @test isapprox(collect(d_Y), Y; rtol=MYRTOL, atol=MYATOL)
+        @test isapprox(collect(d_Y), Y; rtol=MYRTOL, atol=MYATOL)
+    end
 end
 
 end # testset FFT


### PR DESCRIPTION
### Problem

Running FFT operations on a `Threads.@spawn`-ed task (or any task other than the one that created the plan) would intermittently produce `rocfft_status_failure`. This was observed in CI when running tests in parallel on MI300.

The root cause is a constraint in the rocFFT API: `rocfft_execution_info_set_stream` must be called on the same OS thread as the subsequent `rocfft_execute`. Julia tasks can migrate between OS threads at yield points, so storing a single `rocfft_execution_info` per plan and updating its stream before execution is not sufficient — the task may land on a different OS thread between the stream update and the actual execute call. rocFFT's OS-thread constraint applies to the entire `create → set_stream → execute` sequence.

### Fix

`rocfft_execution_info` is now created fresh per execution inside each `unsafe_execute!` call, rather than being stored in the plan struct. The stream and work buffer are set immediately before `rocfft_execute`, with no yield points between setup and execution. The `execution_info` is destroyed after each call.

This matches the intended C++ usage pattern: `rocfft_plan` is the expensive, reusable, thread-safe object; `rocfft_execution_info` is a lightweight per-call envelope carrying runtime context (stream, work buffer). The `plan.stream` and `plan.execution_info` fields are removed from both plan structs accordingly.