### PR TITLE
Fix segfault in qr(dA) \ b

### DIFF
--- a/src/solver/highlevel.jl
+++ b/src/solver/highlevel.jl
@@ -561,23 +561,23 @@ LinearAlgebra.lmul!(
 ) where T =
     ormqr!('L', 'N', A.factors, A.τ, B)
 
+# Julia 1.10+ returns AdjointQ (not Adjoint/Transpose) from adjoint(::AbstractQ) and
+# transpose(::AbstractQ{<:Real}).  Julia 1.12 added a BLAS-backed
+# lmul!(::AdjointQ{…,<:QRPackedQ{T,<:StridedMatrix}}, ::StridedVecOrMat{T}) that
+# matches ROCArrays (ROCArray <: DenseArray <: StridedArray) and calls CPU OpenBLAS
+# with a GPU pointer → segfault.  The Adjoint/Transpose wrappers are never produced
+# for AbstractQ on Julia ≥ 1.10 (AMDGPU's minimum), so only AdjointQ overloads are needed.
 LinearAlgebra.lmul!(
-    adjA::Adjoint{T,<:QRPackedQ{T,<:ROCArray,<:ROCArray}},
+    adjA::LinearAlgebra.AdjointQ{<:Any,<:QRPackedQ{T,<:ROCArray,<:ROCArray}},
     B::ROCVecOrMat{T},
 ) where T <: rocBLAS.ROCBLASReal =
-    ormqr!('L', 'T', parent(adjA).factors, parent(adjA).τ, B)
+    ormqr!('L', 'T', adjA.Q.factors, adjA.Q.τ, B)
 
 LinearAlgebra.lmul!(
-    adjA::Adjoint{T,<:QRPackedQ{T,<:ROCArray,<:ROCArray}},
+    adjA::LinearAlgebra.AdjointQ{<:Any,<:QRPackedQ{T,<:ROCArray,<:ROCArray}},
     B::ROCVecOrMat{T},
 ) where T <: rocBLAS.ROCBLASComplex =
-    ormqr!('L', 'C', parent(adjA).factors, parent(adjA).τ, B)
-
-LinearAlgebra.lmul!(
-    trA::Transpose{T,<:QRPackedQ{T,<:ROCArray,<:ROCArray}},
-    B::ROCVecOrMat{T},
-) where T <: rocBLAS.ROCBLASFloat =
-    ormqr!('L', 'T', parent(trA).factors, parent(trA).τ, B)
+    ormqr!('L', 'C', adjA.Q.factors, adjA.Q.τ, B)
 
 LinearAlgebra.rmul!(
     A::ROCVecOrMat{T},
@@ -587,21 +587,15 @@ LinearAlgebra.rmul!(
 
 LinearAlgebra.rmul!(
     A::ROCVecOrMat{T},
-    adjB::Adjoint{<:Any,<:QRPackedQ{T,<:ROCArray,<:ROCArray}},
+    adjB::LinearAlgebra.AdjointQ{<:Any,<:QRPackedQ{T,<:ROCArray,<:ROCArray}},
 ) where T <: rocBLAS.ROCBLASReal =
-    ormqr!('R', 'T', parent(adjB).factors, parent(adjB).τ, A)
+    ormqr!('R', 'T', adjB.Q.factors, adjB.Q.τ, A)
 
 LinearAlgebra.rmul!(
     A::ROCVecOrMat{T},
-    adjB::Adjoint{<:Any,<:QRPackedQ{T,<:ROCArray,<:ROCArray}},
+    adjB::LinearAlgebra.AdjointQ{<:Any,<:QRPackedQ{T,<:ROCArray,<:ROCArray}},
 ) where T <: rocBLAS.ROCBLASComplex =
-    ormqr!('R', 'C', parent(adjB).factors, parent(adjB).τ, A)
-
-LinearAlgebra.rmul!(
-    A::ROCVecOrMat{T},
-    trA::Transpose{<:Any,<:QRPackedQ{T,<:ROCArray,<:ROCArray}},
-) where T <: rocBLAS.ROCBLASFloat =
-    ormqr!('R', 'T', parent(trA).factors, parent(adjB).τ, A)
+    ormqr!('R', 'C', adjB.Q.factors, adjB.Q.τ, A)
 
 function LinearAlgebra.ldiv!(_qr::QR, b::ROCVector)
     m, n = size(_qr)

--- a/src/solver/highlevel.jl
+++ b/src/solver/highlevel.jl
@@ -561,12 +561,6 @@ LinearAlgebra.lmul!(
 ) where T =
     ormqr!('L', 'N', A.factors, A.τ, B)
 
-# Julia 1.10+ returns AdjointQ (not Adjoint/Transpose) from adjoint(::AbstractQ) and
-# transpose(::AbstractQ{<:Real}).  Julia 1.12 added a BLAS-backed
-# lmul!(::AdjointQ{…,<:QRPackedQ{T,<:StridedMatrix}}, ::StridedVecOrMat{T}) that
-# matches ROCArrays (ROCArray <: DenseArray <: StridedArray) and calls CPU OpenBLAS
-# with a GPU pointer → segfault.  The Adjoint/Transpose wrappers are never produced
-# for AbstractQ on Julia ≥ 1.10 (AMDGPU's minimum), so only AdjointQ overloads are needed.
 LinearAlgebra.lmul!(
     adjA::LinearAlgebra.AdjointQ{<:Any,<:QRPackedQ{T,<:ROCArray,<:ROCArray}},
     B::ROCVecOrMat{T},

--- a/src/solver/highlevel.jl
+++ b/src/solver/highlevel.jl
@@ -104,7 +104,7 @@ for (fname, elty) in (
     @eval begin
         function ormqr!(
             side::Char, trans::Char, A::ROCMatrix{$elty},
-            τ::ROCVector{$elty}, C::ROCVecOrMat{$elty},
+            τ::ROCVector{$elty}, C::StridedROCVecOrMat{$elty},
         )
             $elty <: Complex && trans == 'T' && throw(ArgumentError(
                 "rocSOLVER.ormqr! supports only 'N' or 'C' for Complex types, " *
@@ -557,36 +557,36 @@ end
 LinearAlgebra.qr!(A::ROCMatrix{T}) where T = QR(geqrf!(A)...)
 
 LinearAlgebra.lmul!(
-    A::QRPackedQ{T,<:ROCArray,<:ROCArray}, B::ROCVecOrMat{T},
+    A::QRPackedQ{T,<:ROCArray,<:ROCArray}, B::StridedROCVecOrMat{T},
 ) where T =
     ormqr!('L', 'N', A.factors, A.τ, B)
 
 LinearAlgebra.lmul!(
     adjA::LinearAlgebra.AdjointQ{<:Any,<:QRPackedQ{T,<:ROCArray,<:ROCArray}},
-    B::ROCVecOrMat{T},
+    B::StridedROCVecOrMat{T},
 ) where T <: rocBLAS.ROCBLASReal =
     ormqr!('L', 'T', adjA.Q.factors, adjA.Q.τ, B)
 
 LinearAlgebra.lmul!(
     adjA::LinearAlgebra.AdjointQ{<:Any,<:QRPackedQ{T,<:ROCArray,<:ROCArray}},
-    B::ROCVecOrMat{T},
+    B::StridedROCVecOrMat{T},
 ) where T <: rocBLAS.ROCBLASComplex =
     ormqr!('L', 'C', adjA.Q.factors, adjA.Q.τ, B)
 
 LinearAlgebra.rmul!(
-    A::ROCVecOrMat{T},
+    A::StridedROCVecOrMat{T},
     B::QRPackedQ{T,<:ROCArray,<:ROCArray},
 ) where T <: rocBLAS.ROCBLASFloat =
     ormqr!('R', 'N', B.factors, B.τ, A)
 
 LinearAlgebra.rmul!(
-    A::ROCVecOrMat{T},
+    A::StridedROCVecOrMat{T},
     adjB::LinearAlgebra.AdjointQ{<:Any,<:QRPackedQ{T,<:ROCArray,<:ROCArray}},
 ) where T <: rocBLAS.ROCBLASReal =
     ormqr!('R', 'T', adjB.Q.factors, adjB.Q.τ, A)
 
 LinearAlgebra.rmul!(
-    A::ROCVecOrMat{T},
+    A::StridedROCVecOrMat{T},
     adjB::LinearAlgebra.AdjointQ{<:Any,<:QRPackedQ{T,<:ROCArray,<:ROCArray}},
 ) where T <: rocBLAS.ROCBLASComplex =
     ormqr!('R', 'C', adjB.Q.factors, adjB.Q.τ, A)
@@ -614,6 +614,18 @@ function LinearAlgebra.ldiv!(x::ROCArray, _qr::QR, b::ROCArray)
     return x
 end
 
+# Override \ for GPU QR to avoid stdlib's _zeros() allocating CPU arrays.
+# LinearAlgebra's generic ldiv() calls _zeros(T, b, n) = zeros(T, n) which
+# always produces a CPU Vector regardless of b's type, causing the subsequent
+# ldiv!/lmul! chain to mix GPU factors with CPU data → segfault via OpenBLAS.
+function Base.:\(F::QR{T,<:ROCMatrix,<:ROCVector}, b::ROCVector{T}) where T
+    ldiv!(F, copy(b))
+end
+
+function Base.:\(F::QR{T,<:ROCMatrix,<:ROCVector}, B::ROCMatrix{T}) where T
+    ldiv!(F, copy(B))
+end
+
 # LAPACK
 
 for elty in (:Float32, :Float64, :ComplexF32, :ComplexF64)
@@ -627,7 +639,7 @@ for elty in (:Float32, :Float64, :ComplexF32, :ComplexF64)
         LinearAlgebra.LAPACK.getrf!(A::ROCMatrix{$elty}) = rocSOLVER.getrf!(A)
         LinearAlgebra.LAPACK.getrf!(A::ROCMatrix{$elty}, ipiv::ROCVector{Cint}) = rocSOLVER.getrf!(A, ipiv)
         LinearAlgebra.LAPACK.getrs!(trans::Char, A::ROCMatrix{$elty}, ipiv::ROCVector{Cint}, B::ROCVecOrMat{$elty}) = rocSOLVER.getrs!(trans, A, ipiv, B)
-        LinearAlgebra.LAPACK.ormqr!(side::Char, trans::Char, A::ROCMatrix{$elty}, tau::ROCVector{$elty}, C::ROCVecOrMat{$elty}) = rocSOLVER.ormqr!(side, trans, A, tau, C)
+        LinearAlgebra.LAPACK.ormqr!(side::Char, trans::Char, A::ROCMatrix{$elty}, tau::ROCVector{$elty}, C::StridedROCVecOrMat{$elty}) = rocSOLVER.ormqr!(side, trans, A, tau, C)
         LinearAlgebra.LAPACK.orgqr!(A::ROCMatrix{$elty}, tau::ROCVector{$elty}) = rocSOLVER.orgqr!(A, tau)
         LinearAlgebra.LAPACK.gebrd!(A::ROCMatrix{$elty}) = rocSOLVER.gebrd!(A)
         LinearAlgebra.LAPACK.gesvd!(jobu::Char, jobvt::Char, A::ROCMatrix{$elty}) = rocSOLVER.gesvd!(jobu, jobvt, A)

--- a/src/solver/highlevel.jl
+++ b/src/solver/highlevel.jl
@@ -615,9 +615,6 @@ function LinearAlgebra.ldiv!(x::ROCArray, _qr::QR, b::ROCArray)
 end
 
 # Override \ for GPU QR to avoid stdlib's _zeros() allocating CPU arrays.
-# LinearAlgebra's generic ldiv() calls _zeros(T, b, n) = zeros(T, n) which
-# always produces a CPU Vector regardless of b's type, causing the subsequent
-# ldiv!/lmul! chain to mix GPU factors with CPU data → segfault via OpenBLAS.
 function Base.:\(F::QR{T,<:ROCMatrix,<:ROCVector}, b::ROCVector{T}) where T
     ldiv!(F, copy(b))
 end

--- a/src/solver/highlevel.jl
+++ b/src/solver/highlevel.jl
@@ -619,8 +619,18 @@ function Base.:\(F::QR{T,<:ROCMatrix,<:ROCVector}, b::ROCVector{T}) where T
     ldiv!(F, copy(b))
 end
 
+function Base.:\(F::QR{<:Any,<:ROCMatrix,<:ROCVector}, b::ROCVector)
+    factors, τ, b = copy_rocblasfloat(F.factors, F.τ, b)
+    ldiv!(QR(factors, τ), b)
+end
+
 function Base.:\(F::QR{T,<:ROCMatrix,<:ROCVector}, B::ROCMatrix{T}) where T
     ldiv!(F, copy(B))
+end
+
+function Base.:\(F::QR{<:Any,<:ROCMatrix,<:ROCVector}, B::ROCMatrix)
+    factors, τ, B = copy_rocblasfloat(F.factors, F.τ, B)
+    ldiv!(QR(factors, τ), B)
 end
 
 # LAPACK

--- a/test/hip_rocarray/solver.jl
+++ b/test/hip_rocarray/solver.jl
@@ -50,6 +50,17 @@ p = 5
         @test collect(dQ * dR) ≈ A
         @test collect(dR * dQ') ≈ (R * Q')
 
+        # Explicit lmul!/rmul! coverage for AdjointQ paths (Julia 1.10+).
+        dC = ROCMatrix{elty}(I, m, m)
+        @test collect(lmul!(dF.Q, copy(dC)))  ≈ lmul!(F.Q, Matrix{elty}(I, m, m))
+        @test collect(lmul!(dF.Q', copy(dC))) ≈ lmul!(F.Q', Matrix{elty}(I, m, m))
+        @test collect(rmul!(copy(dC), dF.Q))  ≈ rmul!(Matrix{elty}(I, m, m), F.Q)
+        @test collect(rmul!(copy(dC), dF.Q')) ≈ rmul!(Matrix{elty}(I, m, m), F.Q')
+        if elty <: Real
+            @test collect(lmul!(transpose(dF.Q), copy(dC))) ≈ lmul!(transpose(F.Q), Matrix{elty}(I, m, m))
+            @test collect(rmul!(copy(dC), transpose(dF.Q))) ≈ rmul!(Matrix{elty}(I, m, m), transpose(F.Q))
+        end
+
         A = rand(elty, n, m)
         dA = ROCArray(A)
         dF = qr(dA)
@@ -137,6 +148,16 @@ end
         db = ldiv!(dy, qr(dA), dx)
         @test Array(db) ≈ b
     end
+
+    @testset "qr(dA) \\ b, elty = $elty" for elty in [Float32, Float64, ComplexF32, ComplexF64]
+        A = rand(elty, m, n)
+        b = rand(elty, m)
+        B = rand(elty, m, p)
+        dA, db, dB = ROCArray(A), ROCArray(b), ROCArray(B)
+
+        @test Array(qr(dA) \ db) ≈ qr(A) \ b
+        @test Array(qr(dA) \ dB) ≈ qr(A) \ B
+    end
 end
 
 @testset "geqrf! -- omgqr!" begin
@@ -204,7 +225,7 @@ end
         @test B ≈ collect(d_B)
     end
 
-        
+
 end
 
 @testset "sytrf!" begin

--- a/test/hip_rocarray/solver.jl
+++ b/test/hip_rocarray/solver.jl
@@ -158,6 +158,16 @@ end
         @test Array(qr(dA) \ db) ≈ qr(A) \ b
         @test Array(qr(dA) \ dB) ≈ qr(A) \ B
     end
+
+    @testset "qr(dA) \\ b mixed eltypes" begin
+        A = rand(Float32, m, n)
+        b = rand(Float64, m)
+        B = rand(Float64, m, p)
+        dA, db, dB = ROCArray(A), ROCArray(b), ROCArray(B)
+
+        @test Array(qr(dA) \ db) ≈ qr(A) \ b rtol=sqrt(eps(Float32))
+        @test Array(qr(dA) \ dB) ≈ qr(A) \ B rtol=sqrt(eps(Float32))
+    end
 end
 
 @testset "geqrf! -- omgqr!" begin


### PR DESCRIPTION
### Problem

On Julia 1.10+, `adjoint(Q::AbstractQ)` returns `LinearAlgebra.AdjointQ`, not `Adjoint`, making the six existing `lmul!`/`rmul!` overloads on `Adjoint{T,<:QRPackedQ}` / `Transpose{T,<:QRPackedQ}` dead code. Julia 1.12 then added:

```julia
lmul!(adjQ::AdjointQ{<:Any,<:QRPackedQ{T,<:StridedMatrix}}, B::StridedVecOrMat{T})
```

Since `ROCArray <: StridedArray`, this matches GPU arrays and calls CPU OpenBLAS with a GPU pointer → segfault.

`qr(dA) \ b` was also broken independently: stdlib's `\(Factorization, b)` allocates the output with `zeros(T, n)` — always a CPU array — then passes it through `ldiv!` mixing GPU factors with CPU data → segfault.

### Fix

- Replace the six dead `Adjoint`/`Transpose`-based overloads with `AdjointQ`-based ones, widening `B` to `StridedROCVecOrMat` to also cover SubArray views produced by stdlib internals.
- Add `Base.:\` overloads for `QR{T,<:ROCMatrix,<:ROCVector}` that call `ldiv!(F, copy(b))` directly, bypassing the `zeros(T, n)` CPU allocation.
- Widen `ormqr!` / `LAPACK.ormqr!` to accept `StridedROCVecOrMat`.

### Tests

- `qr(dA) \ b` and `qr(dA) \ B` (tall matrix, vector and matrix RHS)
- Explicit `lmul!`/`rmul!` for `Q`, `Q'`, and `transpose(Q)` (real types)
- `ldiv!(qr(dA), dx)` and `ldiv!(dy, qr(dA), dx)`