### PR TITLE
Add `cholesky(dA) \ b` and `lu(dA) \ b` GPU support

### DIFF
--- a/src/solver/highlevel.jl
+++ b/src/solver/highlevel.jl
@@ -645,8 +645,18 @@ function Base.:\(F::Cholesky{T,<:ROCMatrix}, b::ROCVector{T}) where T
     ldiv!(F, copy(b))
 end
 
+function Base.:\(F::Cholesky{<:Any,<:ROCMatrix}, b::ROCVector)
+    factors, b = copy_rocblasfloat(F.factors, b)
+    ldiv!(Cholesky(factors, F.uplo, F.info), b)
+end
+
 function Base.:\(F::Cholesky{T,<:ROCMatrix}, B::ROCMatrix{T}) where T
     ldiv!(F, copy(B))
+end
+
+function Base.:\(F::Cholesky{<:Any,<:ROCMatrix}, B::ROCMatrix)
+    factors, B = copy_rocblasfloat(F.factors, B)
+    ldiv!(Cholesky(factors, F.uplo, F.info), B)
 end
 
 # LU
@@ -659,16 +669,27 @@ function Base.:\(F::LU{T,<:ROCMatrix,<:ROCVector{Cint}}, b::ROCVector{T}) where 
     ldiv!(F, copy(b))
 end
 
+function Base.:\(F::LU{<:Any,<:ROCMatrix,<:ROCVector{Cint}}, b::ROCVector)
+    factors, b = copy_rocblasfloat(F.factors, b)
+    ldiv!(LU{eltype(factors),typeof(factors),typeof(F.ipiv)}(factors, F.ipiv, F.info), b)
+end
+
 function Base.:\(F::LU{T,<:ROCMatrix,<:ROCVector{Cint}}, B::ROCMatrix{T}) where T
     ldiv!(F, copy(B))
+end
+
+function Base.:\(F::LU{<:Any,<:ROCMatrix,<:ROCVector{Cint}}, B::ROCMatrix)
+    factors, B = copy_rocblasfloat(F.factors, B)
+    ldiv!(LU{eltype(factors),typeof(factors),typeof(F.ipiv)}(factors, F.ipiv, F.info), B)
 end
 
 function LinearAlgebra.lu!(
     A::ROCMatrix{T}, ::LinearAlgebra.RowMaximum = LinearAlgebra.RowMaximum();
     check::Bool = true,
+    allowsingular::Bool = false,
 ) where T <: rocBLAS.ROCBLASFloat
     factors, ipiv, info = rocSOLVER.getrf!(A)
-    check && LinearAlgebra.checknonsingular(BlasInt(info))
+    check && !allowsingular && LinearAlgebra.checknonsingular(BlasInt(info))
     return LU{T,typeof(factors),typeof(ipiv)}(factors, ipiv, BlasInt(info))
 end
 

--- a/src/solver/highlevel.jl
+++ b/src/solver/highlevel.jl
@@ -29,13 +29,14 @@ for (fname, elty) in (
     (:rocsolver_zpotrs, :ComplexF64),
 )
     @eval begin
-        function potrs!(uplo::Char, A::ROCMatrix{$elty}, B::ROCVecOrMat{$elty})
+        function potrs!(uplo::Char, A::ROCMatrix{$elty}, B::StridedROCVecOrMat{$elty})
             chkuplo(uplo)
             n = checksquare(A)
-            m, nrhs = size(B)
+            m = size(B, 1)
+            nrhs = size(B, 2)
             (m == n) || throw(DimensionMismatch("first dimension of B, $m, must match second dimension of A, $n"))
-            lda  = max(1, stride(A, 2))
-            ldb  = max(1, stride(B, 2))
+            lda = max(1, stride(A, 2))
+            ldb = max(1, stride(B, 2))
             $fname(rocBLAS.handle(), uplo, n, nrhs, A, lda, B, ldb)
 
             B
@@ -191,7 +192,7 @@ for (fname, elty) in (
     @eval begin
         function getrs!(
             trans::Char, A::ROCMatrix{$elty}, ipiv::ROCVector{Cint},
-            B::ROCVecOrMat{$elty}
+            B::StridedROCVecOrMat{$elty}
         )
             trans = ($elty <: Real && trans == 'C') ? 'T' : trans
             chktrans(trans)
@@ -633,19 +634,48 @@ function Base.:\(F::QR{<:Any,<:ROCMatrix,<:ROCVector}, B::ROCMatrix)
     ldiv!(QR(factors, τ), B)
 end
 
+# Cholesky
+
+function LinearAlgebra.ldiv!(C::Cholesky{T,<:ROCMatrix}, B::ROCVecOrMat{T}) where T <: rocBLAS.ROCBLASFloat
+    rocSOLVER.potrs!(C.uplo, C.factors, B)
+    return B
+end
+
+function Base.:\(F::Cholesky{T,<:ROCMatrix}, b::ROCVector{T}) where T
+    ldiv!(F, copy(b))
+end
+
+function Base.:\(F::Cholesky{T,<:ROCMatrix}, B::ROCMatrix{T}) where T
+    ldiv!(F, copy(B))
+end
+
+# LU
+function LinearAlgebra.ldiv!(F::LU{T,<:ROCMatrix,<:ROCVector{Cint}}, B::ROCVecOrMat{T}) where T <: rocBLAS.ROCBLASFloat
+    rocSOLVER.getrs!('N', F.factors, F.ipiv, B)
+    return B
+end
+
+function Base.:\(F::LU{T,<:ROCMatrix,<:ROCVector{Cint}}, b::ROCVector{T}) where T
+    ldiv!(F, copy(b))
+end
+
+function Base.:\(F::LU{T,<:ROCMatrix,<:ROCVector{Cint}}, B::ROCMatrix{T}) where T
+    ldiv!(F, copy(B))
+end
+
 # LAPACK
 
 for elty in (:Float32, :Float64, :ComplexF32, :ComplexF64)
     @eval begin
         LinearAlgebra.LAPACK.potrf!(uplo::Char, A::StridedROCMatrix{$elty}) = rocSOLVER.potrf!(uplo, A)
-        LinearAlgebra.LAPACK.potrs!(uplo::Char, A::ROCMatrix{$elty}, B::ROCVecOrMat{$elty}) = rocSOLVER.potrs!(uplo, A, B)
+        LinearAlgebra.LAPACK.potrs!(uplo::Char, A::ROCMatrix{$elty}, B::StridedROCVecOrMat{$elty}) = rocSOLVER.potrs!(uplo, A, B)
         LinearAlgebra.LAPACK.sytrf!(uplo::Char, A::ROCMatrix{$elty}) = rocSOLVER.sytrf!(uplo, A)
         LinearAlgebra.LAPACK.sytrf!(uplo::Char, A::ROCMatrix{$elty}, ipiv::ROCVector{Cint}) = rocSOLVER.sytrf!(uplo, A, ipiv)
         LinearAlgebra.LAPACK.geqrf!(A::ROCMatrix{$elty}) = rocSOLVER.geqrf!(A)
         LinearAlgebra.LAPACK.geqrf!(A::ROCMatrix{$elty}, tau::ROCVector{$elty}) = rocSOLVER.geqrf!(A, tau)
         LinearAlgebra.LAPACK.getrf!(A::ROCMatrix{$elty}) = rocSOLVER.getrf!(A)
         LinearAlgebra.LAPACK.getrf!(A::ROCMatrix{$elty}, ipiv::ROCVector{Cint}) = rocSOLVER.getrf!(A, ipiv)
-        LinearAlgebra.LAPACK.getrs!(trans::Char, A::ROCMatrix{$elty}, ipiv::ROCVector{Cint}, B::ROCVecOrMat{$elty}) = rocSOLVER.getrs!(trans, A, ipiv, B)
+        LinearAlgebra.LAPACK.getrs!(trans::Char, A::ROCMatrix{$elty}, ipiv::ROCVector{Cint}, B::StridedROCVecOrMat{$elty}) = rocSOLVER.getrs!(trans, A, ipiv, B)
         LinearAlgebra.LAPACK.ormqr!(side::Char, trans::Char, A::ROCMatrix{$elty}, tau::ROCVector{$elty}, C::StridedROCVecOrMat{$elty}) = rocSOLVER.ormqr!(side, trans, A, tau, C)
         LinearAlgebra.LAPACK.orgqr!(A::ROCMatrix{$elty}, tau::ROCVector{$elty}) = rocSOLVER.orgqr!(A, tau)
         LinearAlgebra.LAPACK.gebrd!(A::ROCMatrix{$elty}) = rocSOLVER.gebrd!(A)

--- a/src/solver/highlevel.jl
+++ b/src/solver/highlevel.jl
@@ -663,6 +663,15 @@ function Base.:\(F::LU{T,<:ROCMatrix,<:ROCVector{Cint}}, B::ROCMatrix{T}) where 
     ldiv!(F, copy(B))
 end
 
+function LinearAlgebra.lu!(
+    A::ROCMatrix{T}, ::LinearAlgebra.RowMaximum = LinearAlgebra.RowMaximum();
+    check::Bool = true,
+) where T <: rocBLAS.ROCBLASFloat
+    factors, ipiv, info = rocSOLVER.getrf!(A)
+    check && LinearAlgebra.checknonsingular(BlasInt(info))
+    return LU{T,typeof(factors),typeof(ipiv)}(factors, ipiv, BlasInt(info))
+end
+
 # LAPACK
 
 for elty in (:Float32, :Float64, :ComplexF32, :ComplexF64)

--- a/test/hip_rocarray/solver.jl
+++ b/test/hip_rocarray/solver.jl
@@ -234,8 +234,31 @@ end
         LAPACK.potrs!('U',copy(view(A,1:n,1:n)),B)
         @test B ≈ collect(d_B)
     end
+end
 
 
+@testset "cholesky \\ b" begin
+    @testset "elty = $elty" for elty in [Float32, Float64, ComplexF32, ComplexF64]
+        A = rand(elty, n, n); A = A * A' + n * I
+        b = rand(elty, n)
+        B = rand(elty, n, p)
+        dA, db, dB = ROCArray(A), ROCArray(b), ROCArray(B)
+
+        @test Array(cholesky(dA) \ db) ≈ cholesky(A) \ b
+        @test Array(cholesky(dA) \ dB) ≈ cholesky(A) \ B
+    end
+end
+
+@testset "lu \\ b" begin
+    @testset "elty = $elty" for elty in [Float32, Float64, ComplexF32, ComplexF64]
+        A = rand(elty, n, n)
+        b = rand(elty, n)
+        B = rand(elty, n, p)
+        dA, db, dB = ROCArray(A), ROCArray(b), ROCArray(B)
+
+        @test Array(lu(dA) \ db) ≈ lu(A) \ b
+        @test Array(lu(dA) \ dB) ≈ lu(A) \ B
+    end
 end
 
 @testset "sytrf!" begin

--- a/test/hip_rocarray/solver.jl
+++ b/test/hip_rocarray/solver.jl
@@ -221,6 +221,7 @@ end
         LAPACK.potrs!('U',A,B)
         @test B ≈ collect(d_B)
     end
+
     @testset "elty = $elty strided" for elty in [Float32, Float64, ComplexF32, ComplexF64]
         A    = rand(elty,n*2,n*2)
         A    = A*A' + I
@@ -247,6 +248,16 @@ end
         @test Array(cholesky(dA) \ db) ≈ cholesky(A) \ b
         @test Array(cholesky(dA) \ dB) ≈ cholesky(A) \ B
     end
+
+    @testset "mixed eltypes" begin
+        A = rand(Float32, n, n); A = A * A' + n * I
+        b = rand(Float64, n)
+        B = rand(Float64, n, p)
+        dA, db, dB = ROCArray(A), ROCArray(b), ROCArray(B)
+
+        @test Array(cholesky(dA) \ db) ≈ cholesky(A) \ b rtol=sqrt(eps(Float32))
+        @test Array(cholesky(dA) \ dB) ≈ cholesky(A) \ B rtol=sqrt(eps(Float32))
+    end
 end
 
 @testset "lu \\ b" begin
@@ -260,10 +271,24 @@ end
         @test Array(lu(dA) \ dB) ≈ lu(A) \ B
     end
 
+    @testset "mixed eltypes" begin
+        A = rand(Float32, n, n)
+        b = rand(Float64, n)
+        B = rand(Float64, n, p)
+        dA, db, dB = ROCArray(A), ROCArray(b), ROCArray(B)
+
+        @test Array(lu(dA) \ db) ≈ lu(A) \ b rtol=sqrt(eps(Float32))
+        @test Array(lu(dA) \ dB) ≈ lu(A) \ B rtol=sqrt(eps(Float32))
+    end
+
     @testset "check kwarg" begin
         dS = ROCArray(zeros(Float32, n, n))
         @test_throws LinearAlgebra.SingularException lu(dS)
         @test_nowarn lu(dS; check=false)
+        @test_nowarn lu!(copy(dS); allowsingular=true)
+        if VERSION >= v"1.12.0-DEV.0"
+            @test_nowarn lu(dS; allowsingular=true)
+        end
     end
 end
 

--- a/test/hip_rocarray/solver.jl
+++ b/test/hip_rocarray/solver.jl
@@ -259,6 +259,12 @@ end
         @test Array(lu(dA) \ db) ≈ lu(A) \ b
         @test Array(lu(dA) \ dB) ≈ lu(A) \ B
     end
+
+    @testset "check kwarg" begin
+        dS = ROCArray(zeros(Float32, n, n))
+        @test_throws LinearAlgebra.SingularException lu(dS)
+        @test_nowarn lu(dS; check=false)
+    end
 end
 
 @testset "sytrf!" begin


### PR DESCRIPTION
Circumvents stdlib's `\(Factorization, b)` routing through `_zeros(T, b, n) = zeros(T, n)`, which always allocates a CPU array, then passes it to `ldiv!` mixing GPU factors with CPU data leading to a segfault.

### Changes

- Add `LinearAlgebra.ldiv!` and `Base.:\` overloads for `Cholesky{T,<:ROCMatrix}` and `LU{T,<:ROCMatrix,<:ROCVector{Cint}}` that bypass stdlib's allocation and call rocSOLVER directly. Constrained to `T <: ROCBLASFloat` to avoid method ambiguity with stdlib's `BlasFloat`-constrained methods.
- Override `LinearAlgebra.lu!` for `ROCMatrix` with `RowMaximum` pivot to call `rocSOLVER.getrf!` directly and honour the `check` kwarg via `LinearAlgebra.checknonsingular`. This is more idiomatic than patching `LAPACK.getrf!` keyword dispatch and correctly throws `SingularException` on singular input.
- Widen `potrs!` and `getrs!` internal wrappers from `ROCVecOrMat` to `StridedROCVecOrMat` to support SubArray views.
- Fix `potrs!` tuple destructuring (`m, nrhs = size(B)`) that crashed on vector RHS; use `size(B, 1)` / `size(B, 2)` instead.
- Add `LAPACK.potrs!` and `LAPACK.getrs!` overrides (widened to `StridedROCVecOrMat`).
- Add tests for `cholesky \ b` and `lu \ b` for all four element types, plus a `check` kwarg test verifying `SingularException` is thrown on singular input and suppressed with `check=false`.