### PR TITLE
Add eigensolver support for Hermitian and Symmetric

### DIFF
--- a/src/solver/highlevel.jl
+++ b/src/solver/highlevel.jl
@@ -787,6 +787,14 @@ function LinearAlgebra.eigen(A::Hermitian{T,<:ROCMatrix}, B::Hermitian{T,<:ROCMa
     eigen(Symmetric(A), Symmetric(B))
 end
 
+function LinearAlgebra.eigen(A::Hermitian{T,<:ROCMatrix}, B::Symmetric{T,<:ROCMatrix}) where {T<:BlasReal}
+    eigen(Symmetric(A), B)
+end
+
+function LinearAlgebra.eigen(A::Symmetric{T,<:ROCMatrix}, B::Hermitian{T,<:ROCMatrix}) where {T<:BlasReal}
+    eigen(A, Symmetric(B))
+end
+
 function LinearAlgebra.eigen(A::ROCMatrix{T}) where {T<:BlasReal}
     A2 = copy(A)
     issymmetric(A) ? Eigen(syevd!('U', A2)...) : error("GPU eigensolver supports only Hermitian or Symmetric matrices.")

--- a/src/solver/highlevel.jl
+++ b/src/solver/highlevel.jl
@@ -410,6 +410,9 @@ for (jname, fname, elty, relty) in (
 
             AMDGPU.unsafe_free!(E)
 
+            chkargsok(BlasInt(info))
+            info > 0 && throw(LinearAlgebra.PosDefException(BlasInt(info)))
+
             D, A
         end
     end
@@ -770,14 +773,14 @@ end
 
 function LinearAlgebra.eigen(A::Symmetric{T,<:ROCMatrix}, B::Symmetric{T,<:ROCMatrix}) where {T<:BlasReal}
     A2 = copy(A.data)
-    B2 = copy(B.data)
-    Eigen(sygvd!('U', A2, B2)...)
+    B2 = copy(B.uplo == A.uplo ? B.data : B.data')
+    Eigen(sygvd!(A.uplo, A2, B2)...)
 end
 
 function LinearAlgebra.eigen(A::Hermitian{T,<:ROCMatrix}, B::Hermitian{T,<:ROCMatrix}) where {T<:BlasComplex}
     A2 = copy(A.data)
-    B2 = copy(B.data)
-    Eigen(hegvd!('U', A2, B2)...)
+    B2 = copy(B.uplo == A.uplo ? B.data : B.data')
+    Eigen(hegvd!(A.uplo, A2, B2)...)
 end
 
 function LinearAlgebra.eigen(A::Hermitian{T,<:ROCMatrix}, B::Hermitian{T,<:ROCMatrix}) where {T<:BlasReal}

--- a/src/solver/highlevel.jl
+++ b/src/solver/highlevel.jl
@@ -374,6 +374,47 @@ for (jname, fname, elty, relty) in (
     end
 end
 
+for (jname, fname, elty, relty) in (
+    (:sygvd!, :rocsolver_dsygvd, :Float64   , :Float64),
+    (:sygvd!, :rocsolver_ssygvd, :Float32   , :Float32),
+    (:hegvd!, :rocsolver_zhegvd, :ComplexF64, :Float64),
+    (:hegvd!, :rocsolver_chegvd, :ComplexF32, :Float32),
+)
+    @eval begin
+        function $jname(uplo::Char, A::ROCMatrix{$elty}, B::ROCMatrix{$elty})
+            chkuplo(uplo)
+
+            n = checksquare(A)
+            checksquare(B) == n || throw(DimensionMismatch("A and B must have the same size"))
+            lda = max(1, stride(A, 2))
+            ldb = max(1, stride(B, 2))
+
+            D = ROCVector{$relty}(undef, n)
+            E = ROCVector{$relty}(undef, n)
+
+            dev_info = ROCVector{Cint}(undef, 1)
+
+            $fname(
+                rocBLAS.handle(),
+                rocblas_eform_ax,
+                rocblas_evect_original,
+                uplo,
+                n, A, lda,
+                B, ldb,
+                D, E,
+                dev_info
+            )
+
+            info = AMDGPU.@allowscalar dev_info[1]
+            AMDGPU.unsafe_free!(dev_info)
+
+            AMDGPU.unsafe_free!(E)
+
+            D, A
+        end
+    end
+end
+
 for (fname, matrix_elty, vector_elty) in (
     (:rocsolver_zgesvdj, :ComplexF64, :Float64),
     (:rocsolver_cgesvdj, :ComplexF32, :Float32),
@@ -725,6 +766,22 @@ end
 
 function LinearAlgebra.eigen(A::Hermitian{T,<:ROCMatrix}) where {T<:BlasReal}
     eigen(Symmetric(A))
+end
+
+function LinearAlgebra.eigen(A::Symmetric{T,<:ROCMatrix}, B::Symmetric{T,<:ROCMatrix}) where {T<:BlasReal}
+    A2 = copy(A.data)
+    B2 = copy(B.data)
+    Eigen(sygvd!('U', A2, B2)...)
+end
+
+function LinearAlgebra.eigen(A::Hermitian{T,<:ROCMatrix}, B::Hermitian{T,<:ROCMatrix}) where {T<:BlasComplex}
+    A2 = copy(A.data)
+    B2 = copy(B.data)
+    Eigen(hegvd!('U', A2, B2)...)
+end
+
+function LinearAlgebra.eigen(A::Hermitian{T,<:ROCMatrix}, B::Hermitian{T,<:ROCMatrix}) where {T<:BlasReal}
+    eigen(Symmetric(A), Symmetric(B))
 end
 
 function LinearAlgebra.eigen(A::ROCMatrix{T}) where {T<:BlasReal}

--- a/test/hip_rocarray/solver.jl
+++ b/test/hip_rocarray/solver.jl
@@ -481,6 +481,26 @@ end
             end
         end
     end
+
+    @testset "generalized matrix type = $matrix_type" for (matrix_type, eltypes) in [
+        (Symmetric, [Float32, Float64]),
+        (Hermitian, [Float32, Float64, ComplexF32, ComplexF64]),
+    ]
+        @testset "elty = $elty" for elty in eltypes
+            A = rand(elty, m, m); A = matrix_type(A * A' + m * I)
+            B = rand(elty, m, m); B = matrix_type(B * B' + m * I)
+            dA = matrix_type(ROCMatrix(Matrix(A)))
+            dB = matrix_type(ROCMatrix(Matrix(B)))
+
+            E = eigen(dA, dB)
+
+            @test Array(E.values) ≈ eigen(A, B).values
+            for k in 1:length(E.values)
+                @allowscalar lambda = E.values[k]
+                @test dA * E.vectors[:, k] ≈ lambda .* (dB * E.vectors[:, k])
+            end
+        end
+    end
 end
 
 end

--- a/test/hip_rocarray/solver.jl
+++ b/test/hip_rocarray/solver.jl
@@ -501,6 +501,28 @@ end
             end
         end
     end
+
+    @testset "generalized mixed real wrappers" begin
+        @testset "elty = $elty" for elty in [Float32, Float64]
+            A = rand(elty, m, m); A = A * A' + m * I
+            B = rand(elty, m, m); B = B * B' + m * I
+            dA = ROCMatrix(A)
+            dB = ROCMatrix(B)
+
+            for (gpu_A, gpu_B, cpu_A, cpu_B) in (
+                (Hermitian(dA), Symmetric(dB), Hermitian(A), Symmetric(B)),
+                (Symmetric(dA), Hermitian(dB), Symmetric(A), Hermitian(B)),
+            )
+                E = eigen(gpu_A, gpu_B)
+
+                @test Array(E.values) ≈ eigen(cpu_A, cpu_B).values
+                for k in 1:length(E.values)
+                    @allowscalar lambda = E.values[k]
+                    @test gpu_A * E.vectors[:, k] ≈ lambda .* (gpu_B * E.vectors[:, k])
+                end
+            end
+        end
+    end
 end
 
 end


### PR DESCRIPTION
Add ROCMatrix-specific generalized eigensolver support for Hermitian and Symmetric inputs.

This makes calls like `eigen(Hermitian(A_gpu), Hermitian(B_gpu))` dispatch to rocSOLVER instead of falling through to the generic `LinearAlgebra` path.

## Changes

- Add high-level `sygvd!` / `hegvd!` rocSOLVER wrappers.
- Add `eigen(A, B)` methods for `Symmetric` and `Hermitian` ROC matrices.
- Respect wrapper `uplo`, matching Base `LinearAlgebra` behavior.
- Map positive solver `info` to `LinearAlgebra.PosDefException`.
- Added the mixed real wrapper support and tests.

## Testing

Added regression coverage for generalized `Symmetric` and `Hermitian` ROCMatrix eigensolver calls.

Fixes #903.