### PR TITLE
Fix scalar multiplication for `ROCSparseMatrix` adjoint/transpose wrappers.

### DIFF
--- a/src/sparse/generic.jl
+++ b/src/sparse/generic.jl
@@ -335,6 +335,59 @@ function gemm!(
     return C
 end
 
+function gemm(
+    transa::SparseChar, transb::SparseChar, α::Number,
+    A::ROCSparseMatrixCSR{T,Ti}, B::ROCSparseMatrixCSR{T,Ti},
+    index::SparseChar,
+) where {T,Ti}
+    m, k = size(A)
+    k == size(B, 1) || throw(DimensionMismatch(
+        "A has dimensions $(size(A)) but B has dimensions $(size(B))"))
+    n = size(B, 2)
+    alpha = convert(T, α)
+    beta = zero(T)
+
+    if transa != 'N' || transb != 'N'
+        throw(ArgumentError("Sparse gemm only supports transa ($transa) = 'N' and transb ($transb) = 'N'"))
+    end
+
+    descA = ROCSparseMatrixDescriptor(A, index)
+    descB = ROCSparseMatrixDescriptor(B, index)
+    rowPtrC = ROCVector{Ti}(undef, m + 1)
+    descC = ROCSparseMatrixDescriptor(ROCSparseMatrixCSR, rowPtrC, T, Ti, m, n, index)
+
+    function bufferSize()
+        out = Ref{Csize_t}(0)
+        rocsparse_spgemm(
+            handle(), transa, transb, Ref{T}(alpha), descA, descB, Ref{T}(beta),
+            descC, descC, T, rocsparse_spgemm_alg_default,
+            rocsparse_spgemm_stage_buffer_size, out, C_NULL)
+        return out[]
+    end
+
+    local C
+    with_workspace(bufferSize) do buffer
+        buffer_len_ref = Ref{Csize_t}(sizeof(buffer))
+        rocsparse_spgemm(
+            handle(), transa, transb, Ref{T}(alpha), descA, descB, Ref{T}(beta),
+            descC, descC, T, rocsparse_spgemm_alg_default,
+            rocsparse_spgemm_stage_nnz, buffer_len_ref, buffer)
+
+        nnzC = Ref{Int64}()
+        rocsparse_spmat_get_size(descC, Ref{Int64}(), Ref{Int64}(), nnzC)
+        colValC = ROCVector{Ti}(undef, nnzC[])
+        nzValC = ROCVector{T}(undef, nnzC[])
+        C = ROCSparseMatrixCSR{T,Ti}(rowPtrC, colValC, nzValC, (m, n))
+        rocsparse_csr_set_pointers(descC, C.rowPtr, C.colVal, C.nzVal)
+
+        rocsparse_spgemm(
+            handle(), transa, transb, Ref{T}(alpha), descA, descB, Ref{T}(beta),
+            descC, descC, T, rocsparse_spgemm_alg_default,
+            rocsparse_spgemm_stage_compute, buffer_len_ref, buffer)
+    end
+    return C
+end
+
 function sv!(transa::SparseChar, uplo::SparseChar, diag::SparseChar,
              alpha::Number, A::Union{ROCSparseMatrixCSC{T},ROCSparseMatrixCSR{T},ROCSparseMatrixCOO{T}}, X::DenseROCVector{T},
              Y::DenseROCVector{T}, index::SparseChar, algo::rocsparse_spsv_alg=rocsparse_spsv_alg_default) where T

--- a/src/sparse/interfaces.jl
+++ b/src/sparse/interfaces.jl
@@ -232,6 +232,22 @@ end
 _coo_scale(A::ROCSparseMatrixCOO{T}, λ) where {T} =
     ROCSparseMatrixCOO(A.rowInd, A.colInd, A.nzVal .* λ, size(A), nnz(A))
 
+for (wrapa, unwrapa) in adjtrans_wrappers
+    for SparseMatrixType in (:(ROCSparseMatrixCSC{T}), :(ROCSparseMatrixCSR{T}))
+        TypeA = wrapa(SparseMatrixType)
+        @eval begin
+            Base.:(*)(A::$TypeA, λ::Number) where {T <: BlasFloat} = $(unwrapa(:A)) .* λ
+            Base.:(*)(λ::Number, A::$TypeA) where {T <: BlasFloat} = λ .* $(unwrapa(:A))
+        end
+    end
+
+    TypeA = wrapa(:(ROCSparseMatrixCOO{T}))
+    @eval begin
+        Base.:(*)(A::$TypeA, λ::Number) where {T <: BlasFloat} = _coo_scale($(unwrapa(:A)), λ)
+        Base.:(*)(λ::Number, A::$TypeA) where {T <: BlasFloat} = _coo_scale($(unwrapa(:A)), λ)
+    end
+end
+
 # UniformScaling +/-/* for all formats/wrappers; typeof(A′) passes a concrete type to _sparse_identity
 # (SparseMatrixType is a UnionAll with Ti unbound at runtime and won't match its signatures).
 for (wrapa, unwrapa) in adjtrans_wrappers

--- a/src/sparse/interfaces.jl
+++ b/src/sparse/interfaces.jl
@@ -232,21 +232,28 @@ end
 _coo_scale(A::ROCSparseMatrixCOO{T}, λ) where {T} =
     ROCSparseMatrixCOO(A.rowInd, A.colInd, A.nzVal .* λ, size(A), nnz(A))
 
+Base.:(*)(A::ROCSparseMatrix{T}, B::ROCSparseMatrix{T}) where {T <: BlasFloat} =
+    gemm('N', 'N', one(T), ROCSparseMatrixCSR(A), ROCSparseMatrixCSR(B), 'O')
+
 for (wrapa, unwrapa) in adjtrans_wrappers
     for SparseMatrixType in (:(ROCSparseMatrixCSC{T}), :(ROCSparseMatrixCSR{T}))
         TypeA = wrapa(SparseMatrixType)
         @eval begin
-            Base.:(*)(A::$TypeA, λ::Number) where {T <: BlasFloat} = $(unwrapa(:A)) .* λ
-            Base.:(*)(λ::Number, A::$TypeA) where {T <: BlasFloat} = λ .* $(unwrapa(:A))
-            Base.:(*)(λ::Number, A::$TypeA, B::ROCSparseMatrix{T}) where {T <: BlasFloat} = (λ * A) * B
+            Base.:(*)(A::$TypeA, λ::Union{Real,Complex}) where {T <: BlasFloat} = $(unwrapa(:A)) .* λ
+            Base.:(*)(λ::Union{Real,Complex}, A::$TypeA) where {T <: BlasFloat} = λ .* $(unwrapa(:A))
+            Base.:(*)(A::$TypeA, B::ROCSparseMatrix{T}) where {T <: BlasFloat} = $(unwrapa(:A)) * B
+            Base.:(*)(λ::Union{Real,Complex}, A::$TypeA, B::ROCSparseMatrix{T}) where {T <: BlasFloat} =
+                gemm('N', 'N', λ, ROCSparseMatrixCSR($(unwrapa(:A))), ROCSparseMatrixCSR(B), 'O')
         end
     end
 
     TypeA = wrapa(:(ROCSparseMatrixCOO{T}))
     @eval begin
-        Base.:(*)(A::$TypeA, λ::Number) where {T <: BlasFloat} = _coo_scale($(unwrapa(:A)), λ)
-        Base.:(*)(λ::Number, A::$TypeA) where {T <: BlasFloat} = _coo_scale($(unwrapa(:A)), λ)
-        Base.:(*)(λ::Number, A::$TypeA, B::ROCSparseMatrix{T}) where {T <: BlasFloat} = (λ * A) * B
+        Base.:(*)(A::$TypeA, λ::Union{Real,Complex}) where {T <: BlasFloat} = _coo_scale($(unwrapa(:A)), λ)
+        Base.:(*)(λ::Union{Real,Complex}, A::$TypeA) where {T <: BlasFloat} = _coo_scale($(unwrapa(:A)), λ)
+        Base.:(*)(A::$TypeA, B::ROCSparseMatrix{T}) where {T <: BlasFloat} = $(unwrapa(:A)) * B
+        Base.:(*)(λ::Union{Real,Complex}, A::$TypeA, B::ROCSparseMatrix{T}) where {T <: BlasFloat} =
+            gemm('N', 'N', λ, ROCSparseMatrixCSR($(unwrapa(:A))), ROCSparseMatrixCSR(B), 'O')
     end
 end
 

--- a/src/sparse/interfaces.jl
+++ b/src/sparse/interfaces.jl
@@ -238,6 +238,7 @@ for (wrapa, unwrapa) in adjtrans_wrappers
         @eval begin
             Base.:(*)(A::$TypeA, λ::Number) where {T <: BlasFloat} = $(unwrapa(:A)) .* λ
             Base.:(*)(λ::Number, A::$TypeA) where {T <: BlasFloat} = λ .* $(unwrapa(:A))
+            Base.:(*)(λ::Number, A::$TypeA, B::ROCSparseMatrix{T}) where {T <: BlasFloat} = (λ * A) * B
         end
     end
 
@@ -245,6 +246,7 @@ for (wrapa, unwrapa) in adjtrans_wrappers
     @eval begin
         Base.:(*)(A::$TypeA, λ::Number) where {T <: BlasFloat} = _coo_scale($(unwrapa(:A)), λ)
         Base.:(*)(λ::Number, A::$TypeA) where {T <: BlasFloat} = _coo_scale($(unwrapa(:A)), λ)
+        Base.:(*)(λ::Number, A::$TypeA, B::ROCSparseMatrix{T}) where {T <: BlasFloat} = (λ * A) * B
     end
 end
 

--- a/src/sparse/interfaces.jl
+++ b/src/sparse/interfaces.jl
@@ -241,7 +241,8 @@ for (wrapa, unwrapa) in adjtrans_wrappers
         @eval begin
             Base.:(*)(A::$TypeA, λ::Union{Real,Complex}) where {T <: BlasFloat} = $(unwrapa(:A)) .* λ
             Base.:(*)(λ::Union{Real,Complex}, A::$TypeA) where {T <: BlasFloat} = λ .* $(unwrapa(:A))
-            Base.:(*)(A::$TypeA, B::ROCSparseMatrix{T}) where {T <: BlasFloat} = $(unwrapa(:A)) * B
+            Base.:(*)(A::$TypeA, B::ROCSparseMatrix{T}) where {T <: BlasFloat} =
+                gemm('N', 'N', one(T), ROCSparseMatrixCSR($(unwrapa(:A))), ROCSparseMatrixCSR(B), 'O')
             Base.:(*)(λ::Union{Real,Complex}, A::$TypeA, B::ROCSparseMatrix{T}) where {T <: BlasFloat} =
                 gemm('N', 'N', λ, ROCSparseMatrixCSR($(unwrapa(:A))), ROCSparseMatrixCSR(B), 'O')
         end
@@ -251,7 +252,8 @@ for (wrapa, unwrapa) in adjtrans_wrappers
     @eval begin
         Base.:(*)(A::$TypeA, λ::Union{Real,Complex}) where {T <: BlasFloat} = _coo_scale($(unwrapa(:A)), λ)
         Base.:(*)(λ::Union{Real,Complex}, A::$TypeA) where {T <: BlasFloat} = _coo_scale($(unwrapa(:A)), λ)
-        Base.:(*)(A::$TypeA, B::ROCSparseMatrix{T}) where {T <: BlasFloat} = $(unwrapa(:A)) * B
+        Base.:(*)(A::$TypeA, B::ROCSparseMatrix{T}) where {T <: BlasFloat} =
+            gemm('N', 'N', one(T), ROCSparseMatrixCSR($(unwrapa(:A))), ROCSparseMatrixCSR(B), 'O')
         Base.:(*)(λ::Union{Real,Complex}, A::$TypeA, B::ROCSparseMatrix{T}) where {T <: BlasFloat} =
             gemm('N', 'N', λ, ROCSparseMatrixCSR($(unwrapa(:A))), ROCSparseMatrixCSR(B), 'O')
     end

--- a/test/hip_rocsparse/interfaces.jl
+++ b/test/hip_rocsparse/interfaces.jl
@@ -257,6 +257,24 @@ using Adapt
         end
     end
 
+    @testset "sparse-sparse multiplication ($typ, $elty)" for (typ, elty) in (
+        (ROCSparseMatrixCSR, Float32),
+        (ROCSparseMatrixCSR, ComplexF32),
+        (ROCSparseMatrixCSC, Float64),
+        (ROCSparseMatrixCSC, ComplexF64),
+        (ROCSparseMatrixCOO, Float32),
+        (ROCSparseMatrixCOO, ComplexF64),
+    )
+        S = sprand(elty, 10, 10, 0.4)
+        dA = typ(S)
+        α = rand()
+
+        @test SparseMatrixCSC(ROCSparseMatrixCSC(dA * dA)) ≈ S * S
+        @test SparseMatrixCSC(ROCSparseMatrixCSC(transpose(dA) * dA)) ≈ transpose(S) * S
+        @test SparseMatrixCSC(ROCSparseMatrixCSC(adjoint(dA) * dA)) ≈ adjoint(S) * S
+        @test SparseMatrixCSC(ROCSparseMatrixCSC(α * adjoint(dA) * dA)) ≈ α * adjoint(S) * S
+    end
+
     @testset "Diagonal with $typ(10, 10)" for typ in (
         ROCSparseMatrixCSR, ROCSparseMatrixCSC,
     )

--- a/test/hip_rocsparse/interfaces.jl
+++ b/test/hip_rocsparse/interfaces.jl
@@ -238,6 +238,25 @@ using Adapt
         @test SparseMatrixCSC(ROCSparseMatrixCSC(I * dAt)) ≈ Array(Sw)
     end
 
+    @testset "scalar multiplication with wrapped sparse ($wrap, $typ, $elty)" for
+        wrap in (identity, transpose, adjoint),
+        typ in (ROCSparseMatrixCSR, ROCSparseMatrixCSC, ROCSparseMatrixCOO),
+        elty in (Float32, Float64, ComplexF32, ComplexF64)
+
+        S = sprand(elty, 10, 10, 0.5)
+        α = rand()
+        dA = typ(S)
+        dAt = wrap(dA)
+        Sw = wrap(S)
+
+        @test SparseMatrixCSC(ROCSparseMatrixCSC(α * dAt)) ≈ α * Sw
+        @test SparseMatrixCSC(ROCSparseMatrixCSC(dAt * α)) ≈ Sw * α
+
+        if wrap !== identity
+            @test SparseMatrixCSC(ROCSparseMatrixCSC(α * dAt * dA)) ≈ α * Sw * S
+        end
+    end
+
     @testset "Diagonal with $typ(10, 10)" for typ in (
         ROCSparseMatrixCSR, ROCSparseMatrixCSC,
     )


### PR DESCRIPTION
This adds explicit scalar and sparse-sparse multiplication dispatch for plain, `transpose`, and `adjoint` sparse ROC matrices so expressions like:

```julia
a * M'
a * transpose(M)
a * M' * M
```

avoid falling back to generic scalar multiplication that scalar-indexes through GPU-backed wrappers.

## Changes

- Add scalar `*` dispatch for wrapped CSR/CSC sparse matrices via sparse broadcast scaling.
- Add COO handling through `_coo_scale`.
- Add regression tests covering scalar multiplication in both operand orders and the chained issue case across CSR, CSC, COO, wrapper variants, and real/complex float eltypes.
- Add high-level sparse-sparse `*` dispatch via CSR-normalized rocSPARSE SpGEMM so chained forms like `a * M' * M` avoid Base's generic matrix multiplication fallback.

Fixes #854.