### PR TITLE
Add mixed real/complex sparse-dense matrix multiplication

### DIFF
--- a/src/sparse/conversions.jl
+++ b/src/sparse/conversions.jl
@@ -331,6 +331,12 @@ function ROCSparseMatrixCSR(coo::ROCSparseMatrixCOO{Tv}, ind::SparseChar='O') wh
     rocsparse_coo2csr(handle(), coo.rowInd, nnz(coo), m, csrRowPtr, ind)
     ROCSparseMatrixCSR{Tv}(csrRowPtr, coo.colInd, nonzeros(coo), size(coo))
 end
+
+ROCSparseMatrixCSR{Tv,Ti}(csr::ROCSparseMatrixCSR{<:Any,Ti}) where {Tv,Ti} =
+    ROCSparseMatrixCSR{Tv,Ti}(csr.rowPtr, csr.colVal, convert(ROCVector{Tv}, nonzeros(csr)), size(csr))
+ROCSparseMatrixCSR{Tv}(csr::ROCSparseMatrixCSR{<:Any,Ti}) where {Tv,Ti} =
+    ROCSparseMatrixCSR{Tv,Ti}(csr)
+
 # Typed forwarding constructors: allow ROCSparseMatrixCSR{Tv,Ti}(coo) as called by GPUArrays generics
 ROCSparseMatrixCSR{Tv,Ti}(coo::ROCSparseMatrixCOO{Tv,Ti}) where {Tv,Ti} = ROCSparseMatrixCSR(coo)
 
@@ -345,7 +351,15 @@ end
 
 ROCSparseMatrixCSC(coo::ROCSparseMatrixCOO) = ROCSparseMatrixCSC(ROCSparseMatrixCSR(coo)) # no direct conversion
 ROCSparseMatrixCSC{Tv,Ti}(coo::ROCSparseMatrixCOO{Tv,Ti}) where {Tv,Ti} = ROCSparseMatrixCSC(coo)
+ROCSparseMatrixCSC{Tv,Ti}(csc::ROCSparseMatrixCSC{<:Any,Ti}) where {Tv,Ti} =
+    ROCSparseMatrixCSC{Tv,Ti}(
+        csc.colPtr, rowvals(csc), convert(ROCVector{Tv}, nonzeros(csc)), size(csc))
+ROCSparseMatrixCSC{Tv}(csc::ROCSparseMatrixCSC{<:Any,Ti}) where {Tv,Ti} = ROCSparseMatrixCSC{Tv,Ti}(csc)
 ROCSparseMatrixCOO(csc::ROCSparseMatrixCSC) = ROCSparseMatrixCOO(ROCSparseMatrixCSR(csc)) # no direct conversion
+ROCSparseMatrixCOO{Tv,Ti}(coo::ROCSparseMatrixCOO{<:Any,Ti}) where {Tv,Ti} =
+    ROCSparseMatrixCOO{Tv,Ti}(
+        coo.rowInd, coo.colInd, convert(ROCVector{Tv}, nonzeros(coo)), size(coo), nnz(coo))
+ROCSparseMatrixCOO{Tv}(coo::ROCSparseMatrixCOO{<:Any,Ti}) where {Tv,Ti} = ROCSparseMatrixCOO{Tv,Ti}(coo)
 ROCSparseMatrixBSR(coo::ROCSparseMatrixCOO, blockdim) = ROCSparseMatrixBSR(ROCSparseMatrixCSR(coo), blockdim) # no direct conversion
 ROCSparseMatrixCOO(bsr::ROCSparseMatrixBSR) = ROCSparseMatrixCOO(ROCSparseMatrixCSR(bsr)) # no direct conversion
 

--- a/src/sparse/interfaces.jl
+++ b/src/sparse/interfaces.jl
@@ -82,6 +82,52 @@ function LinearAlgebra.generic_matmatmul!(C::ROCMatrix{T}, tA, tB, A::ROCSparseM
     mm_wrapper(tA, tB, alpha, A, B, beta, C)
 end
 
+function Base.:(*)(
+    A::Union{ROCSparseMatrixCSC{TA}, ROCSparseMatrixCSR{TA}, ROCSparseMatrixCOO{TA}},
+    B::DenseROCMatrix{TB},
+) where {TA <: BlasComplex, TB <: BlasReal}
+    C = ROCMatrix{promote_type(TA, TB)}(undef, size(A, 1), size(B, 2))
+    LinearAlgebra.mul!(C, A, B)
+end
+
+function Base.:(*)(
+    A::Union{ROCSparseMatrixCSC{TA}, ROCSparseMatrixCSR{TA}, ROCSparseMatrixCOO{TA}},
+    B::DenseROCMatrix{TB},
+) where {TA <: BlasReal, TB <: BlasComplex}
+    C = ROCMatrix{promote_type(TA, TB)}(undef, size(A, 1), size(B, 2))
+    LinearAlgebra.mul!(C, A, B)
+end
+
+function LinearAlgebra.generic_matmatmul!(
+    C::ROCMatrix{T}, tA, tB,
+    A::Union{ROCSparseMatrixCSC{TA}, ROCSparseMatrixCSR{TA}, ROCSparseMatrixCOO{TA}},
+    B::DenseROCMatrix{TB},
+    alpha::Number, beta::Number,
+) where {T <: BlasComplex, TA <: BlasComplex, TB <: BlasReal}
+    promote_type(TA, TB) === T || throw(ArgumentError("output element type must match promoted input element type"))
+    tA = tA in ('S', 's', 'H', 'h') ? 'N' : tA
+    tB = tB in ('S', 's', 'H', 'h') ? 'N' : tB
+    A = A isa ROCSparseMatrixCSC ? ROCSparseMatrixCSC{T}(A) :
+        A isa ROCSparseMatrixCSR ? ROCSparseMatrixCSR{T}(A) : ROCSparseMatrixCOO{T}(A)
+    B = ROCMatrix{T}(B)
+    mm_wrapper(tA, tB, alpha, A, B, beta, C)
+end
+
+function LinearAlgebra.generic_matmatmul!(
+    C::ROCMatrix{T}, tA, tB,
+    A::Union{ROCSparseMatrixCSC{TA}, ROCSparseMatrixCSR{TA}, ROCSparseMatrixCOO{TA}},
+    B::DenseROCMatrix{TB},
+    alpha::Number, beta::Number,
+) where {T <: BlasComplex, TA <: BlasReal, TB <: BlasComplex}
+    promote_type(TA, TB) === T || throw(ArgumentError("output element type must match promoted input element type"))
+    tA = tA in ('S', 's', 'H', 'h') ? 'N' : tA
+    tB = tB in ('S', 's', 'H', 'h') ? 'N' : tB
+    A = A isa ROCSparseMatrixCSC ? ROCSparseMatrixCSC{T}(A) :
+        A isa ROCSparseMatrixCSR ? ROCSparseMatrixCSR{T}(A) : ROCSparseMatrixCOO{T}(A)
+    B = TB === T ? B : ROCMatrix{T}(B)
+    mm_wrapper(tA, tB, alpha, A, B, beta, C)
+end
+
 # legacy methods with final MulAddMul argument
 LinearAlgebra.generic_matmatmul!(C::ROCMatrix{T}, tA, tB, A::DenseROCMatrix{T}, B::ROCSparseMatrixCSC{T}, _add::MulAddMul) where T <: BlasFloat =
     LinearAlgebra.generic_matmatmul!(C, tA, tB, A, B, _add.alpha, _add.beta)
@@ -103,6 +149,50 @@ end
 function LinearAlgebra.generic_matmatmul!(C::ROCMatrix{T}, tA, tB, A::DenseROCMatrix{T}, B::ROCSparseMatrixCOO{T}, alpha::Number, beta::Number) where T <: BlasFloat
     tA = tA in ('S', 's', 'H', 'h') ? 'N' : tA
     tB = tB in ('S', 's', 'H', 'h') ? 'N' : tB
+    mm!(tA, tB, alpha, A, B, beta, C, 'O')
+end
+
+function Base.:(*)(
+    A::DenseROCMatrix{TA},
+    B::Union{ROCSparseMatrixCSC{TB}, ROCSparseMatrixCSR{TB}, ROCSparseMatrixCOO{TB}},
+) where {TA <: BlasComplex, TB <: BlasReal}
+    C = ROCMatrix{promote_type(TA, TB)}(undef, size(A, 1), size(B, 2))
+    LinearAlgebra.mul!(C, A, B)
+end
+
+function Base.:(*)(
+    A::DenseROCMatrix{TA},
+    B::Union{ROCSparseMatrixCSC{TB}, ROCSparseMatrixCSR{TB}, ROCSparseMatrixCOO{TB}},
+) where {TA <: BlasReal, TB <: BlasComplex}
+    C = ROCMatrix{promote_type(TA, TB)}(undef, size(A, 1), size(B, 2))
+    LinearAlgebra.mul!(C, A, B)
+end
+
+function LinearAlgebra.generic_matmatmul!(
+    C::ROCMatrix{T}, tA, tB, A::DenseROCMatrix{TA},
+    B::Union{ROCSparseMatrixCSC{TB}, ROCSparseMatrixCSR{TB}, ROCSparseMatrixCOO{TB}},
+    alpha::Number, beta::Number,
+) where {T <: BlasComplex, TA <: BlasComplex, TB <: BlasReal}
+    promote_type(TA, TB) === T || throw(ArgumentError("output element type must match promoted input element type"))
+    tA = tA in ('S', 's', 'H', 'h') ? 'N' : tA
+    tB = tB in ('S', 's', 'H', 'h') ? 'N' : tB
+    A = TA === T ? A : ROCMatrix{T}(A)
+    B = B isa ROCSparseMatrixCSC ? ROCSparseMatrixCSC{T}(B) :
+        B isa ROCSparseMatrixCSR ? ROCSparseMatrixCSR{T}(B) : ROCSparseMatrixCOO{T}(B)
+    mm!(tA, tB, alpha, A, B, beta, C, 'O')
+end
+
+function LinearAlgebra.generic_matmatmul!(
+    C::ROCMatrix{T}, tA, tB, A::DenseROCMatrix{TA},
+    B::Union{ROCSparseMatrixCSC{TB}, ROCSparseMatrixCSR{TB}, ROCSparseMatrixCOO{TB}},
+    alpha::Number, beta::Number,
+) where {T <: BlasComplex, TA <: BlasReal, TB <: BlasComplex}
+    promote_type(TA, TB) === T || throw(ArgumentError("output element type must match promoted input element type"))
+    tA = tA in ('S', 's', 'H', 'h') ? 'N' : tA
+    tB = tB in ('S', 's', 'H', 'h') ? 'N' : tB
+    A = ROCMatrix{T}(A)
+    B = B isa ROCSparseMatrixCSC ? ROCSparseMatrixCSC{T}(B) :
+        B isa ROCSparseMatrixCSR ? ROCSparseMatrixCSR{T}(B) : ROCSparseMatrixCOO{T}(B)
     mm!(tA, tB, alpha, A, B, beta, C, 'O')
 end
 

--- a/src/sparse/interfaces.jl
+++ b/src/sparse/interfaces.jl
@@ -65,6 +65,18 @@ LinearAlgebra.generic_matvecmul!(C::ROCVector{T}, tA::AbstractChar, A::ROCSparse
     LinearAlgebra.generic_matvecmul!(C, tA, A, B, _add.alpha, _add.beta)
 LinearAlgebra.generic_matmatmul!(C::ROCMatrix{T}, tA, tB, A::ROCSparseMatrix{T}, B::DenseROCMatrix{T}, _add::MulAddMul) where T <: BlasFloat =
     LinearAlgebra.generic_matmatmul!(C, tA, tB, A, B, _add.alpha, _add.beta)
+LinearAlgebra.generic_matmatmul!(
+    C::ROCMatrix{T}, tA, tB,
+    A::Union{ROCSparseMatrixCSC{TA}, ROCSparseMatrixCSR{TA}, ROCSparseMatrixCOO{TA}},
+    B::DenseROCMatrix{TB}, _add::MulAddMul,
+) where {T <: BlasComplex, TA <: BlasComplex, TB <: BlasReal} =
+    LinearAlgebra.generic_matmatmul!(C, tA, tB, A, B, _add.alpha, _add.beta)
+LinearAlgebra.generic_matmatmul!(
+    C::ROCMatrix{T}, tA, tB,
+    A::Union{ROCSparseMatrixCSC{TA}, ROCSparseMatrixCSR{TA}, ROCSparseMatrixCOO{TA}},
+    B::DenseROCMatrix{TB}, _add::MulAddMul,
+) where {T <: BlasComplex, TA <: BlasReal, TB <: BlasComplex} =
+    LinearAlgebra.generic_matmatmul!(C, tA, tB, A, B, _add.alpha, _add.beta)
 
 function LinearAlgebra.generic_matvecmul!(C::ROCVector{T}, tA::AbstractChar, A::ROCSparseMatrix{T}, B::DenseROCVector{T}, alpha::Number, beta::Number) where T <: BlasFloat
     tA = tA in ('S', 's', 'H', 'h') ? 'N' : tA
@@ -134,6 +146,18 @@ LinearAlgebra.generic_matmatmul!(C::ROCMatrix{T}, tA, tB, A::DenseROCMatrix{T}, 
 LinearAlgebra.generic_matmatmul!(C::ROCMatrix{T}, tA, tB, A::DenseROCMatrix{T}, B::ROCSparseMatrixCSR{T}, _add::MulAddMul) where T <: BlasFloat =
     LinearAlgebra.generic_matmatmul!(C, tA, tB, A, B, _add.alpha, _add.beta)
 LinearAlgebra.generic_matmatmul!(C::ROCMatrix{T}, tA, tB, A::DenseROCMatrix{T}, B::ROCSparseMatrixCOO{T}, _add::MulAddMul) where T <: BlasFloat =
+    LinearAlgebra.generic_matmatmul!(C, tA, tB, A, B, _add.alpha, _add.beta)
+LinearAlgebra.generic_matmatmul!(
+    C::ROCMatrix{T}, tA, tB, A::DenseROCMatrix{TA},
+    B::Union{ROCSparseMatrixCSC{TB}, ROCSparseMatrixCSR{TB}, ROCSparseMatrixCOO{TB}},
+    _add::MulAddMul,
+) where {T <: BlasComplex, TA <: BlasComplex, TB <: BlasReal} =
+    LinearAlgebra.generic_matmatmul!(C, tA, tB, A, B, _add.alpha, _add.beta)
+LinearAlgebra.generic_matmatmul!(
+    C::ROCMatrix{T}, tA, tB, A::DenseROCMatrix{TA},
+    B::Union{ROCSparseMatrixCSC{TB}, ROCSparseMatrixCSR{TB}, ROCSparseMatrixCOO{TB}},
+    _add::MulAddMul,
+) where {T <: BlasComplex, TA <: BlasReal, TB <: BlasComplex} =
     LinearAlgebra.generic_matmatmul!(C, tA, tB, A, B, _add.alpha, _add.beta)
 
 function LinearAlgebra.generic_matmatmul!(C::ROCMatrix{T}, tA, tB, A::DenseROCMatrix{T}, B::ROCSparseMatrixCSC{T}, alpha::Number, beta::Number) where T <: BlasFloat

--- a/test/hip_rocsparse/interfaces.jl
+++ b/test/hip_rocsparse/interfaces.jl
@@ -164,6 +164,33 @@ using Adapt
         @test B ≈ collect(dB)
     end
 
+    @testset "mixed complex/real sparse-dense matmul" begin
+        m, k, n = 8, 10, 6
+        for SparseMatrixType in (ROCSparseMatrixCSC, ROCSparseMatrixCSR, ROCSparseMatrixCOO),
+            (TA, TB) in ((ComplexF32, Float32), (ComplexF64, Float64),
+                         (Float32, ComplexF32), (Float64, ComplexF64))
+
+            T = promote_type(TA, TB)
+            A = sprand(TA, m, k, 0.2)
+            B = rand(TB, k, n)
+            D = sprand(TA, n, n, 0.2)
+            E = rand(TB, n, n)
+
+            dA = SparseMatrixType(A)
+            dB = ROCArray(B)
+            dD = SparseMatrixType(D)
+            dE = ROCArray(E)
+
+            dC = dA * dB
+            @test dC isa ROCMatrix{T}
+            @test Array(dC) ≈ A * B
+
+            dC = dE * dD
+            @test dC isa ROCMatrix{T}
+            @test Array(dC) ≈ E * D
+        end
+    end
+
     @testset "ROCSparseMatrixCSR($f) $elty" for f in (
         transpose, adjoint,
     ), elty in (


### PR DESCRIPTION
Fix mixed real/complex sparse-dense matrix multiplication so it dispatches to AMDGPU/rocSPARSE instead of falling back to scalar indexing.

## Changes

- Add mixed-type sparse-dense and dense-sparse matmul dispatch for CSC, CSR, and COO.
- Add promoted `ROCMatrix` allocation for out-of-place `*`.
- Add typed sparse constructors that convert `nonzeros` while preserving sparse structure.
- Add regression coverage for both operand orders across CSC/CSR/COO.

Fixes #904 