### PR TITLE
Group all Julia Github Actions PRs into a single one

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,16 @@
 version: 2
 updates:
   - package-ecosystem: "julia"
-    directory: "/" # Update [compat] in Project.toml and the checked-in Manifest.toml
+    # Group all Julia GHA PRs into a single PR:
+    groups:
+      all-julia-dependencies:
+        patterns:
+          - "*"
+    directories:
+      - "/"
+      - "/test"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 100
     labels:
       - "dependencies"
       - "julia"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,25 +2,24 @@
 version: 2
 updates:
   - package-ecosystem: "julia"
-    # Group all Julia GHA PRs into a single PR:
-    groups:
-      all-julia-dependencies:
-        patterns:
-          - "*"
+    # Location of Julia projects
     directories:
       - "/"
+      - "/docs"
+      - "/perf"
       - "/test"
     schedule:
       interval: "weekly"
+    ignore:
+      # Ignore package itself
+      - dependency-name: "AMDGPU"
     labels:
       - "dependencies"
       - "julia"
-  - package-ecosystem: "github-actions"
     groups:
-      # Group all GitHub Actions PRs into a single PR:
-      all-github-actions:
-        patterns:
-          - "*"
+      per-dependency:
+        group-by: dependency-name
+  - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
@@ -28,3 +27,8 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    groups:
+      # Group all GitHub Actions PRs into a single PR:
+      all-github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     # Location of Julia projects
     directories:
       - "/"
-      - "/docs"
-      - "/perf"
-      - "/test"
     schedule:
       interval: "weekly"
     ignore:


### PR DESCRIPTION
Improving over #949 .

Question is (cc @vchuravy) about having `test/` in the `directories` given that note from 949:
> only the root environment is covered — the PSA advises against listing multiple directories (docs/, test/, gen/) due to resolver conflicts, recommending Julia 1.12+ workspaces instead, which isn't an option while we support 1.10.