### PR TITLE
Increase `evals` from 1 to 4 in the benchmark suite

### DIFF
--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -12,7 +12,9 @@ AMDGPU.versioninfo()
 # convenience macro to create a benchmark that requires synchronizing the GPU.
 # The setup=(GC+sync) runs before each sample (outside the timing window) to
 # drain pending hipFreeAsync calls before the next allocation, preventing
-# HIP memory pool exhaustion on discrete GPUs.
+# HIP memory pool exhaustion on discrete GPUs. This is load-bearing, not
+# belt-and-braces: dropping it takes the pool to 25.7 GB on a 24 GiB card and
+# the suite never finishes. See set_evals! below for why evals is not 1.
 macro async_benchmarkable(ex...)
     quote
         @benchmarkable(AMDGPU.@sync($(ex...)),
@@ -32,11 +34,20 @@ include("kernel.jl")
 include("array.jl")
 
 @info "Preparing main benchmarks"
-# tune!() uses a strategy that exhausts the HIP memory pool on discrete GPUs.
-# Instead, warmup for compilation and fix evals=1: one GPU round-trip per sample.
+# tune!() still grows the HIP memory pool ~10x (64 MiB -> 640 MiB) on discrete
+# GPUs, and picks evals=1 for 65 of 69 benchmarks anyway since its criterion is
+# timer resolution and every GPU benchmark is already far above it. Instead,
+# warmup for compilation and fix evals explicitly.
 warmup(SUITE; verbose=false)
 
-function set_evals!(group::BenchmarkGroup, evals::Int=1)
+# evals=4: the GC in the `setup` above forces a slow post-GC hipMallocAsync into
+# every timed region at evals=1, inflating allocation-heavy benchmarks ~1.9x
+# (accumulate/F32/dims=1L: 133us at evals=1 vs 70.5us at evals=4). At evals=4
+# three of four evals hit the pool fast path, so the number reflects steady
+# state rather than allocator overhead. The pool still stays flat at 96 MiB.
+# Note evals=2 is the worst of both: a 50/50 slow/fast split puts the sample
+# mean between the two levels, where it is maximally sensitive to the split.
+function set_evals!(group::BenchmarkGroup, evals::Int=4)
     for (_, b) in group
         if b isa BenchmarkGroup
             set_evals!(b, evals)


### PR DESCRIPTION
`perf/runbenchmarks.jl` has pinned `evals=1` since a4575d9 ("Fix hangs on AMDGPU"). That workaround is still needed, but `evals=1` specifically inflates allocation-heavy benchmarks by up to ~1.9x.

The `setup=(GC.gc(false); AMDGPU.synchronize())` runs before each **sample**, so at `evals=1` every timed region pays a slow post-GC `hipMallocAsync` — we report allocator overhead on top of the actual operation. At `evals=4`, three of four evals hit the pool fast path and the number reflects steady state.

Measured in isolation, 10 reps x 3 fresh processes per setting (both stable to <1% CV, so this is a systematic offset, not noise):

| benchmark | `evals=1` | `evals=4` | ratio |
|---|---|---|---|
| `array/accumulate/Float32/dims=1L` | ~133.0 us | ~70.5 us | 1.89x |
| `array/reductions/mapreduce/Float32/1d` | ~132.0 us | ~85.0 us | 1.55x |

### Alternatives tested and rejected

- **Restoring `tune!()`** — still grows the HIP pool 10x (64 MiB -> 640 MiB), and picks `evals=1` for 65 of 69 benchmarks anyway since its criterion is timer resolution. Costs ~442 s and fixes nothing.
- **Dropping the GC from `setup`** — takes the pool to 25.7 GB on a 24 GiB card and the suite never finishes. The original hang, reproduced. Now commented as load-bearing.
- **`evals=2`** — worst of the three (50/69 benchmarks drifting >5% run-to-run, vs 16/69 at `evals=1` and 11/69 at `evals=4`): a 50/50 slow/fast split puts the sample mean between the two levels.

`evals=4` keeps the pool flat at 96 MiB across four full runs, identical to `evals=1`.

### Impact

Allocation-heavy benchmarks drop ~1.5-1.9x at this commit; others are unaffected. Baselines get a one-time discontinuity here — no reset needed, but read regressions across this commit with that in mind.

Tested on Radeon RX 7900 XTX (gfx1100, 24 GiB), ROCm 7.2.3, Julia 1.12.6.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)