### PR TITLE
Support ROCm 7.14+ versioned core-* library layout

### DIFF
--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -44,6 +44,10 @@ AMDGPU.functional(:all)         # true only if every component is available
 
 Run `AMDGPU.versioninfo()` and check that `hip` and the library you need report as functional. Missing components usually mean the corresponding ROCm package is not installed. See [Installation Info](@ref) for platform-specific setup, including the package list for distributions such as Fedora.
 
+## I installed ROCm 7.14 or newer but it isn't detected
+
+ROCm 7.14 changed its on-disk layout, installing libraries under a versioned `core-<version>` subdirectory (for example `/opt/rocm/core-7.14/lib`). AMDGPU.jl discovers this automatically, but if detection fails on a minimal or custom install, make sure `ROCM_PATH` points at the ROCm root (e.g. `/opt/rocm`) rather than at the versioned subdirectory. See [Installation Info](@ref) for details.
+
 ## I'm on Arch Linux and ROCm isn't working
 
 For the last few ROCm releases, users have reported problems with the distro-provided ROCm builds and associated tools ([#770](https://github.com/JuliaGPU/AMDGPU.jl/issues/770), [#696](https://github.com/JuliaGPU/AMDGPU.jl/issues/696), [#767](https://github.com/JuliaGPU/AMDGPU.jl/issues/767)). Some have had success with the [`opencl-amd-dev`](https://aur.archlinux.org/packages/opencl-amd-dev) AUR package instead.

--- a/docs/src/install_tips.md
+++ b/docs/src/install_tips.md
@@ -13,6 +13,8 @@ If you have non-standard path for ROCm, set `ROCM_PATH=<path>`
 environment variable before launching Julia. The `AMDGPU.versioninfo()`
 function prints the paths of any libraries found.
 
+Starting with ROCm 7.14, libraries are installed under a versioned `core-<version>` subdirectory (for example `/opt/rocm/core-7.14/lib`) instead of directly in `/opt/rocm/lib`. AMDGPU.jl handles this automatically by selecting the newest `core-*` directory found under the ROCm root, so keep `ROCM_PATH` pointed at the install root (e.g. `/opt/rocm`) rather than at the versioned subdirectory. A full ("metapackage") install additionally provides a `/opt/rocm/lib` compatibility symlink and needs no special handling; the versioned lookup mainly benefits minimal, GPU-architecture-specific installs that omit that symlink.
+
 Depending on your GPU model and the functionality you want to use, you may have
 to force the GPU architecture by setting the `HSA_OVERRIDE_GFX_VERSION`
 variable to a compatible version.

--- a/src/discovery/utils.jl
+++ b/src/discovery/utils.jl
@@ -1,3 +1,28 @@
+# Enumerate `<root>/core-<version>` subdirectories (ROCm 7.14+ packaging),
+# sorted newest-version first. Returns absolute paths.
+function rocm_core_dirs(path::String)::Vector{String}
+    isdir(path) || return String[]
+    cores = Tuple{VersionNumber, String}[]
+    for entry in readdir(path)
+        startswith(entry, "core-") || continue
+        full = joinpath(path, entry)
+        isdir(full) || continue
+        v = tryparse(VersionNumber, chopprefix(entry, "core-"))
+        v === nothing && continue
+        push!(cores, (v, full))
+    end
+    sort!(cores; by=first, rev=true)
+    return String[c[2] for c in cores]
+end
+
+# True if `dir` holds the HIP runtime library, matching both the unversioned
+# `libamdhip64.so` and versioned `libamdhip64.so.N` (a minimal, gfx-specific
+# install may ship only the latter, without the `-dev` symlink).
+function has_hip_lib(dir::String, libname::String)::Bool
+    isdir(dir) || return false
+    return any(f -> startswith(f, libname), readdir(dir))
+end
+
 # use amdhip as query for a valid rocm_path
 function check_rocm_path(path::String)
     libname = (Sys.islinux() ? "libamdhip64" : "amdhip64") * "." * dlext
@@ -14,6 +39,16 @@ function check_rocm_path(path::String)
         for triplet in ("x86_64-linux-gnu", "aarch64-linux-gnu", "i386-linux-gnu")
             path2 = joinpath(path, "lib", triplet)
             isfile(joinpath(path2, libname)) && @goto success
+        end
+    end
+    # ROCm 7.14+ nests libraries under `<root>/core-<version>/lib`. A full
+    # metapackage install also exposes them via `<root>/lib` (handled above via
+    # a compat symlink), but a minimal, gfx-specific install may not, so probe
+    # the versioned core dirs directly, newest first.
+    if Sys.islinux()
+        for core in rocm_core_dirs(path)
+            path2 = joinpath(core, "lib")
+            has_hip_lib(path2, libname) && @goto success
         end
     end
     return ""
@@ -79,9 +114,14 @@ end
 function find_device_libs(rocm_path::String)::String
     env_dir = get(ENV, "ROCM_PATH", "")
     if isdir(env_dir)
-        path = joinpath(env_dir, "amdgcn", "bitcode")
-        path = check_device_libs(path)
-        isdir(path) && return path
+        for cand in (
+            joinpath(env_dir, "amdgcn", "bitcode"),
+            # ROCm 7.14+ nests device bitcode under lib/llvm/.
+            joinpath(env_dir, "lib", "llvm", "amdgcn", "bitcode"),
+        )
+            path = check_device_libs(cand)
+            isdir(path) && return path
+        end
     end
     # Might be set by tools like Spack or the user
     hip_devlibs_path = get(ENV, "HIP_DEVICE_LIB_PATH", "")
@@ -89,10 +129,15 @@ function find_device_libs(rocm_path::String)::String
     devlibs_path = get(ENV, "DEVICE_LIB_PATH", "")
     devlibs_path !== "" && return devlibs_path
     # Try using hipconfig to find the device libraries.
-    # Try the canonical location.
-    canonical_dir = joinpath(rocm_path, "amdgcn", "bitcode")
-    canonical_dir = check_device_libs(canonical_dir)
-    isdir(canonical_dir) && return canonical_dir
+    # Try the canonical location (`rocm_path` is the libdir).
+    for cand in (
+        joinpath(rocm_path, "amdgcn", "bitcode"),
+        # ROCm 7.14+ nests device bitcode under llvm/.
+        joinpath(rocm_path, "llvm", "amdgcn", "bitcode"),
+    )
+        canonical_dir = check_device_libs(cand)
+        isdir(canonical_dir) && return canonical_dir
+    end
     # Fedora might put it in a weird place
     hipconfig = Sys.which("hipconfig")
     if !isnothing(hipconfig)

--- a/test/core/discovery_tests.jl
+++ b/test/core/discovery_tests.jl
@@ -1,0 +1,112 @@
+using Test
+using AMDGPU
+
+# Pure-filesystem tests for ROCm library discovery against synthetic trees
+# (no real ROCm install or GPU needed). Two kinds of test live here:
+#
+#   * "behaviour"  — layout-independent properties of the discovery functions.
+#                    Version numbers in the fixtures are representative, not
+#                    special-cased; these should hold for any ROCm generation
+#                    that nests libraries under a versioned subdir.
+#   * "layout pins" — concrete on-disk locations AMD chose for a given ROCm
+#                    generation. When a future ROCm moves these, ADD the new
+#                    path (keep the old for back-compat) rather than editing
+#                    in place.
+const Disc = AMDGPU.ROCmDiscovery
+
+# The `core-*` fallback and the `libamdhip64` naming are Linux-specific.
+if Sys.islinux()
+
+hip_lib(dir) = (mkpath(dir); touch(joinpath(dir, "libamdhip64.so")); dir)
+hip_lib_versioned(dir) = (mkpath(dir); touch(joinpath(dir, "libamdhip64.so.7")); dir)
+
+@testset "ROCm discovery" begin
+
+@testset "behaviour: rocm_core_dirs orders newest-first" begin
+    mktempdir() do root
+        @test isempty(Disc.rocm_core_dirs(root))
+        mkpath(joinpath(root, "core-7.2"))
+        mkpath(joinpath(root, "core-7.14"))
+        mkpath(joinpath(root, "core"))       # unversioned -> ignored
+        touch(joinpath(root, "core-junk"))   # not a dir / not a version
+        dirs = Disc.rocm_core_dirs(root)
+        @test length(dirs) == 2
+        @test basename(dirs[1]) == "core-7.14"   # newest first
+        @test basename(dirs[2]) == "core-7.2"
+    end
+    @test isempty(Disc.rocm_core_dirs(joinpath(tempdir(), "no-such-dir-xyz")))
+end
+
+@testset "behaviour: flat lib/ is found" begin
+    mktempdir() do root
+        hip_lib(joinpath(root, "lib"))
+        @test Disc.check_rocm_path(root) == joinpath(root, "lib")
+    end
+end
+
+@testset "behaviour: flat lib/ via compat symlink resolves" begin
+    mktempdir() do root
+        real = hip_lib(joinpath(root, "core-7.14", "lib"))
+        symlink(real, joinpath(root, "lib"))
+        # The `<root>/lib` probe resolves through the symlink and wins before
+        # the versioned-core fallback is reached.
+        @test Disc.check_rocm_path(root) == joinpath(root, "lib")
+    end
+end
+
+@testset "behaviour: fall back to versioned core-*/lib" begin
+    mktempdir() do root
+        hip_lib(joinpath(root, "core-7.14", "lib"))
+        @test Disc.check_rocm_path(root) == joinpath(root, "core-7.14", "lib")
+    end
+end
+
+@testset "behaviour: match versioned-only soname" begin
+    mktempdir() do root
+        # Minimal install may ship only `libamdhip64.so.N`, no `-dev` symlink.
+        hip_lib_versioned(joinpath(root, "core-7.14", "lib"))
+        @test Disc.check_rocm_path(root) == joinpath(root, "core-7.14", "lib")
+    end
+end
+
+@testset "behaviour: newest core-* wins" begin
+    mktempdir() do root
+        hip_lib(joinpath(root, "core-7.2", "lib"))
+        hip_lib(joinpath(root, "core-7.14", "lib"))
+        @test Disc.check_rocm_path(root) == joinpath(root, "core-7.14", "lib")
+    end
+end
+
+@testset "behaviour: nothing found returns empty" begin
+    mktempdir() do root
+        @test Disc.check_rocm_path(root) == ""
+    end
+end
+
+@testset "layout pins: device-libs directories" begin
+    withenv(
+        "ROCM_PATH" => nothing,
+        "HIP_DEVICE_LIB_PATH" => nothing,
+        "DEVICE_LIB_PATH" => nothing,
+    ) do
+        # Known bitcode locations, one row per ROCm generation. Append new
+        # rows here when the layout shifts; do not edit existing ones.
+        for (label, subdir, fname) in (
+            ("classic <libdir>/amdgcn/bitcode",     ("amdgcn", "bitcode"),         "hip.bc"),
+            ("7.14 <libdir>/llvm/amdgcn/bitcode",   ("llvm", "amdgcn", "bitcode"), "hip.bc"),
+            ("7.14 hip.amdgcn.bc filename variant", ("llvm", "amdgcn", "bitcode"), "hip.amdgcn.bc"),
+        )
+            @testset "$label" begin
+                mktempdir() do libdir
+                    bc = joinpath(libdir, subdir...)
+                    mkpath(bc); touch(joinpath(bc, fname))
+                    @test Disc.find_device_libs(libdir) == bc
+                end
+            end
+        end
+    end
+end
+
+end # @testset "ROCm discovery"
+
+end # Sys.islinux()


### PR DESCRIPTION
## Summary

ROCm 7.14 restructures its install: libraries now sit under a versioned `<root>/core-<ver>/lib` tier (e.g. `/opt/rocm/core-7.14/lib`) instead of a flat `<root>/lib`. A full metapackage install still exposes `<root>/lib` through a Debian-alternatives compat symlink, so discovery keeps working there — but a **minimal, gfx-specific install** (the layout AMD now recommends) may omit that symlink, leaving `find_roc_path()` to fall through and ROCm undetected. Device bitcode also moved to `lib/llvm/amdgcn/bitcode`.

Closes #986.

## Changes

- **`check_rocm_path`**: after the existing probes, fall back to `<root>/core-*/lib`, newest version first. Adds helpers `rocm_core_dirs` (glob + version sort) and `has_hip_lib` (matches both `libamdhip64.so` and versioned `libamdhip64.so.N`, since a minimal install may ship only the latter).
- **`find_device_libs`**: also probe `lib/llvm/amdgcn/bitcode` (the 7.14 location) in both the `ROCM_PATH` and libdir branches. Only affects the `JULIA_AMDGPU_DISABLE_ARTIFACTS=1` path; default installs use the artifact device libs and are unchanged.
- New **`test/core/discovery_tests.jl`**: GPU-free synthetic-tree tests, split into layout-independent behaviour and concrete per-generation "layout pins".

## Validation

- No regression on ROCm 7.2.3 (flat layout → `/opt/rocm/lib`, `functional() == true`).
- Real `rocm/dev-ubuntu-24.04:7.14.0-full` image: discovered via the compat symlink.
- Same image with `/opt/rocm/lib` removed (emulating a minimal install): the unpatched probes all miss, while the patched `check_rocm_path` resolves `/opt/rocm/core-7.14/lib` and `AMDGPU.functional() == true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)