### PR TITLE
Make `versioninfo()` robust to version-probe crashes

### DIFF
--- a/src/rand/rocRAND.jl
+++ b/src/rand/rocRAND.jl
@@ -17,8 +17,12 @@ include("error.jl")
 include("librocrand.jl")
 
 function version()
-    s = string(ROCRAND_VERSION)
-    VersionNumber(join([string(s[1]), s[2:4], s[5:end]], '.'))
+    # Query the loaded library at runtime rather than reporting the compile-time
+    # `ROCRAND_VERSION` constant, so `versioninfo` shows the installed version.
+    v = Ref{Cint}()
+    rocrand_get_version(v)
+    ver = Int(v[])
+    VersionNumber(ver ÷ 100_000, (ver ÷ 100) % 1000, ver % 100)
 end
 
 # stdlib Random integration

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,39 @@
+# Run `code` in a short-lived subprocess and return its stdout, or `nothing` if
+# it crashed, timed out, or exited nonzero. Isolates version probes that can
+# segfault on broken ROCm installs, where SIGSEGV isn't catchable in-process.
+function _version_subprocess(code::String; timeout::Real = 60)
+    project = Base.active_project()
+    projarg = project === nothing ? "@." : dirname(project)
+    cmd = `$(Base.julia_cmd()) --startup-file=no --project=$projarg -e $code`
+    out = IOBuffer()
+    try
+        proc = run(pipeline(ignorestatus(cmd); stdout = out, stderr = devnull); wait = false)
+        timedout = Ref(false)
+        timer = Timer(timeout) do _
+            if process_running(proc)
+                timedout[] = true
+                kill(proc)
+            end
+        end
+        wait(proc)
+        close(timer)
+        (timedout[] || !success(proc)) && return nothing
+        v = strip(String(take!(out)))
+        return isempty(v) ? nothing : v
+    catch
+        return nothing
+    end
+end
+
+# rocSPARSE's version query needs a handle, which inits a HIP context and can
+# segfault on broken ROCm installs (issue #920). Probe it out-of-process so a
+# crash degrades to `"err"` instead of killing the session.
+_rocsparse_version_isolated(; timeout::Real = 60) = _version_subprocess("""
+    using AMDGPU
+    AMDGPU.functional(:rocsparse) || exit(2)
+    print(AMDGPU.rocSPARSE.version())
+    """; timeout)
+
 """
     versioninfo(io::IO=stdout)
 
@@ -10,13 +46,23 @@ function versioninfo(io::IO=stdout)
     _status(st::Bool) = st ? "+" : "-"
     _libpath(p::String) = isempty(p) ? "-" : p
     _ver(lib::Symbol, ver_fn) = functional(lib) ? "$(ver_fn())" : "-"
+
+    # `"err"` = present but the out-of-process version probe crashed/timed out.
+    rocsparse_failed = false
+    rocsparse_ver = if functional(:rocsparse)
+        v = _rocsparse_version_isolated()
+        v === nothing ? (rocsparse_failed = true; "err") : v
+    else
+        "-"
+    end
+
     data = String[
         _status(functional(:lld))         "LLD"              "-"                                 _libpath(lld_path);
         _status(functional(:device_libs)) "Device Libraries" "-"                                 _libpath(libdevice_libs);
         _status(functional(:hip))         "HIP"              _ver(:hip, HIP.runtime_version)     _libpath(libhip);
         _status(functional(:rocblas))     "rocBLAS"          _ver(:rocblas, rocBLAS.version)     _libpath(librocblas);
         _status(functional(:rocsolver))   "rocSOLVER"        _ver(:rocsolver, rocSOLVER.version) _libpath(librocsolver);
-        _status(functional(:rocsparse))   "rocSPARSE"        _ver(:rocsparse, rocSPARSE.version) _libpath(librocsparse);
+        _status(functional(:rocsparse))   "rocSPARSE"        rocsparse_ver                       _libpath(librocsparse);
         _status(functional(:rocrand))     "rocRAND"          _ver(:rocrand, rocRAND.version)     _libpath(librocrand);
         _status(functional(:rocfft))      "rocFFT"           _ver(:rocfft, rocFFT.version)       _libpath(librocfft);
         _status(functional(:MIOpen))      "MIOpen"           _ver(:MIOpen, MIOpen.version)       _libpath(libMIOpen_path);
@@ -25,6 +71,13 @@ function versioninfo(io::IO=stdout)
     PrettyTables.pretty_table(io, data; column_labels=[
         "Available", "Name", "Version", "Path"],
         alignment=[:c, :l, :l, :l])
+
+    if rocsparse_failed
+        @warn """rocSPARSE is installed but its version query failed (it ran in an \
+            isolated subprocess and crashed or timed out). This usually indicates a \
+            broken or mismatched ROCm install. See \
+            https://github.com/JuliaGPU/AMDGPU.jl/issues/920."""
+    end
 
     if functional(:hip)
         println(io)

--- a/test/core/core_tests.jl
+++ b/test/core/core_tests.jl
@@ -9,6 +9,29 @@ using AMDGPU: HIP, Runtime, Device, Mem
     @test AMDGPU.functional() isa Bool
 end
 
+@testset "versioninfo probe isolation" begin
+    probe(code; timeout = 60) = AMDGPU._version_subprocess(code; timeout)
+
+    # A clean child returns its stdout.
+    @test probe("print(\"4.2.0\")") == "4.2.0"
+
+    # A failing child degrades to `nothing` without taking down this process —
+    # the point of the isolation: a SIGSEGV in a vendor library (issue #920)
+    # must not crash the caller.
+    @test probe("ccall(:abort, Cvoid, ())") === nothing       # SIGABRT
+    @test probe("unsafe_store!(Ptr{Int}(0), 0)") === nothing  # SIGSEGV
+    @test probe("exit(2)") === nothing                        # nonzero exit
+    @test probe("1 + 1") === nothing                          # no output
+    @test probe("while true; end"; timeout = 2) === nothing   # hang -> timeout
+
+    # On a working setup the real rocSPARSE probe returns a parseable version.
+    if AMDGPU.functional(:rocsparse)
+        v = AMDGPU._rocsparse_version_isolated()
+        @test v !== nothing
+        @test tryparse(VersionNumber, v) !== nothing
+    end
+end
+
 @testset "HIPDevice" begin
     @testset "Device props" begin
         devices = AMDGPU.devices()


### PR DESCRIPTION
### Summary

`AMDGPU.versioninfo()` could take down the entire Julia session with an uncatchable `SIGSEGV` on broken or mismatched ROCm installs. This isolates the one crash-prone probe in a subprocess, and fixes rocRAND to report the actually loaded version. Relates to #920.

### Motivation

Of all the library `version()` calls in `versioninfo()`, only **rocSPARSE** requires creating a handle (`rocsparse_get_version(handle, …)`), which initializes a HIP context. On a broken/mismatched ROCm stack that can segfault (see #920), and a `SIGSEGV` cannot be caught with `try`/`catch`, so the crash propagated out and killed the caller. This is worse now that KA 0.10 forwards `KA.versioninfo(io, ::ROCBackend)` here (#868), exposing the crash through the backend-agnostic API.

Separately, `rocRAND.version()` reported the compile-time `ROCRAND_VERSION` constant (the version AMDGPU was built against) rather than the loaded library, the other libraries already probe at runtime.

### Changes

- **rocSPARSE**: probe its version in a short-lived subprocess with a timeout. A crash, hang, or nonzero exit degrades to `"err"` in the table plus a single warning, instead of crashing the session. The other libraries expose handle-free version queries and stay in-process.
- **rocRAND**: query `rocrand_get_version()` at runtime (handle-free, safe) instead of the compile-time constant.

`"err"` is distinct from `"-"`: `"-"` means the library was not found, `"err"` means it is present but its version query failed — itself a useful diagnostic signal.

### Testing

New `versioninfo probe isolation` testset asserts that a clean child returns its output while `SIGABRT` / `SIGSEGV` / nonzero-exit / no-output / hang all degrade to `nothing` without crashing the caller (the first cases are GPU-independent). Verified locally on gfx1100 (RX 7900 XTX): full `versioninfo()` output unchanged, rocSPARSE version now probed out-of-process, failure path shows `err` + warning.
