### PR TITLE
don't pick up device libs in current dir during precompilation

### DIFF
--- a/src/compiler/device_libs.jl
+++ b/src/compiler/device_libs.jl
@@ -1,6 +1,7 @@
 import AMDGPU: libdevice_libs
 
 function locate_lib(file)
+    isempty(libdevice_libs) && return nothing
     file_path = joinpath(libdevice_libs, file * ".bc")
     if !ispath(file_path)
         file_path = joinpath(libdevice_libs, file * ".amdgcn.bc")


### PR DESCRIPTION
I doubt many people will run into this, but it took my an embarassingly long time to figure out why AMDGPU wasn't precompiling for me. Turns out I had a copy of `ockl.bc` in my current path. During precompilation `libdevice_libs` is empty, but `joinpath("", "ockl.bc")` is just `"ockl.bc"`, so AMDGPU.jl was picking up device libs from the current path during precompilation and failed.
