### PR TITLE
don't return reshaped array from `mapreducedim!`

### DIFF
--- a/src/kernels/mapreduce.jl
+++ b/src/kernels/mapreduce.jl
@@ -90,6 +90,7 @@ function GPUArrays.mapreducedim!(
     Base.check_reducedims(R, A)
     length(A) == 0 && return R # isempty(::Broadcasted) iterates
 
+    R_old = R
     # add singleton dimensions to the output container, if needed
     if ndims(R) < ndims(A)
         dims = Base.fill_to_length(size(R), 1, Val(ndims(A)))
@@ -168,5 +169,5 @@ function GPUArrays.mapreducedim!(
         AMDGPU.unsafe_free!(partial)
     end
 
-    return R
+    return R_old
 end

--- a/test/core/rocarray_base.jl
+++ b/test/core/rocarray_base.jl
@@ -260,4 +260,10 @@ end
     @test Array(x) == [true, true]
 end
 
+@testset "mapreducedim! returning same type" begin
+    R = transpose(AMDGPU.zeros(Float32, 2, 3))
+    A = ROCArray(rand(Float32, 3, 2, 10))
+    @test @inferred(GPUArrays.mapreducedim!(identity, +, R, A)) === R
+end
+
 end


### PR DESCRIPTION
Same as https://github.com/JuliaGPU/CUDA.jl/pull/3219, discovered in https://github.com/JuliaGPU/GPUArrays.jl/pull/754.