### PR TITLE
support DocumenterVitepress 0.3

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -11,4 +11,4 @@ AMDGPU = {path = ".."}
 
 [compat]
 Documenter = "1"
-DocumenterVitepress = "0.2.5"
+DocumenterVitepress = "0.3"

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,12 +1,7 @@
 {
   "devDependencies": {
-    "@nolebase/vitepress-plugin-enhanced-readabilities": "^2.14.0",
-    "@types/d3-format": "^3.0.4",
-    "@types/node": "^22.13.4",
-    "markdown-it": "^14.1.0",
-    "markdown-it-mathjax3": "^4.3.2",
-    "vitepress": "^1.6.3",
-    "vitepress-plugin-tabs": "^0.6.0"
+    "@types/markdown-it-footnote": "^3.0.4",
+    "@types/node": "^25.3.5"
   },
   "scripts": {
     "docs:dev": "vitepress dev build/.documenter",
@@ -14,7 +9,13 @@
     "docs:preview": "vitepress preview build/.documenter"
   },
   "dependencies": {
-    "d3-format": "^3.1.0",
-    "markdown-it-footnote": "^4.0.0"
+    "@mathjax/src": "^4.1.2",
+    "@mdit/plugin-mathjax": "^0.26.1",
+    "@mdit/plugin-tex": "^0.24.1",
+    "@nolebase/vitepress-plugin-enhanced-readabilities": "^2.18.2",
+    "markdown-it": "^14.1.0",
+    "markdown-it-footnote": "^4.0.0",
+    "vitepress": "^1.6.4",
+    "vitepress-plugin-tabs": "^0.8.0"
   }
 }


### PR DESCRIPTION
Supersedes #1007. That PR bumps the `DocumenterVitepress` compat entry, but the docs build then fails in CI.

## Why the plain compat bump fails

DocumenterVitepress substitutes its own `.vitepress/config.mts` and `mathjax-plugin.ts` at build time, but it never adds the npm packages those files import — `npm install` only ever sees the tracked `docs/package.json`. 0.3 moved from MathJax 3 (`markdown-it-mathjax3`) to MathJax 4, so the substituted plugin imports `@mathjax/src` and `@mdit/plugin-tex`, neither of which our `package.json` listed:

```
failed to load config from .../docs/build/.documenter/.vitepress/config.mts
build error:
Cannot find package '@mathjax/src' imported from .../config.mts
```

This stays invisible locally for as long as `docs/node_modules` predates the bump — only a clean install, as CI does, hits it.

## Changes

- `docs/package.json` aligned with DocumenterVitepress 0.3.5's `template/package.json`: adds `@mathjax/src`, `@mdit/plugin-mathjax`, `@mdit/plugin-tex` and `@types/markdown-it-footnote`; bumps `vitepress`, `vitepress-plugin-tabs`, `@nolebase/vitepress-plugin-enhanced-readabilities` and `@types/node`; drops `markdown-it-mathjax3` (superseded) and `d3-format`/`@types/d3-format` (only ever used by DocumenterVitepress' own repo-stars component, which this repo does not have).
- `docs/Project.toml` compat pinned to `"0.3"` instead of the `"0.2.5, 0.3"` range: 0.2's config imports `markdown-it-mathjax3` and 0.3's imports `@mathjax/src`, so a single `package.json` cannot serve both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
