### PR TITLE
docs: bundle the MathJax stylesheet and fix the doctest fence note

### DIFF
--- a/docs/src/.vitepress/theme/index.ts
+++ b/docs/src/.vitepress/theme/index.ts
@@ -1,5 +1,6 @@
 import DefaultTheme from "vitepress/theme";
 import type { Theme as ThemeConfig } from "vitepress";
+import "virtual:mathjax-styles.css";
 
 import VersionPicker from "../../components/VersionPicker.vue";
 import { enhanceAppWithTabs } from "vitepress-plugin-tabs/client";

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -54,4 +54,10 @@ julia --project=docs -e 'using LiveServer; serve(dir="docs/build/1")'
 The last command serves the built site locally; open the printed URL in a browser.
 
 !!! note "Doctests need a GPU"
-    `make.jl` runs with `doctest=true`, so every ```` ```jldoctest ```` block is executed on a real device. Building the docs therefore requires a functional AMD GPU, and a clean build means all examples still produce their documented output. When writing examples, prefer showing `Array(x)` rather than a raw `ROCArray` so the output does not depend on internal buffer types.
+    `make.jl` runs with `doctest=true`, so every block opening with
+
+    ````
+    ```jldoctest
+    ````
+
+    is executed on a real device. Building the docs therefore requires a functional AMD GPU, and a clean build means all examples still produce their documented output. When writing examples, prefer showing `Array(x)` rather than a raw `ROCArray` so the output does not depend on internal buffer types.


### PR DESCRIPTION
Two small, independent docs rendering fixes.

**MathJax stylesheet.** We vendor `docs/src/.vitepress/theme/index.ts`, so DocumenterVitepress uses ours instead of substituting its own. Ours predates 0.3, which moved MathJax's generated stylesheet behind the `virtual:mathjax-styles.css` module the stock theme imports. Without it equations still draw — MathJax 4 inlines the glyph paths — but lose MathJax's own container, line-break, selection and tooltip rules; the built site had none of `mjx-break`, `mjx-collapsed` or `mjx-selected`. Mostly insurance, since the docs contain no real math yet: it matters the first time an equation lands, in particular for the `displayOverflow: 'linebreak'` that 0.3 enables.

**Doctest fence.** `docs/src/testing.md` showed the fence as an inline code span delimited by four backticks, the CommonMark idiom. Julia's Markdown opens inline *math* on any backtick run of two or more, so Documenter parsed it as `Markdown.LaTeX`, emitted `$```jldoctest$`, and the page rendered a triple-prime glyph followed by italic *jldoctest*. No inline spelling avoids this — entities aren't decoded inside code spans, and backslash escapes split the span — so the note now uses a fenced block, which is parsed by fence length. This predates the 0.3 bump; it rendered the same way under 0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)