### PR TITLE
Only convert alpha/beta when the element type is a rocBLAS type.

### DIFF
--- a/src/blas/highlevel.jl
+++ b/src/blas/highlevel.jl
@@ -217,7 +217,7 @@ function LinearAlgebra.generic_matmatmul!(
     end
 
     T = eltype(C)
-    if alpha isa Union{Bool, T} && beta isa Union{Bool, T}
+    if T <: ROCBLASFloat && alpha isa Union{Bool, T} && beta isa Union{Bool, T}
         α, β = T(alpha), T(beta)
 
         if (


### PR DESCRIPTION
`*` calls `generic_matmatmul!` with `alpha::Bool`, so the `Bool` arm of `alpha isa Union{Bool,T}` admits any element type, and `T(alpha)` then errors for types that aren't constructible from a `Bool` (`MethodError: no method matching SVector{2,Float32}(::Bool)`) before we ever reach the `GPUArrays.generic_matmatmul!` fallback at the bottom.

The guard is a superset of what every branch inside it already needs: `gemm!` tests `T <: ROCBLASFloat` itself, and `symm!`/`hemm!` are only instantiated for those element types (the complex ones, for `hemm!`). So no operation that used to reach rocBLAS stops doing so; element types that previously fell through the branch, or hit a `MethodError` in `symm!`, now go straight to the generic fallback.

Exposed by the new `linalg/mul!/mixed-eltype` testsuite entry from JuliaGPU/GPUArrays.jl#758.