### PR TITLE
Fix generic_matmul handling of size zero arrays

### DIFF
--- a/src/blas/highlevel.jl
+++ b/src/blas/highlevel.jl
@@ -142,7 +142,7 @@ function LinearAlgebra.generic_matvecmul!(
         "first dimension of A, $mA, does not match length of Y, $(length(Y))"))
 
     mA == 0 && return Y
-    nA == 0 && return _rmul_or_fill!(Y, β)
+    nA == 0 && return _rmul_or_fill!(Y, beta)
 
     T = eltype(Y)
     if alpha isa Union{Bool,T} && beta isa Union{Bool,T}
@@ -213,7 +213,7 @@ function LinearAlgebra.generic_matmatmul!(
     if mA == 0 || nA == 0 || nB == 0
         size(C) != (mA, nB) && throw(DimensionMismatch(
             "C has dimensions $(size(C)), should have ($mA,$nB)"))
-        return LinearAlgebra._rmul_or_fill!(C, β)
+        return LinearAlgebra._rmul_or_fill!(C, beta)
     end
 
     T = eltype(C)

--- a/src/blas/highlevel.jl
+++ b/src/blas/highlevel.jl
@@ -142,7 +142,7 @@ function LinearAlgebra.generic_matvecmul!(
         "first dimension of A, $mA, does not match length of Y, $(length(Y))"))
 
     mA == 0 && return Y
-    nA == 0 && return rmul!(Y, 0)
+    nA == 0 && return _rmul_or_fill!(Y, β)
 
     T = eltype(Y)
     if alpha isa Union{Bool,T} && beta isa Union{Bool,T}
@@ -213,7 +213,7 @@ function LinearAlgebra.generic_matmatmul!(
     if mA == 0 || nA == 0 || nB == 0
         size(C) != (mA, nB) && throw(DimensionMismatch(
             "C has dimensions $(size(C)), should have ($mA,$nB)"))
-        return LinearAlgebra.rmul!(C, 0)
+        return LinearAlgebra._rmul_or_fill!(C, β)
     end
 
     T = eltype(C)

--- a/src/blas/highlevel.jl
+++ b/src/blas/highlevel.jl
@@ -142,7 +142,7 @@ function LinearAlgebra.generic_matvecmul!(
         "first dimension of A, $mA, does not match length of Y, $(length(Y))"))
 
     mA == 0 && return Y
-    nA == 0 && return _rmul_or_fill!(Y, beta)
+    nA == 0 && return LinearAlgebra._rmul_or_fill!(Y, beta)
 
     T = eltype(Y)
     if alpha isa Union{Bool,T} && beta isa Union{Bool,T}

--- a/test/hip_rocarray/blas.jl
+++ b/test/hip_rocarray/blas.jl
@@ -816,8 +816,8 @@ end
         end
         # matrix * vector 
         C0 = rand(T, m)
-        A0 = rand(T, k)
-        B0 = rand(T, k, m)
+        A0 = rand(T, m, k)
+        B0 = rand(T, k)
         for (α, β) in ( (-one(T), one(T)), (one(T), 2*one(T)), (one(T), zero(T))) 
             Ccpu = copy(C0)
             mul!(Ccpu, A0, B0, α, β)

--- a/test/hip_rocarray/blas.jl
+++ b/test/hip_rocarray/blas.jl
@@ -790,10 +790,34 @@ end
 
 @testset "Handling size zero arrays correctly" begin
     for T in (Float32, Float64, ComplexF32, ComplexF64)
-        m, k, n = (12, 6, 0)
+        m, n, k = (12, 6, 0)
+        # matrix * matrix
         C0 = rand(T, m, n)
         A0 = rand(T, m, k)
         B0 = rand(T, k, n)
+        for (α, β) in ( (-one(T), one(T)), (one(T), 2*one(T)), (one(T), zero(T))) 
+            Ccpu = copy(C0)
+            mul!(Ccpu, A0, B0, α, β)
+            Cgpu = ROCArray(copy(C0))
+            mul!(Cgpu, ROCArray(A0), ROCArray(B0), α, β)
+            @test Ccpu ≈ Array(Cgpu)
+        end
+        # C0 is NaN and beta is zero to test beta is applied
+        C0 = rand(T, m, n)
+        C0[m-1, n-1] = T(NaN)
+        A0 = rand(T, m, k)
+        B0 = rand(T, k, n)
+        for (α, β) in ( (one(T), zero(T)), )
+            Ccpu = copy(C0)
+            mul!(Ccpu, A0, B0, α, β)
+            Cgpu = ROCArray(copy(C0))
+            mul!(Cgpu, ROCArray(A0), ROCArray(B0), α, β)
+            @test Ccpu ≈ Array(Cgpu)
+        end
+        # matrix * vector 
+        C0 = rand(T, m)
+        A0 = rand(T, k)
+        B0 = rand(T, k, m)
         for (α, β) in ( (-one(T), one(T)), (one(T), 2*one(T)), (one(T), zero(T))) 
             Ccpu = copy(C0)
             mul!(Ccpu, A0, B0, α, β)

--- a/test/hip_rocarray/blas.jl
+++ b/test/hip_rocarray/blas.jl
@@ -786,6 +786,22 @@ end
             end
         end
     end
-
 end
+
+@testset "Handling size zero arrays correctly" begin
+    for T in (Float32, Float64, ComplexF32, ComplexF64)
+        m, k, n = (12, 6, 0)
+        C0 = rand(T, m, n)
+        A0 = rand(T, m, k)
+        B0 = rand(T, k, n)
+        for (α, β) in ( (-one(T), one(T)), (one(T), 2*one(T)), (one(T), zero(T))) 
+            Ccpu = copy(C0)
+            mul!(Ccpu, A0, B0, α, β)
+            Cgpu = ROCArray(copy(C0))
+            mul!(Cgpu, ROCArray(A0), ROCArray(B0), α, β)
+            @test Ccpu ≈ Array(Cgpu)
+        end
+    end
+end
+
 end

--- a/test/hip_rocarray/blas.jl
+++ b/test/hip_rocarray/blas.jl
@@ -803,8 +803,7 @@ end
             @test Ccpu ≈ Array(Cgpu)
         end
         # C0 is NaN and beta is zero to test beta is applied
-        C0 = rand(T, m, n)
-        C0[m-1, n-1] = T(NaN)
+        C0 = fill(T(NaN), m, n)
         A0 = rand(T, m, k)
         B0 = rand(T, k, n)
         for (α, β) in ( (one(T), zero(T)), )


### PR DESCRIPTION
Right now the `rmul!` *forces* `beta = 0` even when that should not be the case. However, the output should still be updated even if the input array is size 0.