### PR TITLE
MIOpen: fix some issues found running tests on fedora

### DIFF
--- a/src/dnn/activations.jl
+++ b/src/dnn/activations.jl
@@ -137,7 +137,7 @@ function _∇activation(
     xdesc, ydesc, dydesc, dxdesc = _activation_descriptor.((x, y, dy, dx))
     (; handle, stream) = lib_state()
     miopenActivationBackward(
-        handle, desc, Ref{Float32}(1f0), ydesc.handle, y,
+        handle, desc.handle, Ref{Float32}(1f0), ydesc.handle, y,
         dydesc.handle, dy, xdesc.handle, x, Ref{Float32}(0f0),
         dxdesc.handle, dx)
     dx

--- a/src/dnn/activations.jl
+++ b/src/dnn/activations.jl
@@ -112,11 +112,17 @@ end
 
 # Generic MIOpen interface.
 
+# MIOpen's `activ::ProblemDescription::MakeNetworkConfig` reads `lens[3]`/`lens[4]`
+# for any tensor with fewer than 2 dimensions, so hand it an equivalent 2D
+# descriptor for 1D inputs to avoid the out-of-bounds access.
+_activation_descriptor(x::ROCArray) =
+    TensorDescriptor(ndims(x) == 1 ? reshape(x, :, 1) : x)
+
 function _activation(
     x::ROCArray{T}, desc::ActivationDescriptor,
 ) where T <: MIOPENFloat
     y = similar(x)
-    xdesc, ydesc = TensorDescriptor.((x, y))
+    xdesc, ydesc = _activation_descriptor.((x, y))
     (; handle, stream) = lib_state()
     miopenActivationForward(
         handle, desc.handle, Ref{Float32}(1f0), xdesc.handle, x,
@@ -128,7 +134,7 @@ function _∇activation(
     dy::ROCArray{T}, y::ROCArray{T}, x::ROCArray{T}, desc::ActivationDescriptor,
 ) where T <: MIOPENFloat
     dx = similar(x)
-    xdesc, ydesc, dydesc, dxdesc = TensorDescriptor.((x, y, dy, dx))
+    xdesc, ydesc, dydesc, dxdesc = _activation_descriptor.((x, y, dy, dx))
     (; handle, stream) = lib_state()
     miopenActivationBackward(
         handle, desc, Ref{Float32}(1f0), ydesc.handle, y,

--- a/test/hip_dnn/activations.jl
+++ b/test/hip_dnn/activations.jl
@@ -11,6 +11,8 @@ using AMDGPU.MIOpen
         xd, dyd = ROCArray(x), ROCArray(dy)
 
         yd = MIOpen.relu(xd)
+        dxd = MIOpen.∇relu(dyd, yd, xd)
+        @test all(isapprox.(Array(dxd), dy .* (x .> 0); atol))
 
         yd = MIOpen.leakyrelu(xd, 0.1)
 
@@ -29,6 +31,8 @@ using AMDGPU.MIOpen
         y = tanh.(x)
         yd = MIOpen.tanh(xd)
         @test all(isapprox.(Array(yd), y; atol))
+        dxd = MIOpen.∇tanh(dyd, yd, xd)
+        @test all(isapprox.(Array(dxd), dy .* (1 .- y.^2); atol))
 
         # Non-negative values.
 

--- a/test/hip_dnn/batchnorm.jl
+++ b/test/hip_dnn/batchnorm.jl
@@ -4,6 +4,17 @@ using AMDGPU.MIOpen
 
 @assert AMDGPU.functional(:MIOpen)
 
+# MIOpen's batchnorm kernels gate their gfx9 DPP inline assembly on a list of
+# known RDNA device prefixes; releases before ROCm/rocm-libraries#1288 miss the
+# gfx115x/gfx125x families and fail to compile the kernels there.
+bn_broken = MIOpen.version() < v"3.6" &&
+    any(p -> startswith(AMDGPU.device().gcn_arch, p), ("gfx115", "gfx125"))
+
+if bn_broken
+    @info "Skipping MIOpen batchnorm tests (MIOpen $(MIOpen.version()) " *
+        "miscompiles batchnorm for $(AMDGPU.device().gcn_arch))"
+else
+
 @testset "Different input dimensions" begin
     for sz in ((3, 2), (4, 3, 2), (5, 4, 3, 2))
         x = AMDGPU.ones(Float32, sz)
@@ -29,4 +40,6 @@ using AMDGPU.MIOpen
         @test hμ_saved ≈ hμ_saved2
         @test hν_saved ≈ hν_saved2
     end
+end
+
 end


### PR DESCRIPTION
I encountered some test failures running the test suite using my local rocm installation shipped by Fedora 44. Also fixes and add tests covering `_∇activation`, which wasn't tested before