### PR TITLE
Override `sind`/`cosd` to avoid the malloc hostcall

### DIFF
--- a/src/device/quirks.jl
+++ b/src/device/quirks.jl
@@ -41,6 +41,65 @@ end
 @device_override Base.Math.sincos_domain_error(x) =
     @gpu_throw "DomainError: sincos(x) is only defined for finite x"
 
+# Bodies copied from Base (`base/special/trig.jl`) with the inline `DomainError`
+# throw replaced: boxing its untyped `val` field emits a device-side allocation.
+@device_override function Base.Math.sind(x::Real)
+    if isinf(x)
+        @gpu_throw "DomainError: sind(x) is only defined for finite x"
+    elseif isnan(x)
+        return x
+    end
+
+    rx = copysign(float(rem(x, 360)), x)
+    arx = abs(rx)
+
+    if rx == zero(rx)
+        return rx
+    elseif arx < oftype(rx, 45)
+        return Base.Math.sin_kernel(Base.Math.deg2rad_ext(rx))
+    elseif arx <= oftype(rx, 135)
+        y = Base.Math.deg2rad_ext(oftype(rx, 90) - arx)
+        return copysign(Base.Math.cos_kernel(y), rx)
+    elseif arx == oftype(rx, 180)
+        return copysign(zero(rx), rx)
+    elseif arx < oftype(rx, 225)
+        y = Base.Math.deg2rad_ext((oftype(rx, 180) - arx) * sign(rx))
+        return Base.Math.sin_kernel(y)
+    elseif arx <= oftype(rx, 315)
+        y = Base.Math.deg2rad_ext(oftype(rx, 270) - arx)
+        return -copysign(Base.Math.cos_kernel(y), rx)
+    else
+        y = Base.Math.deg2rad_ext(rx - copysign(oftype(rx, 360), rx))
+        return Base.Math.sin_kernel(y)
+    end
+end
+
+@device_override function Base.Math.cosd(x::Real)
+    if isinf(x)
+        @gpu_throw "DomainError: cosd(x) is only defined for finite x"
+    elseif isnan(x)
+        return x
+    end
+
+    rx = abs(float(rem(x, 360)))
+
+    if rx <= oftype(rx, 45)
+        return Base.Math.cos_kernel(Base.Math.deg2rad_ext(rx))
+    elseif rx < oftype(rx, 135)
+        y = Base.Math.deg2rad_ext(oftype(rx, 90) - rx)
+        return Base.Math.sin_kernel(y)
+    elseif rx <= oftype(rx, 225)
+        y = Base.Math.deg2rad_ext(oftype(rx, 180) - rx)
+        return -Base.Math.cos_kernel(y)
+    elseif rx < oftype(rx, 315)
+        y = Base.Math.deg2rad_ext(rx - oftype(rx, 270))
+        return Base.Math.sin_kernel(y)
+    else
+        y = Base.Math.deg2rad_ext(oftype(rx, 360) - rx)
+        return Base.Math.cos_kernel(y)
+    end
+end
+
 # multidimensional.jl
 @device_override Base.@propagate_inbounds function Base.getindex(
     iter::CartesianIndices{N,R}, I::Vararg{Int, N},

--- a/src/device/quirks.jl
+++ b/src/device/quirks.jl
@@ -43,6 +43,8 @@ end
 
 # Bodies copied from Base (`base/special/trig.jl`) with the inline `DomainError`
 # throw replaced: boxing its untyped `val` field emits a device-side allocation.
+# Provisional: JuliaLang/julia#62842 adds `Base.Math.sind_domain_error`, after
+# which these collapse to two overrides, once the compat floor reaches 1.14.
 @device_override function Base.Math.sind(x::Real)
     if isinf(x)
         @gpu_throw "DomainError: sind(x) is only defined for finite x"

--- a/test/device/math.jl
+++ b/test/device/math.jl
@@ -35,3 +35,40 @@ end
         @test xh[2] ≈ 0
     end
 end
+
+@testset "Degree trigonometry" begin
+    # `sind`/`cosd` are overridden in `device/quirks.jl` so that their
+    # `DomainError` does not box its argument into a malloc hostcall.
+    function kernel_ir(f, T)
+        kernel(out, x) = (@inbounds out[1] = sum(f(x[1])); nothing)
+        io = IOBuffer()
+        AMDGPU.code_llvm(io, kernel,
+            Tuple{AMDGPU.Device.ROCDeviceVector{T, 1}, AMDGPU.Device.ROCDeviceVector{T, 1}};
+            kernel=true, dump_module=true)
+        return String(take!(io))
+    end
+
+    for T in (Float32, Float64), f in (sind, cosd, tand, sincosd, cotd, secd, cscd)
+        @test !occursin("__malloc_hostcall", kernel_ir(f, T))
+    end
+
+    angles = [0, 1, 30, 44.9, 45, 90, 135, 179.9, 180, 225,
+              270, 315, 359.9, 360, 720, -45, -90, -180, -270, 12345.678]
+    for T in (Float16, Float32, Float64)
+        a = T.(angles)
+        d_a = ROCArray(a)
+
+        for f in (sind, cosd, tand, cotd, secd, cscd)
+            @test Array(f.(d_a)) ≈ f.(a) nans=true
+        end
+        @test Array(map(x -> sincosd(x)[1], d_a)) ≈ first.(sincosd.(a)) nans=true
+        @test Array(map(x -> sincosd(x)[2], d_a)) ≈ last.(sincosd.(a)) nans=true
+
+        # Exact at the quadrant boundaries, unlike `sin(deg2rad(x))`.
+        @test Array(sind.(ROCArray(T[0, 180, 360, -180]))) == T[0, 0, 0, 0]
+        @test Array(cosd.(ROCArray(T[90, 270, -90]))) == T[0, 0, 0]
+
+        @test all(isnan, Array(sind.(ROCArray(T[NaN]))))
+        @test all(isnan, Array(cosd.(ROCArray(T[NaN]))))
+    end
+end


### PR DESCRIPTION
Kernels calling `sind`, `cosd`, `tand`, `sincosd`, `secd`, `cscd` or `cotd` report `Global hostcalls detected! - Hostcalls: [:malloc_hostcall]` and spin up its persistent host-side polling task, without allocating anything.

Base's `sind`/`cosd` construct `DomainError(x, msg)` inline, and `DomainError.val` is untyped, so the argument gets boxed: on device that lowers to `gpu_malloc` then `Device.malloc`, writing the `__malloc_hostcall` marker global on a branch that never executes.

Fix: `@device_override` for `Base.Math.sind` and `Base.Math.cosd` with `@gpu_throw`. Base defines the other five in terms of those two, so the overlay covers all of them. The bodies are copied from Base verbatim apart from the throw (the algorithm is identical across Julia 1.10 to 1.13); `sin(deg2rad(x))` would be shorter but loses the exact zeros, `sind(180f0)` giving `-8.7e-8`, and would silently diverge from CPU results.

Tested on gfx1100: no `__malloc_hostcall` in the IR for all seven functions, results bit-identical to the CPU over 22 angles in Float32 and Float64, and `sind(Inf)` still raises `GPU Kernel Exception: DomainError`.

Added new "Degree trigonometry" testset in `test/device/math.jl`.