### PR TITLE
rocBLAS: route 16-bit mul! through gemm_ex (Float16 3→190 TFLOPS on MI300A)

### DIFF
--- a/src/blas/highlevel.jl
+++ b/src/blas/highlevel.jl
@@ -239,10 +239,7 @@ function LinearAlgebra.generic_matmatmul!(
         all(in(('N', 'T', 'C')), (tA, tB)) &&
         A isa StridedROCArray{T} && B isa StridedROCArray{T}
     )
-        # 16-bit eltypes aren't covered by the typed gemm! wrappers (Float16
-        # would map to legacy rocblas_hgemm, which Tensile doesn't tune);
-        # gemm_ex with Float32 accumulation is both the fast and the accurate
-        # path, instead of falling through to GPUArrays' generic kernel.
+        # The non gemm_ex version is slower than the gemm_ex for 16 bit floats
         return gemm_ex!(tA, tB, alpha, A, B, beta, C)
     end
 

--- a/src/blas/highlevel.jl
+++ b/src/blas/highlevel.jl
@@ -234,6 +234,16 @@ function LinearAlgebra.generic_matmatmul!(
         elseif (tB == 'H' || tB == 'h') && tA == 'N'
             return hemm!('R', tB == 'H' ? 'U' : 'L', α, B, A, β, C)
         end
+    elseif (
+        T in (Float16, BFloat16) && alpha isa Real && beta isa Real &&
+        all(in(('N', 'T', 'C')), (tA, tB)) &&
+        A isa StridedROCArray{T} && B isa StridedROCArray{T}
+    )
+        # 16-bit eltypes aren't covered by the typed gemm! wrappers (Float16
+        # would map to legacy rocblas_hgemm, which Tensile doesn't tune);
+        # gemm_ex with Float32 accumulation is both the fast and the accurate
+        # path, instead of falling through to GPUArrays' generic kernel.
+        return gemm_ex!(tA, tB, alpha, A, B, beta, C)
     end
 
     GPUArrays.generic_matmatmul!(C, wrap(A, tA), wrap(B, tB), alpha, beta)

--- a/src/blas/rocBLAS.jl
+++ b/src/blas/rocBLAS.jl
@@ -12,6 +12,7 @@ using LinearAlgebra
 using LinearAlgebra: AdjOrTrans, MulAddMul
 using LinearAlgebra: wrap, UpperOrLowerTriangular
 using CEnum
+using BFloat16s: BFloat16
 
 const rocblas_half = Float16
 const rocblas_float_complex = ComplexF32

--- a/src/blas/wrappers.jl
+++ b/src/blas/wrappers.jl
@@ -768,6 +768,54 @@ for (fname, elty) in
     end
 end
 
+## gemm_ex: GEMM through rocBLAS's Tensile-tuned mixed-precision path.
+# The typed gemm entry points map Float16 to legacy `rocblas_hgemm`, which is
+# not tuned (~3x slower than gemm_ex on MI300); gemm_ex with a Float32
+# compute type is the fast (and more accurate) route for 16-bit eltypes.
+
+gemmex_datatype(::Type{Float16}) = rocblas_datatype_f16_r
+gemmex_datatype(::Type{BFloat16}) = rocblas_datatype_bf16_r
+gemmex_datatype(::Type{Float32}) = rocblas_datatype_f32_r
+gemmex_datatype(::Type{Float64}) = rocblas_datatype_f64_r
+gemmex_datatype(::Type{ComplexF32}) = rocblas_datatype_f32_c
+gemmex_datatype(::Type{ComplexF64}) = rocblas_datatype_f64_c
+
+# 16-bit inputs accumulate in Float32; everything else computes in its own type
+gemmex_compute_type(TA, TB, TC) = promote_type(TA, TB, TC)
+gemmex_compute_type(::Type{Float16}, ::Type{Float16}, TC) = Float32
+gemmex_compute_type(::Type{BFloat16}, ::Type{BFloat16}, TC) = Float32
+
+function gemm_ex!(
+    transA::Char, transB::Char, alpha::Number,
+    A::StridedROCVecOrMat, B::StridedROCVecOrMat, beta::Number,
+    C::StridedROCVecOrMat;
+    compute_type::Type = gemmex_compute_type(eltype(A), eltype(B), eltype(C)),
+)
+    m = size(A, transA == 'N' ? 1 : 2)
+    k = size(A, transA == 'N' ? 2 : 1)
+    n = size(B, transB == 'N' ? 2 : 1)
+    if m != size(C, 1) || n != size(C, 2) || k != size(B, transB == 'N' ? 1 : 2)
+        throw(DimensionMismatch(""))
+    end
+
+    lda = max(1, stride(A, 2))
+    ldb = max(1, stride(B, 2))
+    ldc = max(1, stride(C, 2))
+    α = Ref(convert(compute_type, alpha))
+    β = Ref(convert(compute_type, beta))
+    (; handle, stream) = lib_state()
+    GC.@preserve A B C begin
+        rocblas_gemm_ex_64(handle, transA, transB, m, n, k,
+            α, pointer(A), gemmex_datatype(eltype(A)), lda,
+            pointer(B), gemmex_datatype(eltype(B)), ldb,
+            β, pointer(C), gemmex_datatype(eltype(C)), ldc,
+            pointer(C), gemmex_datatype(eltype(C)), ldc,
+            gemmex_datatype(compute_type), rocblas_gemm_algo_standard,
+            Int32(0), UInt32(0))
+    end
+    C
+end
+
 ## (SY) symmetric matrix-matrix and matrix-vector multiplication
 for (fname, elty) in ((:rocblas_dsymm,:Float64),
                       (:rocblas_ssymm,:Float32),

--- a/src/blas/wrappers.jl
+++ b/src/blas/wrappers.jl
@@ -767,12 +767,7 @@ for (fname, elty) in
         end
     end
 end
-
-## gemm_ex: GEMM through rocBLAS's Tensile-tuned mixed-precision path.
-# The typed gemm entry points map Float16 to legacy `rocblas_hgemm`, which is
-# not tuned (~3x slower than gemm_ex on MI300); gemm_ex with a Float32
-# compute type is the fast (and more accurate) route for 16-bit eltypes.
-
+\
 gemmex_datatype(::Type{Float16}) = rocblas_datatype_f16_r
 gemmex_datatype(::Type{BFloat16}) = rocblas_datatype_bf16_r
 gemmex_datatype(::Type{Float32}) = rocblas_datatype_f32_r

--- a/test/hip_rocarray/blas.jl
+++ b/test/hip_rocarray/blas.jl
@@ -2,6 +2,7 @@ using Test
 using AMDGPU
 using AMDGPU: ROCArray, ROCVector, ROCMatrix
 using LinearAlgebra
+using BFloat16s: BFloat16
 
 @assert AMDGPU.functional(:rocblas)
 
@@ -365,6 +366,23 @@ end
                 (c, a, b) -> mul!(c, f(a), g(b), Ts(1), Ts(1)),
                 rand(T, 5, 5), rand(T, 5, 5), rand(T, 5, 5))
         end
+    end
+
+    @testset "mul! 16-bit eltype (gemm_ex)" for T in (Float16, BFloat16)
+        # routed through gemm_ex! with Float32 accumulation, not the
+        # GPUArrays fallback (Float16) or rocblas_hgemm
+        A, B = rand(T, 128, 64), rand(T, 64, 96)
+        C = ROCArray(A) * ROCArray(B)
+        @test Array(C) ≈ Float32.(A) * Float32.(B) rtol=max(sqrt(eps(Float32)), 2 * Float32(eps(T)))
+        @test testf((c, a, b) -> mul!(c, transpose(a), b, T(2), T(1)),
+                    rand(T, 64, 96), rand(T, 128, 64), rand(T, 128, 96))
+    end
+
+    @testset "gemm_ex! direct" for T in (Float16, BFloat16, Float32)
+        A, B = ROCArray(rand(T, 32, 48)), ROCArray(rand(T, 48, 40))
+        C = ROCArray(zeros(T, 32, 40))
+        rocBLAS.gemm_ex!('N', 'N', 1, A, B, 0, C)
+        @test Array(C) ≈ Float32.(Array(A)) * Float32.(Array(B)) rtol=max(sqrt(eps(Float32)), 2 * Float32(eps(T)))
     end
 
     @testset for T in (Float32, Float64, ComplexF32, ComplexF64)

--- a/test/hip_rocarray/blas.jl
+++ b/test/hip_rocarray/blas.jl
@@ -368,9 +368,7 @@ end
         end
     end
 
-    @testset "mul! 16-bit eltype (gemm_ex)" for T in (Float16, BFloat16)
-        # routed through gemm_ex! with Float32 accumulation, not the
-        # GPUArrays fallback (Float16) or rocblas_hgemm
+    @testset "mul! 16-bit eltype" for T in (Float16, BFloat16)
         A, B = rand(T, 128, 64), rand(T, 64, 96)
         C = ROCArray(A) * ROCArray(B)
         @test Array(C) ≈ Float32.(A) * Float32.(B) rtol=max(sqrt(eps(Float32)), 2 * Float32(eps(T)))


### PR DESCRIPTION
Fixes #1048.

`Float16` `mul!` currently falls through to GPUArrays' generic kernel (the rocBLAS branch in `generic_matmatmul!` requires `T <: ROCBLASFloat`; the Julia-1.12 `generic_matmatmul_wrapper!` overload for `ROCBLASFloatWithHalf` forwards into that same branch). And the typed `gemm!` would be the wrong target anyway: Float16 there maps to legacy `rocblas_hgemm`, which Tensile doesn't tune.

This PR:

- adds `rocBLAS.gemm_ex!`, a high-level wrapper over `rocblas_gemm_ex_64` (mirrors `CUBLAS.gemmEx!`), with a datatype map for f16/bf16/f32/f64/c32/c64 and a compute-type rule giving 16-bit operands Float32 accumulation;
- dispatches `Float16`/`BFloat16` `mul!` through it in `generic_matmatmul!` (covers Julia 1.11 and 1.12 in one place);
- tests: 16-bit `mul!` against an f32 host reference, plus direct `gemm_ex!` tests for f16/bf16/f32. The existing Level 3 `mul!` testset already covers Float16 with every transpose/adjoint/alpha combination, and now exercises the new path.

Measured on an MI300A (gfx942, ROCm 7.2.4, Julia 1.12.6), 4096³, min of 20:

| eltype | `mul!` before | `mul!` after | legacy `gemm!` |
|---|---|---|---|
| Float16 | 3.0 TFLOPS | **190.3** | 69.6 |
| BFloat16 | (GPUArrays fallback) | **207.5** | n/a |
| Float32 | 49.9 | 49.9 | 50.2 |
| Float64 | 52.5 | 52.5 | 52.7 |

`gemm_ex` and typed `gemm!` are identical for f32/f64 (same Tensile kernels underneath), so this routing carries no regression risk; f32/f64 are left on their existing path regardless. Correctness validated for f16/bf16 × {N, T} at odd sizes (rel err ≤ 3.6e-4 / 2.9e-3 vs f32 host reference).

Only the ILP64 `rocblas_gemm_ex_64` binding exists in the generated wrappers, which is what's used here (rocBLAS ≥ 4.0 / ROCm ≥ 6.0).
