### PR TITLE
Transfer buffer ownership at conversion time instead of a per-launch locked phase

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -410,7 +410,7 @@ end
 
 function Adapt.adapt_storage(to::Runtime.Adaptor, x::ROCArray{T,N}) where {T,N}
     managed = x.buf[]
-    push!(to.managed, managed)
+    to.stream === nothing || take_ownership_fast!(managed, to.stream)
     buf = managed.mem
     ptr = convert(Ptr{T}, typeof(buf) <: Mem.HIPBuffer ? buf : buf.dev_ptr)
     llvm_ptr = AMDGPU.LLVMPtr{T,AS.Global}(ptr + x.offset)

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -90,8 +90,8 @@ input object `x` as-is.
 Do not add methods to this function, but instead extend the underlying Adapt.jl package and
 register methods for the the `AMDGPU.Adaptor` type.
 """
-rocconvert(arg, managed::Vector{Managed}=Managed[]) =
-    adapt(Runtime.Adaptor(managed), arg)
+rocconvert(arg) = adapt(Runtime.Adaptor(nothing), arg)
+rocconvert(arg, stream::HIPStream) = adapt(Runtime.Adaptor(stream), arg)
 
 const MACRO_KWARGS = [:launch]
 const COMPILER_KWARGS = [:name, :unsafe_fp_atomics, :wavefrontsize64]

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -445,11 +445,7 @@ function take_ownership!(managed::Managed; stream::HIPStream=AMDGPU.stream())
     return managed
 end
 
-# Fast-path ownership transfer for the kernel-launch path: the overwhelmingly
-# common case is memory already owned by the launching stream and already
-# dirty, both checkable without taking the lock. The unsynchronized read only
-# races with usage patterns that are already racy under the locked protocol
-# (concurrent use of one array from tasks on different streams).
+# Fast-path ownership transfer for the kernel-launch path
 @inline function take_ownership_fast!(managed::Managed, stream::HIPStream)
     (managed.stream === stream && managed.dirty) && return
     Base.@lock managed.lock take_ownership!(managed; stream)

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -445,6 +445,17 @@ function take_ownership!(managed::Managed; stream::HIPStream=AMDGPU.stream())
     return managed
 end
 
+# Fast-path ownership transfer for the kernel-launch path: the overwhelmingly
+# common case is memory already owned by the launching stream and already
+# dirty, both checkable without taking the lock. The unsynchronized read only
+# races with usage patterns that are already racy under the locked protocol
+# (concurrent use of one array from tasks on different streams).
+@inline function take_ownership_fast!(managed::Managed, stream::HIPStream)
+    (managed.stream === stream && managed.dirty) && return
+    Base.@lock managed.lock take_ownership!(managed; stream)
+    return
+end
+
 function lock_managed(managed::AbstractVector{<:Managed})
     locked = unique(managed)
     sort!(locked; by=m -> objectid(m.lock))

--- a/src/runtime/Runtime.jl
+++ b/src/runtime/Runtime.jl
@@ -13,8 +13,11 @@ import ..AMDGPU
 import ..AMDGPU: LockedObject
 import .HIP: HIPDevice
 
-struct Adaptor{M}
-    managed::M
+# Carries the launching stream so that argument conversion can transfer
+# buffer ownership inline (`take_ownership_fast!`); `nothing` skips ownership
+# handling (bare `rocconvert` for reflection/type computation).
+struct Adaptor{S}
+    stream::S
 end
 
 const RT_LOCK = Threads.ReentrantLock()

--- a/src/runtime/hip-execution.jl
+++ b/src/runtime/hip-execution.jl
@@ -57,7 +57,6 @@ function (ker::HIPKernel{F, TT})(
     # Check if previous kernels threw an exception.
     AMDGPU.throw_if_exception(stream.device)
     GC.@preserve args begin
-        # ownership transfer happens inline during conversion
         converted = map(arg -> AMDGPU.rocconvert(arg, stream), args)
         call(ker, converted...; stream, call_kwargs...)
     end

--- a/src/runtime/hip-execution.jl
+++ b/src/runtime/hip-execution.jl
@@ -56,12 +56,10 @@ function (ker::HIPKernel{F, TT})(
 ) where {F, TT, N}
     # Check if previous kernels threw an exception.
     AMDGPU.throw_if_exception(stream.device)
-    managed = AMDGPU.Managed[]
     GC.@preserve args begin
-        converted = map(arg -> AMDGPU.rocconvert(arg, managed), args)
-        AMDGPU.with_managed(managed; stream) do
-            call(ker, converted...; stream, call_kwargs...)
-        end
+        # ownership transfer happens inline during conversion
+        converted = map(arg -> AMDGPU.rocconvert(arg, stream), args)
+        call(ker, converted...; stream, call_kwargs...)
     end
 end
 


### PR DESCRIPTION
While comparing host-side overheads against CUDA.jl on an MI300A, the kernel-launch path stood out: every launch allocates a `Vector{Managed}`, `rocconvert` pushes each argument's buffer into it, and a `with_managed` phase then does `unique` + `sort(by=objectid)` + lock/unlock of every buffer's `ReentrantLock` around the launch. CUDA.jl performs the equivalent stream-ownership tracking inline in pointer conversion, with no per-launch collection phase.

This PR adopts that design:

- `Runtime.Adaptor` carries the launching stream instead of a `Managed` collector (`nothing` skips ownership handling, for bare `rocconvert` used in reflection/`argconvert`);
- the `ROCArray` adapt rule transfers ownership inline via a new `take_ownership_fast!`: an unlocked fast path for the common case (buffer already owned by this stream and already dirty), falling back to the locked `take_ownership!` otherwise. The unsynchronized read only races with usage patterns that were already racy under the locked protocol (concurrent use of one array from tasks on different streams);
- the `HIPKernel` call operator drops the vector and the `with_managed` wrapper. `with_managed`/`lock_managed` remain for external users.

Measured on MI300A (gfx942, ROCm 7.2.4, Julia 1.12.6), empty kernel / 3-array+4-scalar kernel:

| metric | before | after |
|---|---|---|
| no-arg kernel-object launch | 4,781 ns / 144 B | 4,649 ns / **0 B** |
| launch with 3 arrays + 4 scalars | 7,354 ns / 1,232 B | 6,596 ns / **416 B** |
| small broadcast `c .= a .+ b` | 15,437 ns / 3,056 B | 14,685 ns / 2,320 B |

Correctness validated on hardware including the cross-stream case (array owned by the default stream, used from a second stream via `stream!` — the locked slow path still synchronizes the previous stream).

For context from the same comparison: with this change the Julia-side launch overhead is essentially at parity with CUDA.jl (burst submission 3.7 vs 3.1 µs, and raw `hipModuleLaunchKernel` costs as much as the full AMDGPU.jl path) — the remaining gaps vs CUDA (launch throughput, 17 µs launch+sync round trip, and 10 µs `hipMallocFromPoolAsync`+`hipFreeAsync` pairs vs 1.5 µs on CUDA) are in the HIP runtime, not in this package.
