### PR TITLE
Probe rocSPARSE with `Libdl` only

### DIFF
--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -151,6 +151,9 @@ export ROCBackend
 include("precompile.jl")
 
 function __init__()
+    # Discovery runs at load time; a precompiled value would be stale.
+    _ROCSPARSE_VERSION[] = nothing
+
     # Used to shutdown hostcalls if any is running.
     atexit(() -> begin Runtime.RT_EXITING[] = true end)
 

--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -152,7 +152,7 @@ include("precompile.jl")
 
 function __init__()
     # Discovery runs at load time; a precompiled value would be stale.
-    _ROCSPARSE_VERSION[] = nothing
+    global _ROCSPARSE_VERSION = ""
 
     # Used to shutdown hostcalls if any is running.
     atexit(() -> begin Runtime.RT_EXITING[] = true end)

--- a/src/sparse/rocSPARSE.jl
+++ b/src/sparse/rocSPARSE.jl
@@ -42,13 +42,18 @@ lib_state() = library_state(
 handle() = lib_state().handle
 stream() = lib_state().stream
 
+# rocSPARSE packs its version into a single integer, also decoded by `versioninfo`.
+function decode_version(v::Integer)
+    major = v ÷ 100000
+    minor = (v ÷ 100) % 1000
+    patch = v % 100
+    return VersionNumber(major, minor, patch)
+end
+
 function version()
     ver = Ref{Cint}()
     rocsparse_get_version(handle(), ver)
-    major = ver[] ÷ 100000
-    minor = (ver[] ÷ 100) % 1000
-    patch = ver[] % 100
-    return VersionNumber(major, minor, patch)
+    return decode_version(ver[])
 end
 
 include("array.jl")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,10 +1,8 @@
-# Run `code` in a subprocess with `args` as its `ARGS`; returns stdout, or
-# `nothing` on crash, timeout, or nonzero exit. The empty `JULIA_LOAD_PATH` keeps
-# the child out of the active project, so `code` must only use `Base`.
-function _probe_subprocess(
-    code::String, args::Vector{String}; timeout::Real = 20,
-)::Union{String, Nothing}
-    cmd = `$(Base.julia_cmd()) --startup-file=no -O0 --compile=min -e $code $args`
+# Run `code` in a subprocess and return its stdout, or `nothing` on crash,
+# timeout, or nonzero exit. The empty `JULIA_LOAD_PATH` keeps the child out of
+# the active project, so `code` must only use `Base`.
+function _version_subprocess(code::String; timeout::Real = 20)::Union{String, Nothing}
+    cmd = `$(Base.julia_cmd()) --startup-file=no -O0 --compile=min -e $code`
     cmd = addenv(cmd, "JULIA_LOAD_PATH" => "")
     out = IOBuffer()
     try
@@ -26,31 +24,27 @@ function _probe_subprocess(
     end
 end
 
+# Empty until probed, then the version string or `"err"`.
+global _ROCSPARSE_VERSION::String = ""
+
 # rocSPARSE's version query needs a handle, and creating one can segfault on
-# broken ROCm installs (issue #920), so run it out-of-process. `Libdl` only, so
-# the child needs no package environment.
-const _ROCSPARSE_VERSION_PROBE = """
-    const L = Base.Libc.Libdl
-    lib = L.dlopen(ARGS[1])
-    handle = Ref{Ptr{Cvoid}}(C_NULL)
-    ccall(L.dlsym(lib, :rocsparse_create_handle), Cint,
-        (Ptr{Ptr{Cvoid}},), handle) == 0 || exit(2)
-    version = Ref{Cint}(0)
-    ccall(L.dlsym(lib, :rocsparse_get_version), Cint,
-        (Ptr{Cvoid}, Ptr{Cint}), handle[], version) == 0 || exit(2)
-    print(version[])
-    """
-
-# `nothing` until probed, then the version string or `"err"`.
-const _ROCSPARSE_VERSION = Ref{Union{Nothing, String}}(nothing)
-
+# broken ROCm installs (issue #920), so run it out-of-process.
 function _rocsparse_version_isolated(; timeout::Real = 20)
-    cached = _ROCSPARSE_VERSION[]
-    cached === nothing || return cached
+    global _ROCSPARSE_VERSION
+    isempty(_ROCSPARSE_VERSION) || return _ROCSPARSE_VERSION
 
-    out = _probe_subprocess(_ROCSPARSE_VERSION_PROBE, String[librocsparse]; timeout)
+    lib = repr(librocsparse)  # `repr` so Windows separators survive the parser
+    out = _version_subprocess("""
+        handle = Ref{Ptr{Cvoid}}(C_NULL)
+        ccall((:rocsparse_create_handle, $lib), Cint,
+            (Ptr{Ptr{Cvoid}},), handle) == 0 || exit(2)
+        version = Ref{Cint}(0)
+        ccall((:rocsparse_get_version, $lib), Cint,
+            (Ptr{Cvoid}, Ptr{Cint}), handle[], version) == 0 || exit(2)
+        print(version[])
+        """; timeout)
     packed = out === nothing ? nothing : tryparse(Int, out)
-    return _ROCSPARSE_VERSION[] =
+    return _ROCSPARSE_VERSION =
         packed === nothing ? "err" : string(rocSPARSE.decode_version(packed))
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,10 +1,11 @@
-# Run `code` in a short-lived subprocess and return its stdout, or `nothing` if
-# it crashed, timed out, or exited nonzero. Isolates version probes that can
-# segfault on broken ROCm installs, where SIGSEGV isn't catchable in-process.
-function _version_subprocess(code::String; timeout::Real = 60)
-    project = Base.active_project()
-    projarg = project === nothing ? "@." : dirname(project)
-    cmd = `$(Base.julia_cmd()) --startup-file=no --project=$projarg -e $code`
+# Run `code` in a subprocess with `args` as its `ARGS`; returns stdout, or
+# `nothing` on crash, timeout, or nonzero exit. The empty `JULIA_LOAD_PATH` keeps
+# the child out of the active project, so `code` must only use `Base`.
+function _probe_subprocess(
+    code::String, args::Vector{String}; timeout::Real = 20,
+)::Union{String, Nothing}
+    cmd = `$(Base.julia_cmd()) --startup-file=no -O0 --compile=min -e $code $args`
+    cmd = addenv(cmd, "JULIA_LOAD_PATH" => "")
     out = IOBuffer()
     try
         proc = run(pipeline(ignorestatus(cmd); stdout = out, stderr = devnull); wait = false)
@@ -25,14 +26,33 @@ function _version_subprocess(code::String; timeout::Real = 60)
     end
 end
 
-# rocSPARSE's version query needs a handle, which inits a HIP context and can
-# segfault on broken ROCm installs (issue #920). Probe it out-of-process so a
-# crash degrades to `"err"` instead of killing the session.
-_rocsparse_version_isolated(; timeout::Real = 60) = _version_subprocess("""
-    using AMDGPU
-    AMDGPU.functional(:rocsparse) || exit(2)
-    print(AMDGPU.rocSPARSE.version())
-    """; timeout)
+# rocSPARSE's version query needs a handle, and creating one can segfault on
+# broken ROCm installs (issue #920), so run it out-of-process. `Libdl` only, so
+# the child needs no package environment.
+const _ROCSPARSE_VERSION_PROBE = """
+    const L = Base.Libc.Libdl
+    lib = L.dlopen(ARGS[1])
+    handle = Ref{Ptr{Cvoid}}(C_NULL)
+    ccall(L.dlsym(lib, :rocsparse_create_handle), Cint,
+        (Ptr{Ptr{Cvoid}},), handle) == 0 || exit(2)
+    version = Ref{Cint}(0)
+    ccall(L.dlsym(lib, :rocsparse_get_version), Cint,
+        (Ptr{Cvoid}, Ptr{Cint}), handle[], version) == 0 || exit(2)
+    print(version[])
+    """
+
+# `nothing` until probed, then the version string or `"err"`.
+const _ROCSPARSE_VERSION = Ref{Union{Nothing, String}}(nothing)
+
+function _rocsparse_version_isolated(; timeout::Real = 20)
+    cached = _ROCSPARSE_VERSION[]
+    cached === nothing || return cached
+
+    out = _probe_subprocess(_ROCSPARSE_VERSION_PROBE, String[librocsparse]; timeout)
+    packed = out === nothing ? nothing : tryparse(Int, out)
+    return _ROCSPARSE_VERSION[] =
+        packed === nothing ? "err" : string(rocSPARSE.decode_version(packed))
+end
 
 """
     versioninfo(io::IO=stdout)
@@ -48,13 +68,7 @@ function versioninfo(io::IO=stdout)
     _ver(lib::Symbol, ver_fn) = functional(lib) ? "$(ver_fn())" : "-"
 
     # `"err"` = present but the out-of-process version probe crashed/timed out.
-    rocsparse_failed = false
-    rocsparse_ver = if functional(:rocsparse)
-        v = _rocsparse_version_isolated()
-        v === nothing ? (rocsparse_failed = true; "err") : v
-    else
-        "-"
-    end
+    rocsparse_ver = functional(:rocsparse) ? _rocsparse_version_isolated() : "-"
 
     data = String[
         _status(functional(:lld))         "LLD"              "-"                                 _libpath(lld_path);
@@ -73,7 +87,7 @@ function versioninfo(io::IO=stdout)
         "Available", "Name", "Version", "Path"],
         alignment=[:c, :l, :l, :l])
 
-    if rocsparse_failed
+    if rocsparse_ver == "err"
         @warn """rocSPARSE is installed but its version query failed (it ran in an \
             isolated subprocess and crashed or timed out). This usually indicates a \
             broken or mismatched ROCm install. See \

--- a/test/core/core_tests.jl
+++ b/test/core/core_tests.jl
@@ -10,12 +10,12 @@ using AMDGPU: HIP, Runtime, Device, Mem
 end
 
 @testset "versioninfo probe isolation" begin
-    probe(code, args = String[]; timeout = 60) =
-        AMDGPU._probe_subprocess(code, args; timeout)
+    probe(code; timeout = 60) = AMDGPU._version_subprocess(code; timeout)
 
-    # A clean child returns its stdout, and gets its arguments through `ARGS`.
+    # A clean child returns its stdout. Library paths reach it through `repr`,
+    # so Windows separators must survive the round trip.
     @test probe("print(\"4.2.0\")") == "4.2.0"
-    @test probe("print(ARGS[1])", String["C:\\rocm\\lib"]) == "C:\\rocm\\lib"
+    @test probe("print($(repr(raw"C:\rocm\lib")))") == raw"C:\rocm\lib"
 
     # No package environment, so probing can't trigger a precompile (#1040).
     @test probe("print(Base.load_path())") == "String[]"
@@ -32,7 +32,7 @@ end
 
     # On a working setup the probe returns a version; repeats hit the cache.
     if AMDGPU.functional(:rocsparse)
-        AMDGPU._ROCSPARSE_VERSION[] = nothing
+        AMDGPU._ROCSPARSE_VERSION = ""
         v = AMDGPU._rocsparse_version_isolated()
         @test tryparse(VersionNumber, v) !== nothing
         @test AMDGPU._rocsparse_version_isolated() === v

--- a/test/core/core_tests.jl
+++ b/test/core/core_tests.jl
@@ -10,10 +10,16 @@ using AMDGPU: HIP, Runtime, Device, Mem
 end
 
 @testset "versioninfo probe isolation" begin
-    probe(code; timeout = 60) = AMDGPU._version_subprocess(code; timeout)
+    probe(code, args = String[]; timeout = 60) =
+        AMDGPU._probe_subprocess(code, args; timeout)
 
-    # A clean child returns its stdout.
+    # A clean child returns its stdout, and gets its arguments through `ARGS`.
     @test probe("print(\"4.2.0\")") == "4.2.0"
+    @test probe("print(ARGS[1])", String["C:\\rocm\\lib"]) == "C:\\rocm\\lib"
+
+    # No package environment, so probing can't trigger a precompile (#1040).
+    @test probe("print(Base.load_path())") == "String[]"
+    @test probe("using Adapt; print(\"loaded\")") === nothing
 
     # A failing child degrades to `nothing` without taking down this process —
     # the point of the isolation: a SIGSEGV in a vendor library (issue #920)
@@ -24,11 +30,12 @@ end
     @test probe("1 + 1") === nothing                          # no output
     @test probe("while true; end"; timeout = 2) === nothing   # hang -> timeout
 
-    # On a working setup the real rocSPARSE probe returns a parseable version.
+    # On a working setup the probe returns a version; repeats hit the cache.
     if AMDGPU.functional(:rocsparse)
+        AMDGPU._ROCSPARSE_VERSION[] = nothing
         v = AMDGPU._rocsparse_version_isolated()
-        @test v !== nothing
         @test tryparse(VersionNumber, v) !== nothing
+        @test AMDGPU._rocsparse_version_isolated() === v
     end
 end
 


### PR DESCRIPTION
Relates to #1040. Follow-up to #1001.

#1001 moved the rocSPARSE version query into a subprocess so a segfault on a broken ROCm install (#920) degrades to `err` instead of killing the session. But the child ran `using AMDGPU` under the active project which is expensive.

The child now uses `Base.Libc.Libdl` only: it dlopens `librocsparse` by the absolute path the parent already knows and calls `rocsparse_create_handle` / `rocsparse_get_version` directly. The result is memoized for the session.

cc @simeonschaub 