### PR TITLE
Widen dispatch packet loads

### DIFF
--- a/src/device/gcn/indexing.jl
+++ b/src/device/gcn/indexing.jl
@@ -57,16 +57,40 @@ end
 
             # load the index
             offset = base + ((off - 1) * aligned_sizeof(T))
-            idx_ptr_i8 = inbounds_gep!(builder, T_int8, ptr, [ConstantInt(offset)])
-            idx_ptr_T = bitcast!(builder, idx_ptr_i8, T_ptr_T)
-            idx_T = load!(builder, T_T, idx_ptr_T)
-            idx = zext!(builder, idx_T, T_int32)
+            if aligned_sizeof(T) < 4
+                # Load the aligned dword containing the field and extract it
+                # with shift/mask. SMEM has no sub-dword loads, so whether a
+                # bare i16 load of the dispatch packet is widened to an
+                # s_load_dword depends on the surrounding use pattern (e.g. a
+                # zext to i64 -- Julia's default integer arithmetic --
+                # defeats it); the VMEM fallback is a per-wave read of
+                # uncached fine-grained queue memory that stalls every wave
+                # at kernel entry. A dword-aligned dword load is always
+                # SMEM-selectable.
+                aligned = offset & ~0x3
+                idx_ptr_i8 = inbounds_gep!(builder, T_int8, ptr, [ConstantInt(aligned)])
+                idx_ptr_i32 = bitcast!(builder, idx_ptr_i8, T_ptr_i32)
+                word = load!(builder, T_int32, idx_ptr_i32)
+                metadata(word)[LLVM.MD_invariant_load] = MDNode(LLVM.Metadata[])
+                idx = word
+                if (offset & 0x2) != 0
+                    idx = lshr!(builder, idx, ConstantInt(Int32(16)))
+                end
+                idx = and!(builder, idx, ConstantInt(Int32(0xffff)))
+                ret!(builder, idx)
+            else
+                idx_ptr_i8 = inbounds_gep!(builder, T_int8, ptr, [ConstantInt(offset)])
+                idx_ptr_T = bitcast!(builder, idx_ptr_i8, T_ptr_T)
+                idx_T = load!(builder, T_T, idx_ptr_T)
+                idx = zext!(builder, idx_T, T_int32)
 
-            # attach range metadata
-            metadata(idx_T)[LLVM.MD_range] = MDNode([
-                ConstantInt(T(range.start)),
-                ConstantInt(T(range.stop))])
-            ret!(builder, idx)
+                # attach range metadata
+                metadata(idx_T)[LLVM.MD_range] = MDNode([
+                    ConstantInt(T(range.start)),
+                    ConstantInt(T(range.stop))])
+                metadata(idx_T)[LLVM.MD_invariant_load] = MDNode(LLVM.Metadata[])
+                ret!(builder, idx)
+            end
         end
 
         call_function(llvm_f, UInt32)

--- a/src/device/gcn/indexing.jl
+++ b/src/device/gcn/indexing.jl
@@ -67,16 +67,18 @@ end
                 # uncached fine-grained queue memory that stalls every wave
                 # at kernel entry. A dword-aligned dword load is always
                 # SMEM-selectable.
-                aligned = offset & ~0x3
-                idx_ptr_i8 = inbounds_gep!(builder, T_int8, ptr, [ConstantInt(aligned)])
+                byte = offset % 4
+                @assert byte + aligned_sizeof(T) <= 4 "packet field straddles a dword boundary"
+                idx_ptr_i8 = inbounds_gep!(builder, T_int8, ptr, [ConstantInt(offset - byte)])
                 idx_ptr_i32 = bitcast!(builder, idx_ptr_i8, T_ptr_i32)
                 word = load!(builder, T_int32, idx_ptr_i32)
                 metadata(word)[LLVM.MD_invariant_load] = MDNode(LLVM.Metadata[])
                 idx = word
-                if (offset & 0x2) != 0
-                    idx = lshr!(builder, idx, ConstantInt(Int32(16)))
+                if byte != 0
+                    idx = lshr!(builder, idx, ConstantInt(Int32(8 * byte)))
                 end
-                idx = and!(builder, idx, ConstantInt(Int32(0xffff)))
+                mask = (Int64(1) << (8 * aligned_sizeof(T))) - 1
+                idx = and!(builder, idx, ConstantInt(Int32(mask)))
                 ret!(builder, idx)
             else
                 idx_ptr_i8 = inbounds_gep!(builder, T_int8, ptr, [ConstantInt(offset)])

--- a/test/core/codegen.jl
+++ b/test/core/codegen.jl
@@ -1,7 +1,7 @@
 using Test
 using AMDGPU
 using AMDGPU: Device, ROCArray, @roc
-using AMDGPU.Device: sync_workgroup
+using AMDGPU.Device: sync_workgroup, workitemIdx, workgroupIdx, workgroupDim
 using KernelAbstractions: @atomic
 
 @testset "Synchronization" begin
@@ -60,4 +60,27 @@ end
             @test !occursin("global_atomic_add_$fp", gcn)
         end
     end
+end
+
+@testset "Dispatch-packet reads stay scalar" begin
+    # workgroupDim reads 16-bit fields of the AQL dispatch packet; those must
+    # lower to SMEM (s_load) rather than a per-wave VMEM read of uncached
+    # queue memory. The Int64 3-D indexing pattern below used to defeat LLVM's
+    # sub-dword load widening and select the VMEM fallback.
+    function dim_kern!(A)
+        i = (workgroupIdx().x - 1) * workgroupDim().x + workitemIdx().x
+        j = (workgroupIdx().y - 1) * workgroupDim().y + workitemIdx().y
+        k = (workgroupIdx().z - 1) * workgroupDim().z + workitemIdx().z
+        n = i + j + k
+        n <= length(A) && (@inbounds A[n] = n)
+        return
+    end
+
+    iob = IOBuffer()
+    tt = Tuple{AMDGPU.Device.ROCDeviceVector{Float32, AMDGPU.Device.AS.Global}}
+    AMDGPU.code_gcn(iob, dim_kern!, tt; kernel=true)
+    gcn = String(take!(iob))
+    @test occursin("s_load", gcn)
+    @test !occursin("global_load", gcn)
+    @test !occursin("flat_load", gcn)
 end


### PR DESCRIPTION
This is a completely vibecoded fix for the issue I saw when running my kernel.
I run it via `ParallelStencil.jl` and can run against `CUDA.jl` (on H200) and `AMDGPU.jl` (on MI355X). Performance on MI355X was surprisingly worse than on H200. This should not be the case, as my kernel is memory bandwidth bound, and MI355X is 8TB/s vs only 4.8TB/s for H200.

I let Claude loose to fix the issue, and this is what it came back with. I'm not gonna lie, I don't understand those changes. Hopefully they are meaningful i.e not slop.