### PR TITLE
Run the AMDGPU attributor after optimization (kernel descriptors match hipcc)

### DIFF
--- a/src/compiler/codegen.jl
+++ b/src/compiler/codegen.jl
@@ -408,15 +408,8 @@ function run_and_collect(cmd)
     return proc, log
 end
 
-# Infer implicit-argument usage after optimization. LLVM's AMDGPUAttributor
-# proves which implicit kernel inputs (dispatch/queue pointer, dispatch id,
-# workgroup/workitem ids for y/z, hostcall/heap pointers, ...) a kernel can
-# never touch and records that as `amdgpu-no-*` attributes; the backend then
-# stops requesting those SGPR/VGPR inputs in the kernel descriptor. Clang runs
-# this in its default pipeline; GPUCompiler's pipeline never does, so every
-# kernel was compiled as if it used all of them (8 user SGPRs, all workgroup
-# ids, packed workitem ids for x/y/z). It has to run after optimization —
-# before inlining, un-inlined helper calls block the interprocedural proof.
+# Run amdgpu-attributor so that the amdgpu specific attributes are added
+# This reduces some register usage
 function GPUCompiler.finish_ir!(
     @nospecialize(job::HIPCompilerJob), mod::LLVM.Module, entry::LLVM.Function,
 )

--- a/src/compiler/codegen.jl
+++ b/src/compiler/codegen.jl
@@ -407,3 +407,29 @@ function run_and_collect(cmd)
     log = strip(fetch(reader))
     return proc, log
 end
+
+# Infer implicit-argument usage after optimization. LLVM's AMDGPUAttributor
+# proves which implicit kernel inputs (dispatch/queue pointer, dispatch id,
+# workgroup/workitem ids for y/z, hostcall/heap pointers, ...) a kernel can
+# never touch and records that as `amdgpu-no-*` attributes; the backend then
+# stops requesting those SGPR/VGPR inputs in the kernel descriptor. Clang runs
+# this in its default pipeline; GPUCompiler's pipeline never does, so every
+# kernel was compiled as if it used all of them (8 user SGPRs, all workgroup
+# ids, packed workitem ids for x/y/z). It has to run after optimization —
+# before inlining, un-inlined helper calls block the interprocedural proof.
+function GPUCompiler.finish_ir!(
+    @nospecialize(job::HIPCompilerJob), mod::LLVM.Module, entry::LLVM.Function,
+)
+    entry = invoke(GPUCompiler.finish_ir!,
+        Tuple{CompilerJob{GCNCompilerTarget}, typeof(mod), typeof(entry)},
+        job, mod, entry)
+    job.config.kernel || return entry
+
+    name = LLVM.name(entry)
+    tm = GPUCompiler.llvm_machine(job.config.target)
+    @dispose pb=NewPMPassBuilder() begin
+        add!(pb, "amdgpu-attributor")
+        run!(pb, mod, tm)
+    end
+    return functions(mod)[name]
+end

--- a/src/compiler/codegen.jl
+++ b/src/compiler/codegen.jl
@@ -427,9 +427,13 @@ function GPUCompiler.finish_ir!(
 
     name = LLVM.name(entry)
     tm = GPUCompiler.llvm_machine(job.config.target)
-    @dispose pb=NewPMPassBuilder() begin
-        add!(pb, "amdgpu-attributor")
-        run!(pb, mod, tm)
+    # The textual pass name is only registered since LLVM 18; it's a pure
+    # optimization, so skip it on older LLVM (e.g. Julia 1.10's LLVM 15).
+    if LLVM.version() >= v"18"
+        @dispose pb=NewPMPassBuilder() begin
+            add!(pb, "amdgpu-attributor")
+            run!(pb, mod, tm)
+        end
     end
     return functions(mod)[name]
 end


### PR DESCRIPTION
While auditing AMDGPU.jl's codegen against hipcc output on an MI300A, the kernel descriptors stood out: a 1-D `vadd` compiled by AMDGPU.jl requests **every** implicit input — 8 user SGPRs (dispatch ptr, queue ptr, kernarg ptr, dispatch id), all three workgroup ids, and packed x/y/z workitem ids (`.amdhsa_system_vgpr_workitem_id 2`). hipcc emits 2 user SGPRs and `workitem_id 0` for the same kernel.

The difference is LLVM's `AMDGPUAttributor`: clang's pipeline runs it, GPUCompiler's never does. It proves which implicit inputs a kernel can never touch and records `amdgpu-no-*` attributes; the backend then stops requesting those inputs.

This PR runs it in `finish_ir!`, i.e. after optimization. Placement matters: in `finish_module!` (pre-optimization) it inferred nothing, because un-inlined helper calls block the interprocedural proof.

Effect on MI300A (gfx942, ROCm 7.2.4) for the probe kernels:

| kernel | before | after |
|---|---|---|
| 1-D vadd | queue_ptr 1, dispatch_id 1, workitem_id 2, 15 SGPRs | queue_ptr 0, dispatch_id 0, workitem_id 0, 12 SGPRs |
| LDS reduction (no `workgroupDim`) | dispatch_ptr 1, ... | also `amdgpu-no-dispatch-ptr` |
| 3-D kernel | workitem_id 2 | workitem_id 2 (correctly kept) |

Validated on hardware that kernels which *do* use implicit arguments keep working: `@rocprintf` (hostcall — queue ptr + dispatch id), a device-side bounds exception surfacing on the host, 3-D indexing, LDS + `sync_workgroup`, and the broadcast/mapreduce/rocBLAS library paths.

Kernel descriptors before/after and the probe script are in the issue trail of #1055 / this branch's commit message.
