### PR TITLE
Fix off-by-one in indexing !range metadata

### DIFF
--- a/src/device/gcn/indexing.jl
+++ b/src/device/gcn/indexing.jl
@@ -1,5 +1,13 @@
 # Indexing and dimensions
 
+# LLVM's !range is half-open [lo, hi); the ranges below are inclusive.
+function _range_metadata(::Type{T}, range) where T
+    lo = T(range.start)
+    hi = T(range.stop) + one(T)
+    lo == hi && return nothing
+    return MDNode([ConstantInt(lo), ConstantInt(hi)])
+end
+
 @device_function @generated function _index(::Val{fname}, ::Val{name}, ::Val{range}) where {fname, name, range}
     @dispose ctx=Context() begin
         T_int32 = LLVM.Int32Type()
@@ -19,9 +27,8 @@
             idx = call!(builder, intr_typ, intr)
 
             # attach range metadata
-            metadata(idx)[LLVM.MD_range] = MDNode([
-                ConstantInt(UInt32(range.start)),
-                ConstantInt(UInt32(range.stop))])
+            md = _range_metadata(UInt32, range)
+            md === nothing || (metadata(idx)[LLVM.MD_range] = md)
             ret!(builder, idx)
         end
 
@@ -63,9 +70,8 @@ end
             idx = zext!(builder, idx_T, T_int32)
 
             # attach range metadata
-            metadata(idx_T)[LLVM.MD_range] = MDNode([
-                ConstantInt(T(range.start)),
-                ConstantInt(T(range.stop))])
+            md = _range_metadata(T, range)
+            md === nothing || (metadata(idx_T)[LLVM.MD_range] = md)
             ret!(builder, idx)
         end
 
@@ -95,17 +101,18 @@ for dim in (:x, :y, :z)
     @eval @device_function @inline $cufn() = $fn()
 end
 for (dim,off) in ((:x,1), (:y,2), (:z,3))
+    # N.B. These are sizes, so the range runs 1:max, not 0:(max - 1).
     # Workgroup dimension (in workitems)
     fn = Symbol("workgroupDim_$dim")
     base = _packet_offsets[findfirst(x->x==:workgroup_size_x,_packet_names)]
-    @eval @device_function @inline $fn() = _dim($(Val(base)), $(Val(off)), $(Val(0:(_max_group_size - 1))), UInt16)
+    @eval @device_function @inline $fn() = _dim($(Val(base)), $(Val(off)), $(Val(1:_max_group_size)), UInt16)
     cufn = Symbol("blockDim_$dim")
     @eval @device_function @inline $cufn() = $fn()
 
     # Grid dimension (in workitems)
     fn = Symbol("gridItemDim_$dim")
     base = _packet_offsets[findfirst(x->x==:grid_size_x,_packet_names)]
-    @eval @device_function @inline $fn() = _dim($(Val(base)), $(Val(off)), $(Val(0:(_max_grid_size[dim] - 1))), UInt32)
+    @eval @device_function @inline $fn() = _dim($(Val(base)), $(Val(off)), $(Val(1:_max_grid_size[dim])), UInt32)
     # Grid dimension (in workgroups)
     fn_wg = Symbol("gridGroupDim_$dim")
     fn_wg_dim = Symbol("workgroupDim_$dim")

--- a/test/device/indexing.jl
+++ b/test/device/indexing.jl
@@ -46,3 +46,30 @@ using AMDGPU.Device: workitemIdx, workgroupIdx, workgroupDim, gridItemDim, gridG
     A = Array(RA)
     @test A == [groupsize..., (groupsize .* gridsize)..., gridsize...]
 end
+
+@testset "Indexing range metadata" begin
+    # !range is half-open, so an inclusive bound puts the topmost legal value
+    # outside it and comparisons against it fold away. Shows up at groupsize=1024.
+    function edge_kern(X)
+        i = workitemIdx().x
+        (i == 1024) && (@inbounds X[1] = 1)
+        (i >= 1024) && (@inbounds X[2] = 1)
+        (workgroupDim().x == 1024) && (@inbounds X[3] = 1)
+        (gridItemDim().x == 1024) && (@inbounds X[4] = 1)
+        nothing
+    end
+
+    RA = ROCArray(zeros(Int32, 4))
+    @roc groupsize=1024 gridsize=1 edge_kern(RA)
+    @test Array(RA) == Int32[1, 1, 1, 1]
+
+    # ...and the top lane does run, independently of any comparison.
+    function ident_kern(X)
+        @inbounds X[workitemIdx().x] = workitemIdx().x
+        nothing
+    end
+
+    RB = ROCArray(zeros(Int32, 1024))
+    @roc groupsize=1024 gridsize=1 ident_kern(RB)
+    @test Array(RB) == Int32.(1:1024)
+end


### PR DESCRIPTION
LLVM reads `!range` as the half-open `[lo, hi)`, but `_index` and `_dim` pass inclusive Julia ranges straight through. The topmost legal value falls outside the declared range, so comparisons against it fold to false.

On `main` at `groupsize=1024`:

```julia
i = workitemIdx().x
(i == 1024) && (X[1] = 1)
(i >= 1024) && (X[2] = 1)
(workgroupDim().x == 1024) && (X[3] = 1)
(gridItemDim().x == 1024) && (X[4] = 1)
# Int32[0, 0, 0, 1]  -- expected Int32[1, 1, 1, 1]
```

Lane 1024 does run — stores aren't dropped, so `fill!`/broadcast were never corrupting data; only the comparisons vanish.

`_dim` has a second bug: it reads *sizes*, but every call site hands it an *index* range, so `workgroupDim` declared `[0, 1023)` where the truth is `[1, 1025)`.

## Changes

Both go through `_range_metadata(T, range)`, which adds one **in `T`** — a full-width range then wraps to `[lo, 0)`, which LLVM accepts — and returns `nothing` when `lo == hi`, which LLVM rejects. The `_dim` call sites pass size ranges.

| intrinsic | before | after |
|---|---|---|
| `workitemIdx` | `[0, 1023)` | `[0, 1024)` |
| `workgroupIdx` | `[0, 4294967294)` | `[0, 0xffffffff)` |
| `workgroupDim` | `[0, 1023)` | `[1, 1025)` |
| `gridItemDim` | `[0, 4294967294)` | `[1, 0)` wrapping (nonzero) |

## Testing

`core` + `device` pass on gfx1100 (ROCm 7.2.3, Julia 1.12.7). The new testset fails on `main` with `Int32[0, 0, 0, 1]`, so it guards the bug rather than just describing it. The wrapping `[1, 0)` form is checked against `opt`: the verifier accepts it, `x == 0` folds, `x == typemax` stays reachable.