### PR TITLE
Read workgroup/grid dimensions from hidden kernargs instead of the dispatch packet (2x on short kernels)

### DIFF
--- a/src/compiler/codegen.jl
+++ b/src/compiler/codegen.jl
@@ -103,10 +103,16 @@ function GPUCompiler.finish_module!(
 
         # TODO add convergent, mustprogress, willreturn attributes?
 
+        # request the full hidden-argument block (code object v5+): workgroup and
+        # grid dimensions are read from it (see device/gcn/indexing.jl), and the
+        # metadata this emits is what makes the runtime fill it in at launch
+        implicitarg_attr = StringAttribute("amdgpu-implicitarg-num-bytes", "256")
+
         attrs = LLVM.function_attributes(entry)
         push!(attrs, target_cpu_attr)
         push!(attrs, target_features_attr)
         push!(attrs, atomic_attr)
+        push!(attrs, implicitarg_attr)
     end
 
     # Workaround for the lack of zeroinitializer support for LDS.

--- a/src/compiler/codegen.jl
+++ b/src/compiler/codegen.jl
@@ -104,8 +104,7 @@ function GPUCompiler.finish_module!(
         # TODO add convergent, mustprogress, willreturn attributes?
 
         # request the full hidden-argument block (code object v5+): workgroup and
-        # grid dimensions are read from it (see device/gcn/indexing.jl), and the
-        # metadata this emits is what makes the runtime fill it in at launch
+        # grid dimensions are read from it (see device/gcn/indexing.jl),
         implicitarg_attr = StringAttribute("amdgpu-implicitarg-num-bytes", "256")
 
         attrs = LLVM.function_attributes(entry)

--- a/src/device/gcn/helpers.jl
+++ b/src/device/gcn/helpers.jl
@@ -1,7 +1,3 @@
-# HSA dispatch packet offsets
-_packet_names = fieldnames(HSA.KernelDispatchPacket)
-_packet_offsets = fieldoffset.(HSA.KernelDispatchPacket, 1:length(_packet_names))
-
 # which Julia types map to a given ROC lib type
 const fntypes = Dict{Type,Symbol}(
     Nothing => :void,

--- a/src/device/gcn/indexing.jl
+++ b/src/device/gcn/indexing.jl
@@ -36,14 +36,25 @@ end
     end
 end
 
-@device_function @generated function _dim(::Val{base}, ::Val{off}, ::Val{range}, ::Type{T}) where {base, off, range, T}
+# Workgroup/grid dimensions come from the *hidden kernel arguments* (code object
+# v5+): the runtime writes hidden_block_count_{x,y,z} (u32 at 0/4/8) and
+# hidden_group_size_{x,y,z} (u16 at 12/14/16) into the kernarg segment after the
+# explicit arguments, and `llvm.amdgcn.implicitarg.ptr` points at that block.
+# This is what clang does for blockDim/gridDim. The previous implementation read
+# the AQL dispatch packet through `llvm.amdgcn.dispatch.ptr` — that memory is
+# host-coherent queue memory, so every wave paid an uncached SMEM round trip on
+# its very first instructions; on short kernels that alone halved throughput
+# (Floyd-Warshall on MI300A: 21.5 -> 11.0 us per launch, matching hipcc).
+const _hidden_block_count_offset = 0    # u32 × 3
+const _hidden_group_size_offset  = 12   # u16 × 3
+
+@device_function @generated function _dim(::Val{offset}, ::Type{T}, ::Val{range}) where {offset, T, range}
     @dispose ctx=Context() begin
         T_int8 = LLVM.Int8Type()
         T_int32 = LLVM.Int32Type()
 
         _as = convert(Int, AS.Constant)
         T_ptr_i8 = LLVM.PointerType(T_int8, _as)
-        T_ptr_i32 = LLVM.PointerType(T_int32, _as)
 
         T_T = convert(LLVMType, T)
         T_ptr_T = LLVM.PointerType(T_T, _as)
@@ -57,21 +68,25 @@ end
             entry = BasicBlock(llvm_f, "entry")
             position!(builder, entry)
 
-            # get the kernel dispatch pointer
+            # get the implicit (hidden) kernel argument pointer
             intr_typ = LLVM.FunctionType(T_ptr_i8)
-            intr = LLVM.Function(mod, "llvm.amdgcn.dispatch.ptr", intr_typ)
+            intr = LLVM.Function(mod, "llvm.amdgcn.implicitarg.ptr", intr_typ)
             ptr = call!(builder, intr_typ, intr)
 
-            # load the index
-            offset = base + ((off - 1) * aligned_sizeof(T))
+            # load the field
             idx_ptr_i8 = inbounds_gep!(builder, T_int8, ptr, [ConstantInt(offset)])
             idx_ptr_T = bitcast!(builder, idx_ptr_i8, T_ptr_T)
             idx_T = load!(builder, T_T, idx_ptr_T)
+            # the hidden block is at least 4-byte aligned; tell LLVM so the
+            # backend keeps merged accesses SMEM-selectable
+            alignment!(idx_T, gcd(4, offset))
             idx = zext!(builder, idx_T, T_int32)
 
-            # attach range metadata
+            # attach range metadata; the hidden arguments never change during
+            # a dispatch
             md = _range_metadata(T, range)
             md === nothing || (metadata(idx_T)[LLVM.MD_range] = md)
+            metadata(idx_T)[LLVM.MD_invariant_load] = MDNode(LLVM.Metadata[])
             ret!(builder, idx)
         end
 
@@ -102,22 +117,22 @@ for dim in (:x, :y, :z)
 end
 for (dim,off) in ((:x,1), (:y,2), (:z,3))
     # N.B. These are sizes, so the range runs 1:max, not 0:(max - 1).
-    # Workgroup dimension (in workitems)
+    # Workgroup dimension (in workitems): hidden_group_size_{x,y,z}
     fn = Symbol("workgroupDim_$dim")
-    base = _packet_offsets[findfirst(x->x==:workgroup_size_x,_packet_names)]
-    @eval @device_function @inline $fn() = _dim($(Val(base)), $(Val(off)), $(Val(1:_max_group_size)), UInt16)
+    @eval @device_function @inline $fn() = _dim($(Val(_hidden_group_size_offset + 2 * (off - 1))), UInt16,
+                                                $(Val(1:_max_group_size)))
     cufn = Symbol("blockDim_$dim")
     @eval @device_function @inline $cufn() = $fn()
 
-    # Grid dimension (in workitems)
-    fn = Symbol("gridItemDim_$dim")
-    base = _packet_offsets[findfirst(x->x==:grid_size_x,_packet_names)]
-    @eval @device_function @inline $fn() = _dim($(Val(base)), $(Val(off)), $(Val(1:_max_grid_size[dim])), UInt32)
-    # Grid dimension (in workgroups)
+    # Grid dimension (in workgroups): hidden_block_count_{x,y,z}
     fn_wg = Symbol("gridGroupDim_$dim")
-    fn_wg_dim = Symbol("workgroupDim_$dim")
-    # N.B. Don't use div to avoid inserting an exception path
-    @eval @device_function @inline $fn_wg() = Core.Intrinsics.udiv_int($fn(), $fn_wg_dim())
+    @eval @device_function @inline $fn_wg() = _dim($(Val(_hidden_block_count_offset + 4 * (off - 1))), UInt32,
+                                                   $(Val(1:_max_groups[dim])))
+
+    # Grid dimension (in workitems). Launches are always whole workgroups, so
+    # this equals the dispatch packet's grid_size.
+    fn_it = Symbol("gridItemDim_$dim")
+    @eval @device_function @inline $fn_it() = $fn_wg() * $fn()
 end
 
 """

--- a/src/device/gcn/indexing.jl
+++ b/src/device/gcn/indexing.jl
@@ -90,9 +90,12 @@ const _hidden_group_size_offset  = 12   # u16 × 3
 end
 
 # TODO: look these up for the current device/queue
-# TODO: grids can be up to typemax(UInt64)
 const _max_group_size = 1024
-const _max_groups     = (x=typemax(UInt32), y=typemax(UInt32), z=typemax(UInt32))
+# HSA's grid_size fields are UInt32 work-items, so a workgroup index can only
+# exceed typemax(Int32) for more than 2^31 single-work-item groups; such launches
+# are rejected on the host (see Runtime.launch). The tighter !range lets LLVM
+# fold the InexactError check in `Int32(workgroupIdx().x)`.
+const _max_groups     = (x=typemax(Int32), y=typemax(Int32), z=typemax(Int32))
 const _max_grid_size  = (x=typemax(UInt32), y=typemax(UInt32), z=typemax(UInt32))
 
 for dim in (:x, :y, :z)

--- a/src/device/gcn/indexing.jl
+++ b/src/device/gcn/indexing.jl
@@ -40,11 +40,6 @@ end
 # v5+): the runtime writes hidden_block_count_{x,y,z} (u32 at 0/4/8) and
 # hidden_group_size_{x,y,z} (u16 at 12/14/16) into the kernarg segment after the
 # explicit arguments, and `llvm.amdgcn.implicitarg.ptr` points at that block.
-# This is what clang does for blockDim/gridDim. The previous implementation read
-# the AQL dispatch packet through `llvm.amdgcn.dispatch.ptr` — that memory is
-# host-coherent queue memory, so every wave paid an uncached SMEM round trip on
-# its very first instructions; on short kernels that alone halved throughput
-# (Floyd-Warshall on MI300A: 21.5 -> 11.0 us per launch, matching hipcc).
 const _hidden_block_count_offset = 0    # u32 × 3
 const _hidden_group_size_offset  = 12   # u16 × 3
 

--- a/src/runtime/hip-execution.jl
+++ b/src/runtime/hip-execution.jl
@@ -105,6 +105,9 @@ function launch(
 ) where N
     gd = gridsize isa ROCDim3 ? gridsize : ROCDim3(gridsize)
     bd = groupsize isa ROCDim3 ? groupsize : ROCDim3(groupsize)
+    # the device side assumes workgroup indices fit in Int32 (see Device._max_groups)
+    (gd.x <= typemax(Int32) && gd.y <= typemax(Int32) && gd.z <= typemax(Int32)) ||
+        throw(ArgumentError("gridsize exceeds $(typemax(Int32)) workgroups in a dimension"))
     # TODO guard with try/catch & diagnose a failure
     pack_arguments(args...) do kernel_params
         # Inline into `pack_arguments`, so that `kernel_params` does not escape into a

--- a/test/core/codegen.jl
+++ b/test/core/codegen.jl
@@ -1,7 +1,7 @@
 using Test
 using AMDGPU
 using AMDGPU: Device, ROCArray, @roc
-using AMDGPU.Device: sync_workgroup
+using AMDGPU.Device: sync_workgroup, workitemIdx, workgroupIdx, workgroupDim
 using KernelAbstractions: @atomic
 
 @testset "Synchronization" begin
@@ -75,4 +75,28 @@ end
     AMDGPU.synchronize()
     # exceeding the bound is undefined behavior; HIP rejects it at launch
     @test_throws AMDGPU.HIP.HIPError k(; groupsize=512)
+end
+
+@testset "Dimension reads stay scalar" begin
+    # workgroupDim/workgroupIdx must lower to SMEM loads of the (hidden)
+    # kernarg segment. Reading two or more dim components used to merge the
+    # u16 dispatch-packet loads into an under-aligned vector load that could
+    # only select per-wave VMEM.
+    function dim_kern!(A)
+        i = (workgroupIdx().x - 1) * workgroupDim().x + workitemIdx().x
+        j = (workgroupIdx().y - 1) * workgroupDim().y + workitemIdx().y
+        k = (workgroupIdx().z - 1) * workgroupDim().z + workitemIdx().z
+        n = i + j + k
+        n <= length(A) && (@inbounds A[n] = n)
+        return
+    end
+
+    iob = IOBuffer()
+    tt = Tuple{AMDGPU.Device.ROCDeviceVector{Float32, AMDGPU.Device.AS.Global}}
+    AMDGPU.code_gcn(iob, dim_kern!, tt; kernel=true)
+    gcn = String(take!(iob))
+    @test occursin("s_load", gcn)
+    @test !occursin("global_load", gcn)
+    @test !occursin("flat_load", gcn)
+    @test !occursin("buffer_load", gcn)
 end


### PR DESCRIPTION
`workgroupDim`/`gridItemDim` (and everything built on them — the canonical global-index computation) read the AQL dispatch packet through `llvm.amdgcn.dispatch.ptr`. That packet lives in host-coherent queue memory, so **every wave of every kernel pays an uncached SMEM round trip in its first few instructions**. On short kernels this dominates.

Measured on MI300A (gfx942, ROCm 7.2.4) with the rocm-examples Floyd–Warshall kernel (2048 nodes → 2048 dependent launches of a 39-instruction kernel):

| variant | per launch |
|---|---|
| `workgroupDim()` from the dispatch packet (before) | 21.5 µs |
| same kernel, block dims hard-coded (no packet read) | 11.2 µs |
| hipcc's kernel, launched from the same Julia harness | 10.9 µs |
| **`workgroupDim()` from hidden kernargs (this PR)** | **11.4 µs** |

The ISA of the Julia and hipcc kernels is otherwise identical (39 instructions each, same register counts); the only difference was `s_load_dword s10, s[0:1], 0x4` off the dispatch pointer vs clang's `s_load_dword s10, s[0:1], 0x24` off the kernarg segment — `hidden_group_size_x` at explicit-args + 12.

This PR does what clang does: dimensions come from the **hidden kernel arguments** (code object v5+, which GPUCompiler already emits — v6 here), which the runtime writes into the kernarg segment in device memory: `hidden_block_count_{x,y,z}` (u32 at 0/4/8) and `hidden_group_size_{x,y,z}` (u16 at 12/14/16) behind `llvm.amdgcn.implicitarg.ptr`. Consequences:

- `gridGroupDim` is a direct load instead of `udiv(grid_size, group_size)`; `gridItemDim` is `block_count * group_size` (launches are whole workgroups, so this equals the packet's `grid_size`).
- Kernels get `"amdgpu-implicitarg-num-bytes"="256"` so the backend emits the hidden-arg metadata the runtime keys on (`kernarg_segment_size` grows by 256 bytes; verified `hidden_block_count_x`/`hidden_group_size_x` appear and the runtime fills them).
- The loads carry their real alignment, `!range` and `!invariant.load`, so they stay SMEM-selectable — this supersedes the concern in #1054 for the common case (no dispatch-packet loads remain to widen).
- With #1056 (attributor) on top, the dispatch pointer user SGPR disappears entirely since nothing references `dispatch.ptr` anymore.

Broader effect on MI300A: BabelStream Copy 3,306 → 3,601 GB/s (95% of hipcc), Mul 3,377 → 3,602 (97%); rocm-examples bitonic sort 18.4 → 16.6 ms (hipcc 16.0), 5×5 convolution 123 → 110 µs; LDS tiled matmul +2.5%. Correctness validated on the full rocm-examples Applications port (histogram, prefix-sum, convolution, bitonic sort, Floyd–Warshall — all checked against references).


---

**Second commit — bound workgroup indices to `Int32` so checked conversions fold.**

The `!range` on `workgroupIdx` (and now `gridGroupDim`) spanned the full `UInt32`, so the natural `Int32(workgroupIdx().x)` kept its `InexactError` check — and since `throw_inexacterror` is a real call, any kernel indexing that way grew a call frame and SGPR save/restore (the Floyd–Warshall port above: 281 instructions vs 39, 2.8× slower). `workitemIdx`/`workgroupDim` never had this problem: their ranges fit `Int32` and LLVM folds the check.

HSA's `grid_size` fields are `UInt32` work-items, so a workgroup index can only exceed `typemax(Int32)` for more than 2³¹ *single-work-item* groups. `Runtime.launch` now rejects that, and the tighter bound is recorded as `!range`. With the **unchanged** checked idiom, MI300A: Floyd–Warshall 28.9 → 11.4 µs/launch (hipcc 10.9), zero throw calls, 33 instructions; bitonic sort 18.4 → 16.7 ms (hipcc 15.7). Return type stays `UInt32`.
