### PR TITLE
Makes artifact ROCm survive a machine that already has a ROCm in its environment

### DIFF
--- a/ROCm_Runtime/src/ROCm_Runtime.jl
+++ b/ROCm_Runtime/src/ROCm_Runtime.jl
@@ -65,6 +65,27 @@ function get_library(name::String)::String
     return ""
 end
 
+# HIP pulls `libamd_comgr` in transitively, so a system ROCm on LD_LIBRARY_PATH
+# displaces the bundle's. Claim the soname first.
+function preload_comgr()
+    isempty(libamd_comgr) && return
+    try
+        Libdl.dlopen(libamd_comgr)
+    catch err
+        @debug "Could not preload $libamd_comgr" exception=(err, catch_backtrace())
+    end
+    return
+end
+
+# comgr roots its clang driver at LLVM_PATH, which then picks up the device
+# libraries named by ROCM_PATH / HIP_DEVICE_LIB_PATH / DEVICE_LIB_PATH.
+function clear_llvm_path()
+    haskey(ENV, "LLVM_PATH") || return
+    @debug "Unsetting LLVM_PATH ($(ENV["LLVM_PATH"])): it redirects comgr away from the ROCm artifact"
+    delete!(ENV, "LLVM_PATH")
+    return
+end
+
 function __init__()
     global artifact_dir = find_artifact_dir()
     is_available() || return
@@ -84,6 +105,10 @@ function __init__()
     global libhipblaslt = get_library(lib_prefix * "hipblaslt")
     global libhiptensor = get_library(lib_prefix * "hiptensor")
     global libMIOpen = get_library(lib_prefix * "MIOpen")
+
+    # Both must precede `AMDGPU.__init__`, which loads HSA and HIP.
+    preload_comgr()
+    clear_llvm_path()
 end
 
 end

--- a/ci/cscs-mi300.yml
+++ b/ci/cscs-mi300.yml
@@ -30,13 +30,10 @@ include:
   paths:
     - rocfft-trace.log
 
-# AMDGPU.jl takes ROCm either from the uenv ($ROCM_LOCAL == "true": the merged
-# ROCM_PATH below, resolved through ROCm_Runtime_Discovery) or from the TheRock
-# artifacts shipped by ROCm_Runtime ($ROCM_LOCAL == "false"). Which one is used
-# is decided by ROCm_Runtime's "local" preference; it is a compile-time
-# preference that also gates artifact resolution, so it has to be set before
-# Pkg.instantiate(). It is set explicitly in both variants rather than relying
-# on the default, and the resolved provider is asserted afterwards, so that a
+# ROCm comes from the uenv ($ROCM_LOCAL == "true", via the merged ROCM_PATH below
+# and ROCm_Runtime_Discovery) or from the TheRock artifacts. ROCm_Runtime's "local"
+# preference decides, and gates artifact resolution too, so it must be set before
+# Pkg.instantiate(). Both variants set it explicitly and assert the result, so a
 # change of default cannot silently swap the ROCm underneath a job.
 .unit_test_script: &unit_test_script
   - srun -n 1 --uenv $UENV --view=default bash -c '
@@ -92,11 +89,11 @@ UnitTest julia 1.13 (system ROCm):
   script: *unit_test_script
   artifacts: *trace_artifacts
 
-# Coverage of the artifact path, what AMDGPU.jl uses by default. Allowed to
-# fail for now: with the ROCm 7.14 TheRock bundle, every HIP application failed
-# at its first stream creation on gfx942, reported as hipErrorOutOfMemory even
-# though nothing ran out of memory (https://github.com/ROCm/TheRock/issues/7426).
-# Drop allow_failure once the job is green with the ROCm 10.0 bundle.
+# Coverage of the artifact path, what AMDGPU.jl uses by default. Allowed to fail
+# until green on the 10.0 bundle: a ROCm in the environment can displace the
+# bundle's libamd_comgr, failing the blit-kernel link at the first stream and
+# reporting it as hipErrorOutOfMemory. ROCm_Runtime works around it; see
+# https://github.com/ROCm/TheRock/issues/7426.
 UnitTest julia 1.12 (ROCm artifacts):
   extends: .baremetal-runner-beverin-mi300
   allow_failure: true


### PR DESCRIPTION
On any host where a second ROCm is visible to the dynamic loader, the bundle we ship gets partly displaced by it. TheRock's libraries carry `DT_RUNPATH`, which the loader searches only *after* `LD_LIBRARY_PATH`, so a ROCm module, a uenv, `/opt/rocm` in a shell profile, or one of AMD's own containers wins. Everything AMDGPU.jl uses directly it opens by absolute path, so `libamd_comgr` slips through, which HIP pulls in transitively. HIP from the bundle then JIT-compiles its blit kernels through a foreign comgr, which resolves device libraries relative to *its own* installation.

On a version mismatch that fails outright. On CSCS beverin every test died at the first `hipStreamCreateWithPriority` with `hipErrorOutOfMemory` — which is ROCclr reporting a blit-program build failure, not memory. Underneath, `ld.lld` could not find `__amd_streamOpsIncrement`/`Decrement`, because the bundle's 7.14 blit source was being linked against the uenv's 7.2.3 `ockl.bc`. On a *close* pair of versions the same mixing would miscompile quietly instead, which is the worse case.

There is a second, independent route to the same failure: `LLVM_PATH`. comgr reads it and roots its clang driver there, after which clang prefers `ROCM_PATH` / `HIP_DEVICE_LIB_PATH` / `DEVICE_LIB_PATH` over the device libraries comgr carries itself. Pointing `LLVM_PATH` at the bundle's own `llvm/` does not help — those other variables still win — so it has to be unset while we are on the artifact.

So `ROCm_Runtime.__init__` now does two things, both only in artifact mode (it returns early when a local ROCm is preferred), and both before HSA or HIP are loaded, which holds because `AMDGPU.__init__` runs after it:

- opens the bundle's `libamd_comgr` by absolute path, claiming the soname before anything else can. Julia's default `dlopen` flags are used deliberately: the soname is claimed for later dependency lookups either way, and `RTLD_LOCAL` keeps comgr's LLVM out of the global namespace, where Julia's own already lives. Verified equivalent across `RTLD_LAZY`, `RTLD_LOCAL|RTLD_NOW` and `RTLD_GLOBAL|RTLD_NOW`. It is skipped if the bundle has no comgr, and a failure to open it is logged at `@debug` rather than raised, so this cannot itself become a new way for loading to fail.
- deletes `LLVM_PATH`, logging the old value at `@debug`.

Both are needed; either alone still fails.

### Verification

On beverin, artifact mode inside the ROCm 7.2.3 uenv with the environment otherwise untouched — no `LD_LIBRARY_PATH`, `HSA_TOOLS_LIB` or `LLVM_PATH` sanitising in the job script. comgr resolves to the artifact and blit kernels link against comgr's own `/tmp/comgr-*/rocm/amdgcn/bitcode`. Green on stream creation, broadcast, rocBLAS gemm, a custom `@roc` kernel, mapreduce, and 8 concurrent streams. Before the change, all of these failed at the first stream.

Off-uenv behaviour is unchanged: with no foreign ROCm present the preload is a no-op on a library that was going to be loaded anyway, and `LLVM_PATH` is normally unset.

### Notes

The root defect is upstream: TheRock ships a self-contained ROCm whose `libamd_comgr` keeps a generic soname and `DT_RUNPATH`, so any system ROCm on `LD_LIBRARY_PATH` displaces it. They already avoid this for their vendored dependencies by namespacing them `librocm_sysdeps_*`; comgr did not get the same treatment. Filed as a correction on https://github.com/ROCm/TheRock/issues/7426, which had originally been reported against the gfx94X bundle — the bundle is fine, the environment was not.

`HSA_TOOLS_LIB` is a third route to the same displacement: the bundle's HSA runtime dlopens it by absolute path, and a foreign rocprofiler drags its own comgr in through its `RPATH`, ahead of HIP. The comgr preload closes that one too, since it runs first.

One residual, not addressed here: with the fix applied, a comgr action still references the uenv's `amdgcn/bitcode/opencl.bc` alongside the bundled one that the blit kernels use. Nothing observed fails because of it, but it is worth understanding before the artifact CI job is trusted unconditionally.