### PR TITLE
Claim the bundle's vendor libraries, and drop the rocSPARSE version probe

### DIFF
--- a/ROCm_Runtime/src/ROCm_Runtime.jl
+++ b/ROCm_Runtime/src/ROCm_Runtime.jl
@@ -67,6 +67,8 @@ end
 
 # Claimed from the bundle before LD_LIBRARY_PATH can resolve them elsewhere.
 # Leaves first, as (subdirectory of the library directory, prefix, open all).
+# HSA must precede HIP, or HIP's `libhsa-runtime64.so.1` binds outside the
+# bundle; the vendor libraries here are ones other vendor libraries pull in.
 const PRELOAD_LIBRARIES = [
     ("rocm_sysdeps/lib", "librocm_sysdeps_",        true),
     ("llvm/lib",         "libLLVM",                 false),
@@ -76,10 +78,19 @@ const PRELOAD_LIBRARIES = [
     ("",                 "libamd_comgr",            false),
     ("",                 "libhiprtc",               false),
     ("",                 "librocm_kpack",           false),
+    ("",                 "libamdhip64",             false),
+    ("",                 "libroctx64",              false),
+    ("",                 "libhipblaslt",            false),
+    ("",                 "librocblas",              false),
 ]
 
 # path => :loaded / :failed, prefix => :absent. Shown by `AMDGPU.versioninfo()`.
 global preload_log::Vector{Pair{String,Symbol}} = Pair{String,Symbol}[]
+
+# What `preload_bundle` claimed, in the order it claimed it. A separate process
+# has to replay this to bind the bundle rather than a ROCm on LD_LIBRARY_PATH.
+preload_paths()::Vector{String} =
+    [path for (path, status) in preload_log if status === :loaded]
 
 function find_libraries(subdir::String, prefix::String, every::Bool)::Vector{String}
     dir = joinpath(artifact_dir, Sys.iswindows() ? "bin" : "lib", subdir)
@@ -133,6 +144,10 @@ redirect_env() = [name => ENV[name] for name in REDIRECT_ENV if haskey(ENV, name
 const FOREIGN_LIBRARY_NAMES = [
     "libamd_comgr", "libhsa-runtime64", "libamdhip64", "libhiprtc",
     "librocprofiler-register", "librocm_kpack", "libLLVM", "libclang-cpp",
+    # Vendor libraries: one can pull another in, and the soname collides across
+    # ROCm versions, so these mix silently unless the bundle claims them first.
+    "librocblas", "librocsparse", "librocsolver", "librocrand", "librocfft",
+    "libhipblaslt", "libhiptensor", "libMIOpen", "libroctx64",
 ]
 
 function foreign_libraries()::Vector{String}

--- a/ROCm_Runtime/src/ROCm_Runtime.jl
+++ b/ROCm_Runtime/src/ROCm_Runtime.jl
@@ -87,11 +87,6 @@ const PRELOAD_LIBRARIES = [
 # path => :loaded / :failed, prefix => :absent. Shown by `AMDGPU.versioninfo()`.
 global preload_log::Vector{Pair{String,Symbol}} = Pair{String,Symbol}[]
 
-# What `preload_bundle` claimed, in the order it claimed it. A separate process
-# has to replay this to bind the bundle rather than a ROCm on LD_LIBRARY_PATH.
-preload_paths()::Vector{String} =
-    [path for (path, status) in preload_log if status === :loaded]
-
 function find_libraries(subdir::String, prefix::String, every::Bool)::Vector{String}
     dir = joinpath(artifact_dir, Sys.iswindows() ? "bin" : "lib", subdir)
     isdir(dir) || return String[]

--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -150,10 +150,6 @@ export ROCBackend
 include("precompile.jl")
 
 function __init__()
-    # Discovery runs at load time; a precompiled value would be stale.
-    global _ROCSPARSE_VERSION = ""
-    global _ROCSPARSE_PROBE_REASON = :ok
-
     # Used to shutdown hostcalls if any is running.
     atexit(() -> begin Runtime.RT_EXITING[] = true end)
 

--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -152,6 +152,7 @@ include("precompile.jl")
 function __init__()
     # Discovery runs at load time; a precompiled value would be stale.
     global _ROCSPARSE_VERSION = ""
+    global _ROCSPARSE_PROBE_REASON = :ok
 
     # Used to shutdown hostcalls if any is running.
     atexit(() -> begin Runtime.RT_EXITING[] = true end)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,7 +1,7 @@
-# Run `code` in a subprocess and return its stdout, or `nothing` on crash,
-# timeout, or nonzero exit. The empty `JULIA_LOAD_PATH` keeps the child out of
-# the active project, so `code` must only use `Base`.
-function _version_subprocess(code::String; timeout::Real = 20)::Union{String, Nothing}
+# Run `code` in a subprocess and return its stdout, or why it produced none:
+# `:timeout`, `:crashed`, `:empty`, `:spawn`, `Symbol("exit", code)`. The empty
+# `JULIA_LOAD_PATH` keeps the child out of the active project (`Base` only).
+function _version_subprocess(code::String; timeout::Real = 20)::Union{String, Symbol}
     cmd = `$(Base.julia_cmd()) --startup-file=no -O0 --compile=min -e $code`
     cmd = addenv(cmd, "JULIA_LOAD_PATH" => "")
     out = IOBuffer()
@@ -16,30 +16,34 @@ function _version_subprocess(code::String; timeout::Real = 20)::Union{String, No
         end
         wait(proc)
         close(timer)
-        (timedout[] || !success(proc)) && return nothing
+        timedout[] && return :timeout
+        # A killed process reports the signal, not a nonzero exit code.
+        proc.termsignal == 0 || return :crashed
+        proc.exitcode == 0 || return Symbol("exit", proc.exitcode)
         v = strip(String(take!(out)))
-        return isempty(v) ? nothing : v
+        return isempty(v) ? :empty : String(v)
     catch
-        return nothing
+        return :spawn
     end
 end
 
-# Empty until probed, then the version string or `"err"`.
+# Empty until probed, then the version string or `"err"`; `:ok` until the probe
+# fails, then why it did.
 global _ROCSPARSE_VERSION::String = ""
+global _ROCSPARSE_PROBE_REASON::Symbol = :ok
 
 # rocSPARSE's version query needs a handle, and creating one can segfault on
 # broken ROCm installs (issue #920), so run it out-of-process.
 function _rocsparse_version_isolated(; timeout::Real = 20)
-    global _ROCSPARSE_VERSION
+    global _ROCSPARSE_VERSION, _ROCSPARSE_PROBE_REASON
     isempty(_ROCSPARSE_VERSION) || return _ROCSPARSE_VERSION
 
     lib = repr(librocsparse)  # `repr` so Windows separators survive the parser
-    # HIP loads comgr by soname, so a system ROCm in the environment can displace
-    # the provider's copy. The parent claims the soname first (see
-    # `ROCm_Runtime.preload_bundle`); the child has to do the same. Only comgr:
-    # replaying the parent's whole closure here costs more than the probe's budget.
-    preload = isempty(libamd_comgr) ? "" :
-        "Base.Libc.Libdl.dlopen($(repr(libamd_comgr)); throw_error = false)"
+    # `LD_LIBRARY_PATH` outranks the bundle's `DT_RUNPATH`, so a child that has
+    # claimed nothing queries whatever ROCm the environment provides instead.
+    preload = join(("Base.Libc.Libdl.dlopen($(repr(p)); throw_error = false)"
+        for p in unique([ROCm_Runtime.preload_paths(); libamdhip64; librocblas])
+        if !isempty(p)), "\n")
     out = _version_subprocess("""
         $preload
         handle = Ref{Ptr{Cvoid}}(C_NULL)
@@ -47,12 +51,16 @@ function _rocsparse_version_isolated(; timeout::Real = 20)
             (Ptr{Ptr{Cvoid}},), handle) == 0 || exit(2)
         version = Ref{Cint}(0)
         ccall((:rocsparse_get_version, $lib), Cint,
-            (Ptr{Cvoid}, Ptr{Cint}), handle[], version) == 0 || exit(2)
+            (Ptr{Cvoid}, Ptr{Cint}), handle[], version) == 0 || exit(3)
         print(version[])
         """; timeout)
-    packed = out === nothing ? nothing : tryparse(Int, out)
-    return _ROCSPARSE_VERSION =
-        packed === nothing ? "err" : string(rocSPARSE.decode_version(packed))
+    packed = out isa String ? tryparse(Int, out) : nothing
+    if packed === nothing
+        _ROCSPARSE_PROBE_REASON = out isa Symbol ? out : :unparseable
+        return _ROCSPARSE_VERSION = "err"
+    end
+    _ROCSPARSE_PROBE_REASON = :ok
+    return _ROCSPARSE_VERSION = string(rocSPARSE.decode_version(packed))
 end
 
 """
@@ -91,9 +99,17 @@ function versioninfo(io::IO=stdout)
         alignment=[:c, :l, :l, :l])
 
     if rocsparse_ver == "err"
-        @warn """rocSPARSE is installed but its version query failed (it ran in an \
-            isolated subprocess and crashed or timed out). This usually indicates a \
-            broken or mismatched ROCm install. See \
+        reason = _ROCSPARSE_PROBE_REASON
+        what =
+            reason === :timeout ? "timed out (it runs in an isolated subprocess)" :
+            reason === :crashed ? "crashed (it runs in an isolated subprocess, so \
+                                   this process survived)" :
+            reason === :exit2   ? "could not create a rocSPARSE handle" :
+            reason === :exit3   ? "could not query the version" :
+            "failed ($reason)"
+        @warn """rocSPARSE is installed but its version probe $what. The probe claims \
+            the provider's libraries before querying; if another ROCm is still ahead of \
+            them on `LD_LIBRARY_PATH` it can bind there instead. See \
             https://github.com/JuliaGPU/AMDGPU.jl/issues/920."""
     end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,68 +1,3 @@
-# Run `code` in a subprocess and return its stdout, or why it produced none:
-# `:timeout`, `:crashed`, `:empty`, `:spawn`, `Symbol("exit", code)`. The empty
-# `JULIA_LOAD_PATH` keeps the child out of the active project (`Base` only).
-function _version_subprocess(code::String; timeout::Real = 20)::Union{String, Symbol}
-    cmd = `$(Base.julia_cmd()) --startup-file=no -O0 --compile=min -e $code`
-    cmd = addenv(cmd, "JULIA_LOAD_PATH" => "")
-    out = IOBuffer()
-    try
-        proc = run(pipeline(ignorestatus(cmd); stdout = out, stderr = devnull); wait = false)
-        timedout = Ref(false)
-        timer = Timer(timeout) do _
-            if process_running(proc)
-                timedout[] = true
-                kill(proc)
-            end
-        end
-        wait(proc)
-        close(timer)
-        timedout[] && return :timeout
-        # A killed process reports the signal, not a nonzero exit code.
-        proc.termsignal == 0 || return :crashed
-        proc.exitcode == 0 || return Symbol("exit", proc.exitcode)
-        v = strip(String(take!(out)))
-        return isempty(v) ? :empty : String(v)
-    catch
-        return :spawn
-    end
-end
-
-# Empty until probed, then the version string or `"err"`; `:ok` until the probe
-# fails, then why it did.
-global _ROCSPARSE_VERSION::String = ""
-global _ROCSPARSE_PROBE_REASON::Symbol = :ok
-
-# rocSPARSE's version query needs a handle, and creating one can segfault on
-# broken ROCm installs (issue #920), so run it out-of-process.
-function _rocsparse_version_isolated(; timeout::Real = 20)
-    global _ROCSPARSE_VERSION, _ROCSPARSE_PROBE_REASON
-    isempty(_ROCSPARSE_VERSION) || return _ROCSPARSE_VERSION
-
-    lib = repr(librocsparse)  # `repr` so Windows separators survive the parser
-    # `LD_LIBRARY_PATH` outranks the bundle's `DT_RUNPATH`, so a child that has
-    # claimed nothing queries whatever ROCm the environment provides instead.
-    preload = join(("Base.Libc.Libdl.dlopen($(repr(p)); throw_error = false)"
-        for p in unique([ROCm_Runtime.preload_paths(); libamdhip64; librocblas])
-        if !isempty(p)), "\n")
-    out = _version_subprocess("""
-        $preload
-        handle = Ref{Ptr{Cvoid}}(C_NULL)
-        ccall((:rocsparse_create_handle, $lib), Cint,
-            (Ptr{Ptr{Cvoid}},), handle) == 0 || exit(2)
-        version = Ref{Cint}(0)
-        ccall((:rocsparse_get_version, $lib), Cint,
-            (Ptr{Cvoid}, Ptr{Cint}), handle[], version) == 0 || exit(3)
-        print(version[])
-        """; timeout)
-    packed = out isa String ? tryparse(Int, out) : nothing
-    if packed === nothing
-        _ROCSPARSE_PROBE_REASON = out isa Symbol ? out : :unparseable
-        return _ROCSPARSE_VERSION = "err"
-    end
-    _ROCSPARSE_PROBE_REASON = :ok
-    return _ROCSPARSE_VERSION = string(rocSPARSE.decode_version(packed))
-end
-
 """
     versioninfo(io::IO=stdout)
 
@@ -76,10 +11,10 @@ function versioninfo(io::IO=stdout)
         "local ROCm installation" : "downloaded artifacts")
     _status(st::Bool) = st ? "+" : "-"
     _libpath(p::String) = isempty(p) ? "-" : p
-    _ver(lib::Symbol, ver_fn) = functional(lib) ? "$(ver_fn())" : "-"
-
-    # `"err"` = present but the out-of-process version probe crashed/timed out.
-    rocsparse_ver = functional(:rocsparse) ? _rocsparse_version_isolated() : "-"
+    # rocSPARSE needs a handle for its version, so its query can fail where the
+    # others cannot; `"err"` keeps one library from sinking the whole report.
+    _ver(lib::Symbol, ver_fn) =
+        functional(lib) ? (try "$(ver_fn())" catch; "err" end) : "-"
 
     data = String[
         _status(functional(:lld))         "LLD"              "-"                                 _libpath(lld_path);
@@ -87,7 +22,7 @@ function versioninfo(io::IO=stdout)
         _status(functional(:hip))         "HIP"              _ver(:hip, HIP.runtime_version)     _libpath(libamdhip64);
         _status(functional(:rocblas))     "rocBLAS"          _ver(:rocblas, rocBLAS.version)     _libpath(librocblas);
         _status(functional(:rocsolver))   "rocSOLVER"        _ver(:rocsolver, rocSOLVER.version) _libpath(librocsolver);
-        _status(functional(:rocsparse))   "rocSPARSE"        rocsparse_ver                       _libpath(librocsparse);
+        _status(functional(:rocsparse))   "rocSPARSE"        _ver(:rocsparse, rocSPARSE.version) _libpath(librocsparse);
         _status(functional(:rocrand))     "rocRAND"          _ver(:rocrand, rocRAND.version)     _libpath(librocrand);
         _status(functional(:rocfft))      "rocFFT"           _ver(:rocfft, rocFFT.version)       _libpath(librocfft);
         _status(functional(:hiptensor))   "hipTENSOR"        _ver(:hiptensor, hipTENSOR.version) _libpath(libhiptensor);
@@ -98,18 +33,10 @@ function versioninfo(io::IO=stdout)
         "Available", "Name", "Version", "Path"],
         alignment=[:c, :l, :l, :l])
 
-    if rocsparse_ver == "err"
-        reason = _ROCSPARSE_PROBE_REASON
-        what =
-            reason === :timeout ? "timed out (it runs in an isolated subprocess)" :
-            reason === :crashed ? "crashed (it runs in an isolated subprocess, so \
-                                   this process survived)" :
-            reason === :exit2   ? "could not create a rocSPARSE handle" :
-            reason === :exit3   ? "could not query the version" :
-            "failed ($reason)"
-        @warn """rocSPARSE is installed but its version probe $what. The probe claims \
-            the provider's libraries before querying; if another ROCm is still ahead of \
-            them on `LD_LIBRARY_PATH` it can bind there instead. See \
+    if any(==("err"), @view data[:, 3])
+        @warn """A library is installed but its version query failed. Check the \
+            foreign-library report below: a ROCm from the environment mixed into \
+            this process is the usual cause. See \
             https://github.com/JuliaGPU/AMDGPU.jl/issues/920."""
     end
 

--- a/test/core/core_tests.jl
+++ b/test/core/core_tests.jl
@@ -9,34 +9,14 @@ using AMDGPU: HIP, Runtime, Device, Mem
     @test AMDGPU.functional() isa Bool
 end
 
-@testset "versioninfo probe isolation" begin
-    probe(code; timeout = 60) = AMDGPU._version_subprocess(code; timeout)
-
-    # A clean child returns its stdout. Library paths reach it through `repr`,
-    # so Windows separators must survive the round trip.
-    @test probe("print(\"4.2.0\")") == "4.2.0"
-    @test probe("print($(repr(raw"C:\rocm\lib")))") == raw"C:\rocm\lib"
-
-    # No package environment, so probing can't trigger a precompile (#1040).
-    @test probe("print(Base.load_path())") == "String[]"
-    @test probe("using Adapt; print(\"loaded\")") === :exit1
-
-    # A failing child reports why without taking down this process — the point
-    # of the isolation: a SIGSEGV in a vendor library (issue #920) must not
-    # crash the caller.
-    @test probe("ccall(:abort, Cvoid, ())") === :crashed       # SIGABRT
-    @test probe("unsafe_store!(Ptr{Int}(0), 0)") === :crashed  # SIGSEGV
-    @test probe("exit(2)") === :exit2                          # nonzero exit
-    @test probe("1 + 1") === :empty                            # no output
-    @test probe("while true; end"; timeout = 2) === :timeout   # hang -> timeout
-
-    # On a working setup the probe returns a version; repeats hit the cache.
+@testset "versioninfo" begin
+    # rocSPARSE is the only library whose version query needs a handle (#920).
     if AMDGPU.functional(:rocsparse)
-        AMDGPU._ROCSPARSE_VERSION = ""
-        v = AMDGPU._rocsparse_version_isolated()
-        @test tryparse(VersionNumber, v) !== nothing
-        @test AMDGPU._rocsparse_version_isolated() === v
+        @test AMDGPU.rocSPARSE.version() isa VersionNumber
     end
+    # Having touched rocSPARSE, nothing from a ROCm outside the artifact may be
+    # loaded: that mixture is silent until something downstream misbehaves.
+    @test isempty(AMDGPU.ROCm_Runtime.foreign_libraries())
 end
 
 @testset "HIPDevice" begin

--- a/test/core/core_tests.jl
+++ b/test/core/core_tests.jl
@@ -19,16 +19,16 @@ end
 
     # No package environment, so probing can't trigger a precompile (#1040).
     @test probe("print(Base.load_path())") == "String[]"
-    @test probe("using Adapt; print(\"loaded\")") === nothing
+    @test probe("using Adapt; print(\"loaded\")") === :exit1
 
-    # A failing child degrades to `nothing` without taking down this process —
-    # the point of the isolation: a SIGSEGV in a vendor library (issue #920)
-    # must not crash the caller.
-    @test probe("ccall(:abort, Cvoid, ())") === nothing       # SIGABRT
-    @test probe("unsafe_store!(Ptr{Int}(0), 0)") === nothing  # SIGSEGV
-    @test probe("exit(2)") === nothing                        # nonzero exit
-    @test probe("1 + 1") === nothing                          # no output
-    @test probe("while true; end"; timeout = 2) === nothing   # hang -> timeout
+    # A failing child reports why without taking down this process — the point
+    # of the isolation: a SIGSEGV in a vendor library (issue #920) must not
+    # crash the caller.
+    @test probe("ccall(:abort, Cvoid, ())") === :crashed       # SIGABRT
+    @test probe("unsafe_store!(Ptr{Int}(0), 0)") === :crashed  # SIGSEGV
+    @test probe("exit(2)") === :exit2                          # nonzero exit
+    @test probe("1 + 1") === :empty                            # no output
+    @test probe("while true; end"; timeout = 2) === :timeout   # hang -> timeout
 
     # On a working setup the probe returns a version; repeats hit the cache.
     if AMDGPU.functional(:rocsparse)


### PR DESCRIPTION
EDIT: rolled-back most of #1001 

In artifact mode on a host with another ROCm on `LD_LIBRARY_PATH` (here a CSCS uenv), `versioninfo()` reported rocSPARSE as `err` and the core test asserting the probe returns a version failed. The cause is not rocSPARSE.

`PRELOAD_LIBRARIES` claimed the runtime closure but no vendor library, and AMDGPU claims those lazily on the first `ccall`, so whichever is touched first wins. TheRock's libraries carry `DT_RUNPATH`, which `LD_LIBRARY_PATH` outranks, so touching rocSPARSE first pulled its dependencies from the environment. Measured in artifact mode after `rocSPARSE.version()`:

```
rocsparse -> <artifact>/lib/librocsparse.so
rocblas   -> /user-environment/env/default/lib/librocblas.so.5
roctx     -> /user-environment/env/default/lib/libroctx64.so.4
foreign_libraries() = String[]
```

`FOREIGN_LIBRARY_NAMES` listed only runtime libraries, so `versioninfo()` printed "Foreign ROCm libraries loaded: none" while two rocBLAS versions were live in the process.

The isolated probe from #1051 hit the same thing: a bare child has claimed nothing at all, so it resolved the bundle's `librocsparse` against uenv HIP 7.2.3 and `rocsparse_create_handle` segfaulted, which is what surfaced as `err`.

### Changes

- `PRELOAD_LIBRARIES` also claims `libamdhip64`, `libroctx64`, `libhipblaslt` and `librocblas` — the vendor libraries that other vendor libraries pull in (`librocsparse` needs `librocblas` and `libroctx64`; `librocblas` needs `libhipblaslt`). Order is load-bearing: HSA must precede HIP, or HIP's `libhsa-runtime64.so.1` binds outside the bundle and the dlopen fails with `undefined symbol: hsa_amd_queue_create, version ROCR_1`.
- `FOREIGN_LIBRARY_NAMES` gains the vendor libraries, so a mixed process is reported instead of passing as clean.
- The out-of-process version probe is removed (`_version_subprocess`, `_rocsparse_version_isolated`, the cache global and its `__init__` reset). With the libraries claimed correctly there is nothing left for it to protect against, and it was a lot of machinery for one cell of a table.
- `versioninfo` queries rocSPARSE in-process like every other library. The shared `_ver` helper now guards *all* of them, so a failing query shows `err` instead of taking down the whole report — previously none were guarded.

### Result

On beverin (2x MI300A, artifact ROCm under uenv), before -> after:

| | before | after |
|---|---|---|
| `versioninfo` rocSPARSE | `err` + misleading warning | `5.0.0` |
| `librocblas` / `libroctx64` / `libhipblaslt` | uenv | bundle |
| `foreign_libraries()` | `String[]` (wrong) | `String[]` (correct) |
| preloaded libraries | 41 | 45 |

### Trade-off

A SIGSEGV inside `rocsparse_create_handle` (#920) again takes down the session rather than degrading to `err`. Two things make that acceptable: the preload fix removes the mixed-library cause that produced the crash here, and `versioninfo` already initialises HIP and enumerates devices in-process, so a genuinely broken install fails before the rocSPARSE row either way. `try`/`catch` still covers every non-fatal failure.