### PR TITLE
Handle hipTENSOR 2.4: fix the version decode, reject the layouts it miscomputes

### DIFF
--- a/docs/src/libraries/tensor.md
+++ b/docs/src/libraries/tensor.md
@@ -8,10 +8,7 @@ which can be used to perform operations on high-dimensional arrays. However, the
   operator passed as `opABC` to `A` and `B`, and the one passed as `opAB` to that intermediate result and `C`. This is currently handled by our wrapper.
 - Unlike NVIDIA's `cuTENSOR`, `hipTENSOR` wants a *complex* compute descriptor for complex operands: pairing e.g. `ComplexF32` tensors with `HIPTENSOR_COMPUTE_DESC_32F` makes
   `hiptensorCreatePlan` fail with `HIPTENSOR_STATUS_EXECUTION_FAILED`
-- from `hipTENSOR` 2.4 on (the version in the ROCm 10.0 bundles, for instance), the contraction kernels no longer use the mode labels to work out how their operands line up:
-  they read every descriptor positionally, and only compute the right result when `A` is indexed by its free modes followed by the contracted ones, `B` likewise, and `C` and `D`
-  by `A`'s free modes followed by `B`'s, with every operand packed column-major. Any other layout is *silently* miscomputed — `hiptensorContract` reports success and writes a
-  plausible but wrong result — so `plan_contraction` rejects it with an `ArgumentError`. Permute the operands with `permutedims` first. `hipTENSOR` 2.2 handled arbitrary mode
-  orders, and is left alone
-- `hipTENSOR` 2.2 accepts `HIPTENSOR_OP_CONJ` on a contraction's inputs and then silently ignores it, computing the unconjugated product; 2.4 rejects it instead, failing
-  `hiptensorCreatePlan` with `HIPTENSOR_STATUS_EXECUTION_FAILED`
+- from `hipTENSOR` 2.4 on, a contraction is only computed correctly when every operand is packed column-major and indexed with the free modes before the contracted ones:
+  `A = [M…, K…]`, `B = [N…, K…]`, `C = D = [M…, N…]`. Other layouts come back wrong with no error reported, so `plan_contraction` rejects them with an `ArgumentError` —
+  permute the operands with `permutedims` first
+- on `hipTENSOR` 2.4, `HIPTENSOR_OP_CONJ` on a contraction's input makes `hiptensorCreatePlan` fail with `HIPTENSOR_STATUS_EXECUTION_FAILED`

--- a/docs/src/libraries/tensor.md
+++ b/docs/src/libraries/tensor.md
@@ -8,3 +8,10 @@ which can be used to perform operations on high-dimensional arrays. However, the
   operator passed as `opABC` to `A` and `B`, and the one passed as `opAB` to that intermediate result and `C`. This is currently handled by our wrapper.
 - Unlike NVIDIA's `cuTENSOR`, `hipTENSOR` wants a *complex* compute descriptor for complex operands: pairing e.g. `ComplexF32` tensors with `HIPTENSOR_COMPUTE_DESC_32F` makes
   `hiptensorCreatePlan` fail with `HIPTENSOR_STATUS_EXECUTION_FAILED`
+- from `hipTENSOR` 2.4 on (the version in the ROCm 10.0 bundles, for instance), the contraction kernels no longer use the mode labels to work out how their operands line up:
+  they read every descriptor positionally, and only compute the right result when `A` is indexed by its free modes followed by the contracted ones, `B` likewise, and `C` and `D`
+  by `A`'s free modes followed by `B`'s, with every operand packed column-major. Any other layout is *silently* miscomputed — `hiptensorContract` reports success and writes a
+  plausible but wrong result — so `plan_contraction` rejects it with an `ArgumentError`. Permute the operands with `permutedims` first. `hipTENSOR` 2.2 handled arbitrary mode
+  orders, and is left alone
+- `hipTENSOR` 2.2 accepts `HIPTENSOR_OP_CONJ` on a contraction's inputs and then silently ignores it, computing the unconjugated product; 2.4 rejects it instead, failing
+  `hiptensorCreatePlan` with `HIPTENSOR_STATUS_EXECUTION_FAILED`

--- a/src/tensor/hipTENSOR.jl
+++ b/src/tensor/hipTENSOR.jl
@@ -48,12 +48,11 @@ lib_state() = library_state(
 handle() = lib_state().handle
 stream() = lib_state().stream
 
+# `hiptensorGetVersion` encodes `major * 1_000_000 + minor * 1_000 + patch` (2.4.0 reports
+# 2004000), not cuTENSOR's `major * 10_000 + minor * 100 + patch`.
 function version()
     ver = hiptensorGetVersion()
-    major = ver ÷ 10000
-    minor = (ver ÷ 100) % 100
-    patch = ver % 100
-    return VersionNumber(join((major,minor,patch), "."))
+    return VersionNumber(ver ÷ 1_000_000, (ver ÷ 1_000) % 1_000, ver % 1_000)
 end
 
 end

--- a/src/tensor/operations.jl
+++ b/src/tensor/operations.jl
@@ -330,9 +330,8 @@ function contract!(plan::hipTensorPlan,
     return C
 end
 
-# hipTENSOR 2.4 lines a contraction's operands up positionally rather than by mode label,
-# and silently miscomputes every layout but the one checked below; 2.2 handled arbitrary
-# mode orders. See `docs/src/libraries/tensor.md`.
+# hipTENSOR 2.4 returns wrong results, with no error reported, unless a contraction's
+# operands are packed column-major and indexed as checked below.
 const CANONICAL_CONTRACTION_LAYOUT = v"2.4"
 
 # A's free modes, B's free modes, the contracted modes, and any mode shared by all three,
@@ -363,8 +362,8 @@ function check_contraction_layout(
 
     M, N, K, batched = contraction_mode_groups(Ainds, Binds, Cinds)
     isempty(batched) || throw(ArgumentError(
-        "hipTENSOR $(version()) has no layout that contracts correctly with a mode shared " *
-        "by all three operands, but $(batched) " * (length(batched) == 1 ? "is" : "are") *
+        "this wrapper does not support a contraction with a mode shared by all three " *
+        "operands, and $(batched) " * (length(batched) == 1 ? "is" : "are") *
         " shared by A, B and C here."))
 
     problems = String[]
@@ -383,8 +382,8 @@ function check_contraction_layout(
         "hipTENSOR $(version()) only contracts correctly when its operands are packed " *
         "column-major and indexed in the order it expects: A by its free modes followed " *
         "by the contracted ones ($([M; K]) here), B likewise ($([N; K])), and C by A's " *
-        "free modes followed by B's ($([M; N])). It miscomputes every other layout " *
-        "without reporting an error, so this combination is rejected: " *
+        "free modes followed by B's ($([M; N])). Other layouts are miscomputed without " *
+        "an error being reported, so this combination is rejected: " *
         join(problems, ", ") * ". Permute the operands with `permutedims` first."))
 end
 

--- a/src/tensor/operations.jl
+++ b/src/tensor/operations.jl
@@ -330,6 +330,64 @@ function contract!(plan::hipTensorPlan,
     return C
 end
 
+# hipTENSOR 2.4 lines a contraction's operands up positionally rather than by mode label,
+# and silently miscomputes every layout but the one checked below; 2.2 handled arbitrary
+# mode orders. See `docs/src/libraries/tensor.md`.
+const CANONICAL_CONTRACTION_LAYOUT = v"2.4"
+
+# A's free modes, B's free modes, the contracted modes, and any mode shared by all three,
+# each in the order its owner declares them
+function contraction_mode_groups(Ainds::ModeType, Binds::ModeType, Cinds::ModeType)
+    M = [mode for mode in Cinds if mode in Ainds && !(mode in Binds)]
+    N = [mode for mode in Cinds if mode in Binds && !(mode in Ainds)]
+    K = [mode for mode in Ainds if mode in Binds && !(mode in Cinds)]
+    batched = [mode for mode in Cinds if mode in Ainds && mode in Binds]
+    return M, N, K, batched
+end
+
+# does `X` have the generalised packed column-major layout hipTENSOR assumes?
+function is_packed(@nospecialize(X::AbstractArray))
+    expected = 1
+    for (i, len) in enumerate(size(X))
+        stride(X, i) == expected || return false
+        expected *= len
+    end
+    return true
+end
+
+function check_contraction_layout(
+        @nospecialize(A::AbstractArray), Ainds::ModeType,
+        @nospecialize(B::AbstractArray), Binds::ModeType,
+        @nospecialize(C::AbstractArray), Cinds::ModeType)
+    version() < CANONICAL_CONTRACTION_LAYOUT && return nothing
+
+    M, N, K, batched = contraction_mode_groups(Ainds, Binds, Cinds)
+    isempty(batched) || throw(ArgumentError(
+        "hipTENSOR $(version()) has no layout that contracts correctly with a mode shared " *
+        "by all three operands, but $(batched) " * (length(batched) == 1 ? "is" : "are") *
+        " shared by A, B and C here."))
+
+    problems = String[]
+    collect(Ainds) == [M; K] ||
+        push!(problems, "A is indexed by $(collect(Ainds)) instead of $([M; K])")
+    collect(Binds) == [N; K] ||
+        push!(problems, "B is indexed by $(collect(Binds)) instead of $([N; K])")
+    collect(Cinds) == [M; N] ||
+        push!(problems, "C is indexed by $(collect(Cinds)) instead of $([M; N])")
+    is_packed(A) || push!(problems, "A is not packed column-major")
+    is_packed(B) || push!(problems, "B is not packed column-major")
+    is_packed(C) || push!(problems, "C is not packed column-major")
+    isempty(problems) && return nothing
+
+    throw(ArgumentError(
+        "hipTENSOR $(version()) only contracts correctly when its operands are packed " *
+        "column-major and indexed in the order it expects: A by its free modes followed " *
+        "by the contracted ones ($([M; K]) here), B likewise ($([N; K])), and C by A's " *
+        "free modes followed by B's ($([M; N])). It miscomputes every other layout " *
+        "without reporting an error, so this combination is rejected: " *
+        join(problems, ", ") * ". Permute the operands with `permutedims` first."))
+end
+
 function plan_contraction(
         @nospecialize(A::AbstractArray), Ainds::ModeType, opA::hiptensorOperator_t,
         @nospecialize(B::AbstractArray), Binds::ModeType, opB::hiptensorOperator_t,
@@ -353,6 +411,8 @@ function plan_contraction(
     length(modeB) == ndims(B) || throw(ArgumentError("Binds must match number of dimensions in B!"))
     modeC = collect(Cint, Cinds)
     length(modeC) == ndims(C) || throw(ArgumentError("Cinds must match number of dimensions in C!"))
+
+    check_contraction_layout(A, Ainds, B, Binds, C, Cinds)
 
     compute_desc = compute_descriptor(compute_type === nothing ?
         default_compute_type(contraction_compute_types, "contraction",

--- a/test/hiptensor/contractions.jl
+++ b/test/hiptensor/contractions.jl
@@ -31,11 +31,14 @@ eltypes = [(Float32, Float32, Float32, Float32),
         indsoA = allinds[1:NoA]
         indsoB = allinds[NoA .+ (1:NoB)]
         indsc = allinds[NoA .+ NoB .+ (1:Nc)]
-        pA = randperm(NoA + Nc)
+        # hipTENSOR 2.4 only computes the layout `check_contraction_layout` enforces;
+        # random mode orders are meaningful only on the versions that accept them.
+        canonical_layout = hipTENSOR.version() >= v"2.4"
+        pA = canonical_layout ? collect(1:(NoA + Nc))        : randperm(NoA + Nc)
+        pB = canonical_layout ? [(Nc + 1):(Nc + NoB); 1:Nc]  : randperm(Nc + NoB)
+        pC = canonical_layout ? collect(1:(NoA + NoB))       : randperm(NoA + NoB)
         ipA = invperm(pA)
-        pB = randperm(Nc + NoB)
         ipB = invperm(pB)
-        pC = randperm(NoA + NoB)
         ipC = invperm(pC)
         compute_rtol = (eltyCompute == Float16 || eltyC == Float16) ? 1e-2 : (eltyCompute == Float32 ? 1e-4 : 1e-6)
         dimsA = [dimsoA; dimsc][pA]
@@ -141,42 +144,71 @@ eltypes = [(Float32, Float32, Float32, Float32),
             # silently ignores it: the results below are the unconjugated products. These
             # are `@test_broken` so that they start failing again once that is fixed.
             @testset "with conjugation flag for complex arguments" begin
-                if eltyA <: Complex
-                    opA   = AMDGPU.hipTENSOR.OP_CONJ
-                    opB   = AMDGPU.hipTENSOR.OP_IDENTITY
-                    opOut = AMDGPU.hipTENSOR.OP_IDENTITY
-                    dC    = contract!(complex(1.0, 0.0), dA, indsA, opA, dB, indsB, opB,
-                                                    0, dC, indsC, opC, opOut; compute_type=eltyCompute)
-                    C     = collect(dC)
-                    mC    = reshape(permutedims(C, ipC), (loA, loB))
-                    @test_broken isapprox(mC, conj(mA) * mB; rtol=compute_rtol)
-                    @test mC ≈ mA * mB rtol=compute_rtol   # opA was ignored
-                end
-                if eltyB <: Complex
-                    opA = AMDGPU.hipTENSOR.OP_IDENTITY
-                    opB = AMDGPU.hipTENSOR.OP_CONJ
-                    opOut = AMDGPU.hipTENSOR.OP_IDENTITY
-                    dC = contract!(complex(1.0, 0.0), dA, indsA, opA, dB, indsB, opB,
-                                   complex(0.0, 0.0), dC, indsC, opC, opOut; compute_type=eltyCompute)
-                    C = collect(dC)
-                    mC = reshape(permutedims(C, ipC), (loA, loB))
-                    @test_broken isapprox(mC, mA * conj(mB); rtol=compute_rtol)
-                    @test mC ≈ mA * mB rtol=compute_rtol   # opB was ignored
-                end
-                if eltyA <: Complex && eltyB <: Complex
-                    opA = AMDGPU.hipTENSOR.OP_CONJ
-                    opB = AMDGPU.hipTENSOR.OP_CONJ
-                    opOut = AMDGPU.hipTENSOR.OP_IDENTITY
-                    dC = contract!(one(eltyCompute), dA, indsA, opA, dB, indsB, opB,
-                            zero(eltyCompute), dC, indsC, opC, opOut; compute_type=eltyCompute)
-                    C = collect(dC)
-                    mC = reshape(permutedims(C, ipC), (loA, loB))
-                    @test_broken isapprox(mC, conj(mA) * conj(mB); rtol=compute_rtol)
-                    @test mC ≈ mA * mB rtol=compute_rtol   # opA and opB were ignored
+                if canonical_layout
+                    # 2.4 rejects OP_CONJ outright, failing `hiptensorCreatePlan`
+                    if eltyA <: Complex
+                        @test_throws hipTENSOR.hipTENSORError contract!(
+                            complex(1.0, 0.0), dA, indsA, AMDGPU.hipTENSOR.OP_CONJ,
+                            dB, indsB, AMDGPU.hipTENSOR.OP_IDENTITY,
+                            0, dC, indsC, opC, AMDGPU.hipTENSOR.OP_IDENTITY;
+                            compute_type=eltyCompute)
+                    end
+                    if eltyB <: Complex
+                        @test_throws hipTENSOR.hipTENSORError contract!(
+                            complex(1.0, 0.0), dA, indsA, AMDGPU.hipTENSOR.OP_IDENTITY,
+                            dB, indsB, AMDGPU.hipTENSOR.OP_CONJ,
+                            complex(0.0, 0.0), dC, indsC, opC, AMDGPU.hipTENSOR.OP_IDENTITY;
+                            compute_type=eltyCompute)
+                    end
+                else
+                    if eltyA <: Complex
+                        opA   = AMDGPU.hipTENSOR.OP_CONJ
+                        opB   = AMDGPU.hipTENSOR.OP_IDENTITY
+                        opOut = AMDGPU.hipTENSOR.OP_IDENTITY
+                        dC    = contract!(complex(1.0, 0.0), dA, indsA, opA, dB, indsB, opB,
+                                                        0, dC, indsC, opC, opOut; compute_type=eltyCompute)
+                        C     = collect(dC)
+                        mC    = reshape(permutedims(C, ipC), (loA, loB))
+                        @test_broken isapprox(mC, conj(mA) * mB; rtol=compute_rtol)
+                        @test mC ≈ mA * mB rtol=compute_rtol   # opA was ignored
+                    end
+                    if eltyB <: Complex
+                        opA = AMDGPU.hipTENSOR.OP_IDENTITY
+                        opB = AMDGPU.hipTENSOR.OP_CONJ
+                        opOut = AMDGPU.hipTENSOR.OP_IDENTITY
+                        dC = contract!(complex(1.0, 0.0), dA, indsA, opA, dB, indsB, opB,
+                                       complex(0.0, 0.0), dC, indsC, opC, opOut; compute_type=eltyCompute)
+                        C = collect(dC)
+                        mC = reshape(permutedims(C, ipC), (loA, loB))
+                        @test_broken isapprox(mC, mA * conj(mB); rtol=compute_rtol)
+                        @test mC ≈ mA * mB rtol=compute_rtol   # opB was ignored
+                    end
+                    if eltyA <: Complex && eltyB <: Complex
+                        opA = AMDGPU.hipTENSOR.OP_CONJ
+                        opB = AMDGPU.hipTENSOR.OP_CONJ
+                        opOut = AMDGPU.hipTENSOR.OP_IDENTITY
+                        dC = contract!(one(eltyCompute), dA, indsA, opA, dB, indsB, opB,
+                                zero(eltyCompute), dC, indsC, opC, opOut; compute_type=eltyCompute)
+                        C = collect(dC)
+                        mC = reshape(permutedims(C, ipC), (loA, loB))
+                        @test_broken isapprox(mC, conj(mA) * conj(mB); rtol=compute_rtol)
+                        @test mC ≈ mA * mB rtol=compute_rtol   # opA and opB were ignored
+                    end
                 end
             end
             AMDGPU.synchronize()
         end
+    end
+end
+
+@testset "layouts hipTENSOR miscomputes are rejected" begin
+    if hipTENSOR.version() >= v"2.4"
+        dA = ROCArray(rand(Float32, 2, 4))
+        dB = ROCArray(rand(Float32, 4, 3))   # indexed [K, N]; hipTENSOR 2.4 needs [N, K]
+        dC = ROCArray(zeros(Float32, 2, 3))
+        op = AMDGPU.hipTENSOR.OP_IDENTITY
+        @test_throws ArgumentError contract!(1f0, dA, ['a', 'k'], op, dB, ['k', 'b'], op,
+                                             0f0, dC, ['a', 'b'], op, op)
     end
 end
 
@@ -198,7 +230,8 @@ end
         vD = @view dD[3:6]
         tA = hipTensor(reshape(vA, (4, 1)), [1, 2])
         tB = hipTensor(reshape(vB, (1, 1)), [3, 2])
-        tC = hipTensor(reshape(vC, (1, 4)), [3, 1])
+        # C must be indexed by A's free modes then B's; see `check_contraction_layout`
+        tC = hipTensor(reshape(vC, (4, 1)), [1, 3])
         mul!(tC, tA, tB)
     end
 end

--- a/test/hiptensor/contractions.jl
+++ b/test/hiptensor/contractions.jl
@@ -31,8 +31,8 @@ eltypes = [(Float32, Float32, Float32, Float32),
         indsoA = allinds[1:NoA]
         indsoB = allinds[NoA .+ (1:NoB)]
         indsc = allinds[NoA .+ NoB .+ (1:Nc)]
-        # hipTENSOR 2.4 only computes the layout `check_contraction_layout` enforces;
-        # random mode orders are meaningful only on the versions that accept them.
+        # `check_contraction_layout` rejects other layouts on hipTENSOR 2.4 and above, so
+        # use the canonical one there; random orders still exercise earlier versions.
         canonical_layout = hipTENSOR.version() >= v"2.4"
         pA = canonical_layout ? collect(1:(NoA + Nc))        : randperm(NoA + Nc)
         pB = canonical_layout ? [(Nc + 1):(Nc + NoB); 1:Nc]  : randperm(Nc + NoB)


### PR DESCRIPTION
hipTENSOR 2.4 (the version in the ROCm 10.0 bundles) no longer uses the mode labels to line a contraction's operands up. It reads every descriptor positionally, and computes the right result only when the operands are packed column-major and indexed as

* `A = [M…, K…]` — A's free modes, then the contracted ones
* `B = [N…, K…]`
* `C = D = [M…, N…]` — A's free modes, then B's

Every other layout is **silently miscomputed**: `hiptensorContract` returns `HIPTENSOR_STATUS_SUCCESS` and writes a plausible but wrong result. hipTENSOR 2.2 handled arbitrary mode orders, which is what the wrapper was written against.

Of the 120 shapes `test/hiptensor/contractions.jl` generates, 115 came out wrong on an MI300A, with relative errors of 0.3–1.2. Reordering the descriptors alone fixes only 80 of them; all 120 are correct once every operand is packed and canonical.

Two related changes in 2.4:

* `HIPTENSOR_OP_CONJ` on a contraction's input is now rejected — `hiptensorCreatePlan` fails with `HIPTENSOR_STATUS_EXECUTION_FAILED`. On 2.2 it was accepted and silently ignored.
* `hiptensorGetVersion()` returns `2004000`, i.e. `major * 1_000_000 + minor * 1_000 + patch`. `version()` decoded it cuTENSOR-style and reported the library as `v"200.40.0"`.

## Changes

* fix the `version()` decode, so hipTENSOR 2.4.0 reports `v"2.4.0"`
* add `check_contraction_layout`, called from `plan_contraction`: on hipTENSOR ≥ 2.4, reject any layout the library would miscompute, naming the index order each operand needs. Below 2.4 it returns immediately, so 2.2 is untouched.
* document both restrictions in `docs/src/libraries/tensor.md`
* tests use random mode orders below 2.4 and the canonical layout at or above it, expect `hipTENSORError` from `OP_CONJ` on 2.4, and gain a test asserting the guard fires

Making arbitrary layouts work on 2.4 would mean materialising permuted copies of every operand — a copy of `A`, `B` and `C` on most calls — so that is left until upstream says whether the layout requirement is intended.

## Testing

Verified on an MI300A (gfx942) against hipTENSOR 2.4.0 from the ROCm 10.0 `gfx94X-dcgpu` bundle: `test/hiptensor/contractions.jl` passes 433/433, no failures or broken tests.

Not tested against hipTENSOR 2.2. That path is unchanged by construction.