### PR TITLE
Skip Int128 in the GPUArrays test suite on LLVM 18

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,6 +80,19 @@ init_code = quote
     include($gpuarrays_testsuite)
     testf(f, xs...; kwargs...) = TestSuite.compare(f, AMDGPU.ROCArray, xs...; kwargs...)
 
+    const eltypes = [Int16, Int32, Int64,
+                     Float16, Float32, Float64,
+                     ComplexF16, ComplexF32, ComplexF64,
+                     Complex{Int16}, Complex{Int32}, Complex{Int64}]
+    # Kernels are compiled with Julia's in-tree LLVM, and the LLVM 18 that Julia 1.12
+    # ships with miscompiles Int128 arithmetic on AMDGPU (JuliaGPU/AMDGPU.jl#1002).
+    # Only exercise Int128 as a generic element type on newer LLVM versions.
+    const int128_supported = Base.libllvm_version >= v"19"
+    if int128_supported
+        push!(eltypes, Int128)
+    end
+    TestSuite.supported_eltypes(::Type{<:AMDGPU.ROCArray}) = eltypes
+
     macro grab_output(ex, io=stdout)
         quote
             mktemp() do fname, fout


### PR DESCRIPTION
GPUArrays.jl#723 adds Int128 to the test suite's default element types on Julia 1.12+, but Julia 1.12's in-tree LLVM 18 miscompiles Int128 arithmetic on AMDGPU (#1002). Add an explicit `supported_eltypes` overload for ROCArray, like oneAPI.jl does, and only include Int128 on LLVM 19 or newer.