### PR TITLE
Exclude Int128 from testing on linalg/core

### DIFF
--- a/test/core/rocarray_broadcast.jl
+++ b/test/core/rocarray_broadcast.jl
@@ -59,3 +59,18 @@ end
     @test Array(test_kernel.(ROCArray(M), Int128(10))) == test_kernel.(M, Int128(10))
     AMDGPU.synchronize()
 end
+
+# https://github.com/JuliaGPU/AMDGPU.jl/issues/1002
+# The multiply-add that GPUArrays' `axpy!`/`axpby!` lower to is still miscompiled on
+# LLVM 20, which is why `runtests.jl` drops Int128 from the `gpuarrays/linalg/core`
+# element types.
+if Base.libllvm_version >= v"19"
+    @testset "Int128 axpby! miscompilation" begin
+        a, b = rand(Int128), rand(Int128)
+        x, y = rand(Int128, 5), rand(Int128, 5)
+        gx, gy = ROCArray(x), ROCArray(y)
+        gy .= gx .* a .+ gy .* b
+        @test_broken Array(gy) == x .* a .+ y .* b
+        AMDGPU.synchronize()
+    end
+end

--- a/test/core/rocarray_broadcast.jl
+++ b/test/core/rocarray_broadcast.jl
@@ -61,11 +61,14 @@ end
 end
 
 # https://github.com/JuliaGPU/AMDGPU.jl/issues/1002
-@testset "Int128 axpby! miscompilation" begin
-    a, b = rand(Int128), rand(Int128)
-    x, y = rand(Int128, 5), rand(Int128, 5)
-    gx, gy = ROCArray(x), ROCArray(y)
-    gy .= gx .* a .+ gy .* b
-    @test_broken Array(gy) == x .* a .+ y .* b
-    AMDGPU.synchronize()
+# Gated on the same condition that puts Int128 into the `linalg/core` eltypes:
+if int128_supported
+    @testset "Int128 axpby! miscompilation" begin
+        a, b = rand(Int128), rand(Int128)
+        x, y = rand(Int128, 5), rand(Int128, 5)
+        gx, gy = ROCArray(x), ROCArray(y)
+        gy .= gx .* a .+ gy .* b
+        @test_broken Array(gy) == x .* a .+ y .* b
+        AMDGPU.synchronize()
+    end
 end

--- a/test/core/rocarray_broadcast.jl
+++ b/test/core/rocarray_broadcast.jl
@@ -61,16 +61,11 @@ end
 end
 
 # https://github.com/JuliaGPU/AMDGPU.jl/issues/1002
-# The multiply-add that GPUArrays' `axpy!`/`axpby!` lower to is still miscompiled on
-# LLVM 20, which is why `runtests.jl` drops Int128 from the `gpuarrays/linalg/core`
-# element types.
-if Base.libllvm_version >= v"19"
-    @testset "Int128 axpby! miscompilation" begin
-        a, b = rand(Int128), rand(Int128)
-        x, y = rand(Int128, 5), rand(Int128, 5)
-        gx, gy = ROCArray(x), ROCArray(y)
-        gy .= gx .* a .+ gy .* b
-        @test_broken Array(gy) == x .* a .+ y .* b
-        AMDGPU.synchronize()
-    end
+@testset "Int128 axpby! miscompilation" begin
+    a, b = rand(Int128), rand(Int128)
+    x, y = rand(Int128, 5), rand(Int128, 5)
+    gx, gy = ROCArray(x), ROCArray(y)
+    gy .= gx .* a .+ gy .* b
+    @test_broken Array(gy) == x .* a .+ y .* b
+    AMDGPU.synchronize()
 end

--- a/test/core/rocarray_broadcast.jl
+++ b/test/core/rocarray_broadcast.jl
@@ -66,6 +66,6 @@ end
     x, y = rand(Int128, 5), rand(Int128, 5)
     gx, gy = ROCArray(x), ROCArray(y)
     gy .= gx .* a .+ gy .* b
-    @test broken = Base.libllvm_version >= v"18" Array(gy) == x .* a .+ y .* b
+    @test Array(gy) == x .* a .+ y .* b broken=(Base.libllvm_version >= v"18")
     AMDGPU.synchronize()
 end

--- a/test/core/rocarray_broadcast.jl
+++ b/test/core/rocarray_broadcast.jl
@@ -61,14 +61,11 @@ end
 end
 
 # https://github.com/JuliaGPU/AMDGPU.jl/issues/1002
-# Gated on the same condition that puts Int128 into the `linalg/core` eltypes:
-if int128_supported
-    @testset "Int128 axpby! miscompilation" begin
-        a, b = rand(Int128), rand(Int128)
-        x, y = rand(Int128, 5), rand(Int128, 5)
-        gx, gy = ROCArray(x), ROCArray(y)
-        gy .= gx .* a .+ gy .* b
-        @test_broken Array(gy) == x .* a .+ y .* b
-        AMDGPU.synchronize()
-    end
+@testset "Int128 axpby! miscompilation" begin
+    a, b = rand(Int128), rand(Int128)
+    x, y = rand(Int128, 5), rand(Int128, 5)
+    gx, gy = ROCArray(x), ROCArray(y)
+    gy .= gx .* a .+ gy .* b
+    @test broken = Base.libllvm_version >= v"18" Array(gy) == x .* a .+ y .* b
+    AMDGPU.synchronize()
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -93,6 +93,13 @@ init_code = quote
     end
     TestSuite.supported_eltypes(::Type{<:AMDGPU.ROCArray}) = eltypes
 
+    # LLVM 20 still miscompiles the Int128 multiply-add that GPUArrays' `axpy!` and
+    # `axpby!` lower to, so keep Int128 out of that suite. `core/rocarray_broadcast`
+    # carries a `@test_broken` that starts failing once the miscompilation is fixed.
+    TestSuite.supported_eltypes(
+        ::Type{<:AMDGPU.ROCArray}, ::typeof(TestSuite.test_linalg_core),
+    ) = filter(!=(Int128), eltypes)
+
     macro grab_output(ex, io=stdout)
         quote
             mktemp() do fname, fout

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,19 +84,7 @@ init_code = quote
                      Float16, Float32, Float64,
                      ComplexF16, ComplexF32, ComplexF64,
                      Complex{Int16}, Complex{Int32}, Complex{Int64}]
-    # Kernels are compiled with Julia's in-tree LLVM, and the LLVM 18 that Julia 1.12
-    # ships with miscompiles Int128 arithmetic on AMDGPU (JuliaGPU/AMDGPU.jl#1002).
-    # Only exercise Int128 as a generic element type on newer LLVM versions.
-    const int128_supported = Base.libllvm_version >= v"19"
-    if int128_supported
-        push!(eltypes, Int128)
-    end
     TestSuite.supported_eltypes(::Type{<:AMDGPU.ROCArray}) = eltypes
-
-    # Miscompilation of Int128 arithmetic on AMDGPU (JuliaGPU/AMDGPU.jl#1002).
-    # `core/rocarray_broadcast` carries a `@test_broken` to track this.
-    TestSuite.supported_eltypes(
-        ::Type{<:AMDGPU.ROCArray}, ::typeof(TestSuite.test_linalg_core),
 
     macro grab_output(ex, io=stdout)
         quote

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -93,9 +93,8 @@ init_code = quote
     end
     TestSuite.supported_eltypes(::Type{<:AMDGPU.ROCArray}) = eltypes
 
-    # LLVM 20 still miscompiles the Int128 multiply-add that GPUArrays' `axpy!` and
-    # `axpby!` lower to, so keep Int128 out of that suite. `core/rocarray_broadcast`
-    # carries a `@test_broken` that starts failing once the miscompilation is fixed.
+    # Miscompilation of Int128 arithmetic on AMDGPU (JuliaGPU/AMDGPU.jl#1002).
+    # `core/rocarray_broadcast` carries a `@test_broken` to track this.
     TestSuite.supported_eltypes(
         ::Type{<:AMDGPU.ROCArray}, ::typeof(TestSuite.test_linalg_core),
     ) = filter(!=(Int128), eltypes)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -97,7 +97,6 @@ init_code = quote
     # `core/rocarray_broadcast` carries a `@test_broken` to track this.
     TestSuite.supported_eltypes(
         ::Type{<:AMDGPU.ROCArray}, ::typeof(TestSuite.test_linalg_core),
-    ) = filter(!=(Int128), eltypes)
 
     macro grab_output(ex, io=stdout)
         quote

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,7 +80,7 @@ init_code = quote
     include($gpuarrays_testsuite)
     testf(f, xs...; kwargs...) = TestSuite.compare(f, AMDGPU.ROCArray, xs...; kwargs...)
 
-    const eltypes = [Int16, Int32, Int64,
+    const eltypes = [Int16, Int32, Int64, # TODO: add Int128 once #1002 is addressed
                      Float16, Float32, Float64,
                      ComplexF16, ComplexF32, ComplexF64,
                      Complex{Int16}, Complex{Int32}, Complex{Int64}]


### PR DESCRIPTION
Possibly workaround #1066 according to https://github.com/JuliaGPU/AMDGPU.jl/pull/1066#issuecomment-5538187568