### PR TITLE
Guard empty-array launch in out-of-place reverse

### DIFF
--- a/src/kernels/reverse.jl
+++ b/src/kernels/reverse.jl
@@ -83,6 +83,7 @@ function _reverse!(
 
     groupsize = 256
     gridsize = cld(length(x), groupsize)
+    iszero(gridsize) && return
     @roc groupsize=groupsize gridsize=gridsize _kernel!(y, x)
 end
 
@@ -118,5 +119,6 @@ function _reverse!(x::AnyROCArray{T, N}; dims=1:ndims(x)) where {T, N}
 
     groupsize = 256
     gridsize = cld(prod(reduced_sz), groupsize)
+    iszero(gridsize) && return
     @roc groupsize=groupsize gridsize=gridsize _kernel!(x)
 end

--- a/test/hip_rocarray/reverse.jl
+++ b/test/hip_rocarray/reverse.jl
@@ -48,4 +48,19 @@ using AMDGPU: ROCArray
         @test y == Array(reverse(xd; dims))
         @test y == Array(reverse!(xd; dims))
     end
+
+    @testset "empty" begin
+        for T in (Float32, Int16)
+            xd = ROCArray(T[])
+            @test Array(reverse(xd)) == reverse(T[])
+            @test Array(reverse!(xd)) == reverse(T[])
+
+            for sz in ((0, 3), (3, 0)), dims in (:, 1, 2)
+                m = Matrix{T}(undef, sz)
+                md = ROCArray(m)
+                @test Array(reverse(md; dims)) == reverse(m; dims)
+                @test Array(reverse!(md; dims)) == reverse(m; dims)
+            end
+        end
+    end
 end


### PR DESCRIPTION
Fixes #1068