### PR TITLE
Adapt to the library-based AMDGPU_LLVM_Backend_jll 23 and LLVMDowngrader_jll 0.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -49,9 +49,6 @@ AMDGPUEnzymeCoreExt = "EnzymeCore"
 AMDGPUSparseMatricesCSRExt = "SparseMatricesCSR"
 AMDGPUSpecialFunctionsExt = "SpecialFunctions"
 
-[sources]
-GPUCompiler = {url = "https://github.com/JuliaGPU/GPUCompiler.jl", rev = "tb/jll-libraries"}
-
 [compat]
 AMDGPU_LLVM_Backend_jll = "23"
 AbstractFFTs = "1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -49,8 +49,11 @@ AMDGPUEnzymeCoreExt = "EnzymeCore"
 AMDGPUSparseMatricesCSRExt = "SparseMatricesCSR"
 AMDGPUSpecialFunctionsExt = "SpecialFunctions"
 
+[sources]
+GPUCompiler = {url = "https://github.com/JuliaGPU/GPUCompiler.jl", rev = "tb/jll-libraries"}
+
 [compat]
-AMDGPU_LLVM_Backend_jll = "22.1.8"
+AMDGPU_LLVM_Backend_jll = "23"
 AbstractFFTs = "1.0"
 AcceleratedKernels = "0.3.1, 0.4"
 Adapt = "4"
@@ -61,11 +64,11 @@ ChainRulesCore = "1"
 EnzymeCore = "0.8"
 ExprTools = "0.1"
 GPUArrays = "11.5.14"
-GPUCompiler = "2.5"
+GPUCompiler = "2.7"
 GPUToolbox = "3"
 KernelAbstractions = "0.9.2"
 LLVM = "9"
-LLVMDowngrader_jll = "0.9.1"
+LLVMDowngrader_jll = "0.10"
 PrecompileTools = "1"
 Preferences = "1"
 PrettyTables = "3"

--- a/src/AMDGPU.jl
+++ b/src/AMDGPU.jl
@@ -58,6 +58,7 @@ LockedObject(payload) = LockedObject(ReentrantLock(), payload)
 # Load binary dependencies.
 include("discovery/discovery.jl")
 using .ROCmDiscovery
+using .ROCmDiscovery: AMDGPU_LLVM_Backend_jll
 
 include("utils.jl")
 

--- a/src/compiler/Compiler.jl
+++ b/src/compiler/Compiler.jl
@@ -4,10 +4,10 @@ import Core: LLVMPtr
 
 using ..GPUCompiler
 using ..LLVM
-using Libdl
 using Printf
 
 import AMDGPU_LLVM_Backend_jll # used for linking; GPUCompiler uses the in-tree backend otherwise
+using AMDGPU_LLVM_Backend_jll: libamdgpu
 
 import ..AMDGPU
 import ..AMDGPU: AS

--- a/src/compiler/Compiler.jl
+++ b/src/compiler/Compiler.jl
@@ -4,9 +4,10 @@ import Core: LLVMPtr
 
 using ..GPUCompiler
 using ..LLVM
+using Libdl
 using Printf
 
-import AMDGPU_LLVM_Backend_jll # used for lld and GPUCompiler uses the in-tree backend otherwise
+import AMDGPU_LLVM_Backend_jll # used for linking; GPUCompiler uses the in-tree backend otherwise
 
 import ..AMDGPU
 import ..AMDGPU: AS

--- a/src/compiler/codegen.jl
+++ b/src/compiler/codegen.jl
@@ -293,12 +293,11 @@ function create_executable(obj)
     use_precompile_lld = isempty(AMDGPU.lld_path) &&
                          ccall(:jl_generating_output, Cint, ()) == 1 &&
                          AMDGPU_LLVM_Backend_jll.is_available()
-    lld = if AMDGPU.lld_artifact || use_precompile_lld
-        `$(AMDGPU_LLVM_Backend_jll.lld()) -flavor gnu`
-    else
-        @assert !isempty(AMDGPU.lld_path) "ld.lld was not found; cannot link kernel"
-        `$(AMDGPU.lld_path)`
+    if AMDGPU.lld_artifact || use_precompile_lld
+        return link_in_process(obj)
     end
+    @assert !isempty(AMDGPU.lld_path) "ld.lld was not found; cannot link kernel"
+    lld = `$(AMDGPU.lld_path)`
 
     path_o = tempname(;cleanup=false) * ".obj"
     path_exe = tempname(;cleanup=false) * ".exe"
@@ -309,6 +308,31 @@ function create_executable(obj)
 
     rm(path_o)
     rm(path_exe)
+    return bin
+end
+
+# link a relocatable object into an HSA code object through `libamdgpu`, i.e.
+# `ld.lld -flavor gnu -shared` without spawning a process or touching the file system
+function link_in_process(obj::AbstractVector{UInt8})
+    obj = convert(Vector{UInt8}, obj)
+    lib = Libdl.dlopen(AMDGPU_LLVM_Backend_jll.libamdgpu)
+    buffer = Ref{Ptr{Cvoid}}(C_NULL)
+    message = Ref{Cstring}(C_NULL)
+    status = @ccall $(Libdl.dlsym(lib, :AMDGPULink))(
+        obj::Ptr{UInt8}, length(obj)::Csize_t,
+        buffer::Ptr{Ptr{Cvoid}}, message::Ptr{Cstring})::Cint
+    if status != 0
+        msg = "Failed to link kernel"
+        if message[] != C_NULL
+            msg *= ":\n" * unsafe_string(message[])
+            @ccall $(Libdl.dlsym(lib, :AMDGPUDisposeMessage))(message[]::Cstring)::Cvoid
+        end
+        error(msg)
+    end
+    start = @ccall $(Libdl.dlsym(lib, :AMDGPUGetBufferStart))(buffer[]::Ptr{Cvoid})::Ptr{UInt8}
+    size = @ccall $(Libdl.dlsym(lib, :AMDGPUGetBufferSize))(buffer[]::Ptr{Cvoid})::Csize_t
+    bin = copy(unsafe_wrap(Array, start, size))
+    @ccall $(Libdl.dlsym(lib, :AMDGPUDisposeMemoryBuffer))(buffer[]::Ptr{Cvoid})::Cvoid
     return bin
 end
 

--- a/src/compiler/codegen.jl
+++ b/src/compiler/codegen.jl
@@ -315,24 +315,23 @@ end
 # `ld.lld -flavor gnu -shared` without spawning a process or touching the file system
 function link_in_process(obj::AbstractVector{UInt8})
     obj = convert(Vector{UInt8}, obj)
-    lib = Libdl.dlopen(AMDGPU_LLVM_Backend_jll.libamdgpu)
     buffer = Ref{Ptr{Cvoid}}(C_NULL)
     message = Ref{Cstring}(C_NULL)
-    status = @ccall $(Libdl.dlsym(lib, :AMDGPULink))(
+    status = @ccall libamdgpu.AMDGPULink(
         obj::Ptr{UInt8}, length(obj)::Csize_t,
         buffer::Ptr{Ptr{Cvoid}}, message::Ptr{Cstring})::Cint
     if status != 0
         msg = "Failed to link kernel"
         if message[] != C_NULL
             msg *= ":\n" * unsafe_string(message[])
-            @ccall $(Libdl.dlsym(lib, :AMDGPUDisposeMessage))(message[]::Cstring)::Cvoid
+            @ccall libamdgpu.AMDGPUDisposeMessage(message[]::Cstring)::Cvoid
         end
         error(msg)
     end
-    start = @ccall $(Libdl.dlsym(lib, :AMDGPUGetBufferStart))(buffer[]::Ptr{Cvoid})::Ptr{UInt8}
-    size = @ccall $(Libdl.dlsym(lib, :AMDGPUGetBufferSize))(buffer[]::Ptr{Cvoid})::Csize_t
+    start = @ccall libamdgpu.AMDGPUGetBufferStart(buffer[]::Ptr{Cvoid})::Ptr{UInt8}
+    size = @ccall libamdgpu.AMDGPUGetBufferSize(buffer[]::Ptr{Cvoid})::Csize_t
     bin = copy(unsafe_wrap(Array, start, size))
-    @ccall $(Libdl.dlsym(lib, :AMDGPUDisposeMemoryBuffer))(buffer[]::Ptr{Cvoid})::Cvoid
+    @ccall libamdgpu.AMDGPUDisposeMemoryBuffer(buffer[]::Ptr{Cvoid})::Cvoid
     return bin
 end
 

--- a/src/discovery/discovery.jl
+++ b/src/discovery/discovery.jl
@@ -22,8 +22,31 @@ end
 function get_ld_lld(rocm_path::String)::Tuple{String, Bool}
     lld_path = find_ld_lld(rocm_path)
     isempty(lld_path) || return (lld_path, false)
-    AMDGPU_LLVM_Backend_jll.is_available() || return (lld_path, false)
-    return (AMDGPU_LLVM_Backend_jll.lld_path, true)
+    # the artifact links in-process through `libamdgpu`, so there is no tool path
+    return ("", AMDGPU_LLVM_Backend_jll.is_available())
+end
+
+# downgrade bitcode to the format of an older LLVM through `libllvm_downgrade`
+function downgrade_bitcode(input::Vector{UInt8}, version::VersionNumber)
+    lib = Libdl.dlopen(LLVMDowngrader_jll.libllvm_downgrade)
+    buffer = Ref{Ptr{Cvoid}}(C_NULL)
+    message = Ref{Cstring}(C_NULL)
+    status = @ccall $(Libdl.dlsym(lib, :LLVMDGDowngrade))(
+        input::Ptr{UInt8}, length(input)::Csize_t, version.major::Cuint, version.minor::Cuint,
+        buffer::Ptr{Ptr{Cvoid}}, message::Ptr{Cstring})::Cint
+    if status != 0
+        msg = "unknown error"
+        if message[] != C_NULL
+            msg = unsafe_string(message[])
+            @ccall $(Libdl.dlsym(lib, :LLVMDGDisposeMessage))(message[]::Cstring)::Cvoid
+        end
+        error(msg)
+    end
+    start = @ccall $(Libdl.dlsym(lib, :LLVMDGGetBufferStart))(buffer[]::Ptr{Cvoid})::Ptr{UInt8}
+    size = @ccall $(Libdl.dlsym(lib, :LLVMDGGetBufferSize))(buffer[]::Ptr{Cvoid})::Csize_t
+    output = copy(unsafe_wrap(Array, start, size))
+    @ccall $(Libdl.dlsym(lib, :LLVMDGDisposeMemoryBuffer))(buffer[]::Ptr{Cvoid})::Cvoid
+    return output
 end
 
 # bitcode versions `llvm-downgrade` can target.
@@ -50,13 +73,12 @@ function downgrade_device_libs(src_dir::String)::String
         for file in readdir(src_dir)
             endswith(file, ".bc") || continue
             # Just skip libraries the downgrader can't handle. `link_device_libs!` will throw an error if it is actually needed
-            cmd = `$(LLVMDowngrader_jll.llvm_downgrade()) --bitcode-version=$(target.major).$(target.minor) -o $(joinpath(tmp, file)) $(joinpath(src_dir, file))`
-            err_io = IOBuffer()
             try
-                run(pipeline(cmd; stderr=err_io))
-            catch
+                bitcode = downgrade_bitcode(read(joinpath(src_dir, file)), target)
+                write(joinpath(tmp, file), bitcode)
+            catch err
                 @warn """Failed to downgrade device library `$file` to LLVM $(target.major), skipping it.
-                $(rstrip(String(take!(err_io))))
+                $(sprint(showerror, err))
                 """
                 rm(joinpath(tmp, file); force=true)
             end

--- a/src/discovery/discovery.jl
+++ b/src/discovery/discovery.jl
@@ -7,6 +7,7 @@ export libhiptensor
 
 using AMDGPU_LLVM_Backend_jll
 using LLVMDowngrader_jll
+using LLVMDowngrader_jll: libllvm_downgrade
 using Preferences
 using Scratch
 using Libdl
@@ -28,24 +29,23 @@ end
 
 # downgrade bitcode to the format of an older LLVM through `libllvm_downgrade`
 function downgrade_bitcode(input::Vector{UInt8}, version::VersionNumber)
-    lib = Libdl.dlopen(LLVMDowngrader_jll.libllvm_downgrade)
     buffer = Ref{Ptr{Cvoid}}(C_NULL)
     message = Ref{Cstring}(C_NULL)
-    status = @ccall $(Libdl.dlsym(lib, :LLVMDGDowngrade))(
+    status = @ccall libllvm_downgrade.LLVMDGDowngrade(
         input::Ptr{UInt8}, length(input)::Csize_t, version.major::Cuint, version.minor::Cuint,
         buffer::Ptr{Ptr{Cvoid}}, message::Ptr{Cstring})::Cint
     if status != 0
         msg = "unknown error"
         if message[] != C_NULL
             msg = unsafe_string(message[])
-            @ccall $(Libdl.dlsym(lib, :LLVMDGDisposeMessage))(message[]::Cstring)::Cvoid
+            @ccall libllvm_downgrade.LLVMDGDisposeMessage(message[]::Cstring)::Cvoid
         end
         error(msg)
     end
-    start = @ccall $(Libdl.dlsym(lib, :LLVMDGGetBufferStart))(buffer[]::Ptr{Cvoid})::Ptr{UInt8}
-    size = @ccall $(Libdl.dlsym(lib, :LLVMDGGetBufferSize))(buffer[]::Ptr{Cvoid})::Csize_t
+    start = @ccall libllvm_downgrade.LLVMDGGetBufferStart(buffer[]::Ptr{Cvoid})::Ptr{UInt8}
+    size = @ccall libllvm_downgrade.LLVMDGGetBufferSize(buffer[]::Ptr{Cvoid})::Csize_t
     output = copy(unsafe_wrap(Array, start, size))
-    @ccall $(Libdl.dlsym(lib, :LLVMDGDisposeMemoryBuffer))(buffer[]::Ptr{Cvoid})::Cvoid
+    @ccall libllvm_downgrade.LLVMDGDisposeMemoryBuffer(buffer[]::Ptr{Cvoid})::Cvoid
     return output
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -65,7 +65,7 @@ function versioninfo(io::IO=stdout)
     rocsparse_ver = functional(:rocsparse) ? _rocsparse_version_isolated() : "-"
 
     data = String[
-        _status(functional(:lld))         "LLD"              "-"                                 _libpath(lld_path);
+        _status(functional(:lld))         "LLD"              "-"                                 _libpath(lld_artifact ? AMDGPU_LLVM_Backend_jll.libamdgpu : lld_path);
         _status(functional(:device_libs)) "Device Libraries" "-"                                 _libpath(libdevice_libs);
         _status(functional(:hip))         "HIP"              _ver(:hip, HIP.runtime_version)     _libpath(libhip);
         _status(functional(:rocblas))     "rocBLAS"          _ver(:rocblas, rocBLAS.version)     _libpath(librocblas);
@@ -145,7 +145,7 @@ function functional(component::Symbol)
     if component == :hip
         return !isempty(libhip)
     elseif component == :lld
-        return !isempty(lld_path)
+        return !isempty(lld_path) || lld_artifact
     elseif component == :device_libs
         return !isempty(libdevice_libs)
     elseif component == :rocblas

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -26,5 +26,4 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
-GPUCompiler = {url = "https://github.com/JuliaGPU/GPUCompiler.jl", rev = "tb/jll-libraries"}
 AMDGPU = {path = ".."}

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -26,4 +26,5 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
+GPUCompiler = {url = "https://github.com/JuliaGPU/GPUCompiler.jl", rev = "tb/jll-libraries"}
 AMDGPU = {path = ".."}


### PR DESCRIPTION
JuliaPackaging/Yggdrasil#14727 replaced the `llc`, `lld` and `llvm-downgrade` executables in the GPU LLVM JLLs with shared libraries exposing a small C API, moving the back-ends to LLVM 23 at the same time. JuliaGPU/GPUCompiler.jl#930 makes GPUCompiler call those libraries in-process, and bumps its compat to the new JLL majors. Since this package pins the same JLL, it needs its compat bumped in lockstep, which is what this PR does.

AMDGPU.jl used two of the removed tools itself, so besides the compat bumps (`AMDGPU_LLVM_Backend_jll` → 23, `LLVMDowngrader_jll` → 0.10, `GPUCompiler` → 2.7):

- Linking the kernel object into an HSA code object goes through `AMDGPULink` from `libamdgpu` (`ld.lld -flavor gnu -shared` in-process, no temporary files) whenever the artifact is used. A system `ld.lld` from ROCm is still preferred when found, and still spawned as before. `lld_artifact` now means "link through the library" and no longer comes with a tool path; `versioninfo` shows the library instead.
- Downgrading the device libraries for the in-process LLVM goes through `LLVMDGDowngrade`, one buffer at a time, with the downgrader's error message in the warning when a library is skipped.