### PR TITLE
Adapt to LLVMDowngrader_jll 0.11 and GPUCompiler 2.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -49,9 +49,6 @@ AMDGPUEnzymeCoreExt = "EnzymeCore"
 AMDGPUSparseMatricesCSRExt = "SparseMatricesCSR"
 AMDGPUSpecialFunctionsExt = "SpecialFunctions"
 
-[sources]
-GPUCompiler = {url = "https://github.com/JuliaGPU/GPUCompiler.jl", rev = "tb/llvm23-jlls"}
-
 [compat]
 AMDGPU_LLVM_Backend_jll = "23"
 AbstractFFTs = "1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -49,6 +49,9 @@ AMDGPUEnzymeCoreExt = "EnzymeCore"
 AMDGPUSparseMatricesCSRExt = "SparseMatricesCSR"
 AMDGPUSpecialFunctionsExt = "SpecialFunctions"
 
+[sources]
+GPUCompiler = {url = "https://github.com/JuliaGPU/GPUCompiler.jl", rev = "tb/llvm23-jlls"}
+
 [compat]
 AMDGPU_LLVM_Backend_jll = "23"
 AbstractFFTs = "1.0"
@@ -61,11 +64,11 @@ ChainRulesCore = "1"
 EnzymeCore = "0.8"
 ExprTools = "0.1"
 GPUArrays = "11.5.14"
-GPUCompiler = "2.7"
+GPUCompiler = "2.8"
 GPUToolbox = "3"
 KernelAbstractions = "0.9.2"
 LLVM = "9"
-LLVMDowngrader_jll = "0.10"
+LLVMDowngrader_jll = "0.11"
 PrecompileTools = "1"
 Preferences = "1"
 PrettyTables = "3"


### PR DESCRIPTION
Bumps the compat bounds to LLVMDowngrader_jll 0.11 (JuliaPackaging/Yggdrasil#14758, built against LLVM 23) and GPUCompiler 2.8 (JuliaGPU/GPUCompiler.jl#931). The downgrader C API is unchanged, so this is compat-only.